### PR TITLE
Convert core services to Typer apps

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.2.3"
+version = "0.2.4"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IVS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.2.3"
+version = "0.2.4"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.2.3"
+version = "0.2.4"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IVS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 ]
 
 [project.scripts]
-log_cs = 'egse.logger.log_cs:cli'
-sm_cs = 'egse.storage.storage_cs:cli'
+log_cs = 'egse.logger.log_cs:app'
+sm_cs = 'egse.storage.storage_cs:app'
 cm_cs = 'egse.confman.confman_cs:app'
 pm_cs = 'egse.procman.procman_cs:cli'
 

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -91,7 +91,7 @@ class ConfigurationManagerControlServer(ControlServer):
         start_http_server(CTRL_SETTINGS.METRICS_PORT)
 
 
-app = typer.Typer()
+app = typer.Typer(name="cm_cs", no_args_is_help=True)
 
 
 @app.command()
@@ -103,7 +103,7 @@ def start():
     The cm_cs is normally started automatically on egse-server boot.
     """
 
-    multiprocessing.current_process().name = "confman_cs"
+    multiprocessing.current_process().name = "cm_cs"
 
     try:
         check_prerequisites()

--- a/libs/cgse-core/src/egse/logger/log_cs.py
+++ b/libs/cgse-core/src/egse/logger/log_cs.py
@@ -12,10 +12,9 @@ from logging.handlers import SocketHandler
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 from typing import Optional
-from typing import Union
 
-import click
 import rich
+import typer
 import zmq
 from prometheus_client import Counter
 from prometheus_client import start_http_server
@@ -89,12 +88,10 @@ class DateTimeFormatter(logging.Formatter):
 file_formatter = DateTimeFormatter(fmt=LOG_FORMAT_KEY_VALUE, datefmt=LOG_FORMAT_DATE)
 
 
-@click.group()
-def cli():
-    pass
+app = typer.Typer(name="log_cs", no_args_is_help=True)
 
 
-@cli.command()
+@app.command()
 def start():
     """Start the Logger Control Server."""
 
@@ -161,7 +158,7 @@ def start():
                 handle_log_record(record)
 
         except KeyboardInterrupt:
-            click.echo("KeyboardInterrupt caught!")
+            rich.print("KeyboardInterrupt caught!")
             break
 
     record = logging.LogRecord(
@@ -183,7 +180,7 @@ def start():
     receiver.close(linger=0)
 
 
-@cli.command()
+@app.command()
 def start_bg():
     """Start the Logger Control Server in the background."""
     proc = SubProcess("log_cs", ["log_cs", "start"])
@@ -250,7 +247,7 @@ def handle_command(command) -> dict:
     return response
 
 
-@cli.command()
+@app.command()
 def stop():
     """Stop the Logger Control Server."""
 
@@ -261,7 +258,7 @@ def stop():
         rich.print(f"[red] ERROR: {response}")
 
 
-@cli.command()
+@app.command()
 def roll():
     """Roll over the log file of the Logger Control Server."""
 
@@ -272,7 +269,7 @@ def roll():
         rich.print(f"[red]ERROR: {response}")
 
 
-@cli.command()
+@app.command()
 def status():
     """Roll over the log file of the Logger Control Server."""
 
@@ -287,9 +284,8 @@ def status():
         rich.print("Log Manager Status: [red]not active")
 
 
-@cli.command()
-@click.argument('level')
-def set_level(level: Union[int, str]):
+@app.command()
+def set_level(level: str):
     """Set the logging level for """
     try:
         level = logging.getLevelName(int(level))
@@ -307,4 +303,4 @@ def set_level(level: Union[int, str]):
 
 
 if __name__ == "__main__":
-    cli()
+    app()

--- a/libs/cgse-core/src/egse/procman/procman_cs.py
+++ b/libs/cgse-core/src/egse/procman/procman_cs.py
@@ -146,7 +146,7 @@ def cli():
 def start():
     """Start the Process Manager."""
 
-    multiprocessing.current_process().name = "procman_cs"
+    multiprocessing.current_process().name = "pm_cs"
 
     # We import this class such that the class name is
     # 'egse.procman.procman_cs.ProcessManagerControlServer' and we
@@ -154,7 +154,7 @@ def start():
     # If this import would not be done, the class name for the
     # ProcessManagerControlServer would be '__main__.ProcessManagerControlServer'.
 
-    from egse.procman.procman_cs import ProcessManagerControlServer
+    from egse.procman.procman_cs import ProcessManagerControlServer  # noqa
 
     try:
         control_server = ProcessManagerControlServer()

--- a/libs/cgse-core/src/scripts/_status.py
+++ b/libs/cgse-core/src/scripts/_status.py
@@ -32,7 +32,7 @@ async def status_log_cs():
     #
     # stdout, stderr = proc.communicate()
 
-    rich.print(stdout.decode(), end='')
+    rich.print(stdout.decode().rstrip())
     if stderr:
         rich.print(f"[red]{stderr.decode()}[/]")
 
@@ -54,7 +54,7 @@ async def status_sm_cs():
     #
     # stdout, stderr = proc.communicate()
 
-    rich.print(stdout.decode(), end='')
+    rich.print(stdout.decode().rstrip())
     if stderr:
         rich.print(f"[red]{stderr.decode()}[/]")
 
@@ -76,6 +76,6 @@ async def status_cm_cs():
     #
     # stdout, stderr = proc.communicate()
 
-    rich.print(stdout.decode(), end='')
+    rich.print(stdout.decode().rstrip())
     if stderr:
         rich.print(f"[red]{stderr.decode()}[/]")

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.2.3"
+version = "0.2.4"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.2.3"
+version = "0.2.4"
 description = "Tools for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.2.3"
+version = "0.2.4"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.2.3"
+version = "0.2.4"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.2.3"
+version = "0.2.4"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.2.3"
+version = "0.2.4"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.2.3"
+version = "0.2.4"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.2.3"
+version = "0.2.4"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},


### PR DESCRIPTION
- The `log_cs` and `sm_cs` have been converted to Typer apps
- small editorial fixes
- Bumped patch version 0.2.3 → 0.2.4
