### PR TITLE
fixes a bug parsing the Setup filename when the site id contains an underscore

### DIFF
--- a/libs/cgse-common/src/egse/setup.py
+++ b/libs/cgse-common/src/egse/setup.py
@@ -263,7 +263,7 @@ def _get_attribute(self, name, default):
     return attr
 
 
-def _parse_filename_for_setup_id(filename: str):
+def _parse_filename_for_setup_id(filename: str) -> str | None:
     """Returns the setup_id from the filename, or None when no match was found."""
 
     # match = re.search(r"SETUP_([^_]+)_(\d+)", filename)
@@ -275,6 +275,31 @@ def _parse_filename_for_setup_id(filename: str):
         return match[2]  # match[2] is setup_id
     except (IndexError, TypeError):
         return None
+
+
+def disentangle_filename(filename: str) -> tuple:
+    """
+    Returns the site_id and setup_id (as a tuple) that is extracted from the Setups filename.
+
+    Args:
+        filename (str): the filename or fully qualified file path as a string.
+
+    Returns:
+          A tuple (site_id, setup_id).
+    """
+    if filename is None:
+        return ()
+
+    MODULE_LOGGER.info(f"{filename = }")
+
+    match = re.search(r"SETUP_(\w+)_([\d]{5})_([\d]{6})_([\d]{6})\.yaml", filename)
+
+    if match is None:
+        return ()
+
+    site_id, setup_id = match[1], match[2]
+
+    return site_id, setup_id
 
 
 def get_last_setup_id_file_path(site_id: str = None) -> Path:

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -146,6 +146,7 @@ from egse.response import Success
 from egse.settings import Settings
 from egse.settings import SettingsError
 from egse.setup import Setup
+from egse.setup import disentangle_filename
 from egse.setup import load_last_setup_id
 from egse.setup import save_last_setup_id
 from egse.system import filter_by_attr
@@ -835,7 +836,8 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
         setups = filter_by_attr(setups, **attr)
 
         for setup in setups:
-            _, setup_site, setup_id, _ = str(setup._filename).split("_", maxsplit=3)
+            # FIXME: are we sure setup.get_filename() returns a Path?
+            setup_site, setup_id = disentangle_filename(str(setup.get_filename()))
             description = _get_description_for_setup(setup, int(setup_id))
             cam_id = _get_sut_id_for_setup(setup)
             setup_list.append((setup_id, setup_site, description, cam_id))

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -23,6 +23,7 @@ from egse.confman import ConfigurationManagerProxy
 from egse.control import ControlServer
 from egse.env import get_conf_data_location
 from egse.process import SubProcess
+from egse.response import Failure
 from egse.response import Response
 from egse.settings import Settings
 
@@ -162,6 +163,10 @@ def list_setups(**attr):
 
     with ConfigurationManagerProxy() as cm:
         setups = cm.list_setups(**attr)
+    if isinstance(setups, Failure):
+        rich.print(f"[red]ERROR: {setups}[/]")
+        rich.print("Check the log file for a more detailed error message.")
+        return
     if setups:
         # We want to have the most recent (highest id number) last, but keep the site together
         setups = sorted(setups, key=lambda x: (x[1], x[0]))


### PR DESCRIPTION
The Setup filename was not properly parsed to extract the site_id and the setup_id when the site_id contains an underscore. This lead to an error when asking the list of Setups. In addition, the Failure that was returned was not handled on the client side.