### PR TITLE
fixed argument and return types for a lot of functions and methods

### DIFF
--- a/docs/api/bits.md
+++ b/docs/api/bits.md
@@ -2,4 +2,8 @@
 title: "egse.bits"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.bits

--- a/docs/api/calibration.md
+++ b/docs/api/calibration.md
@@ -2,4 +2,8 @@
 title: "egse.calibration"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.calibration

--- a/docs/api/command.md
+++ b/docs/api/command.md
@@ -2,4 +2,8 @@
 title: "egse.command"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.command

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -2,4 +2,8 @@
 title: "egse.config"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.config

--- a/docs/api/control.md
+++ b/docs/api/control.md
@@ -2,4 +2,8 @@
 title: "egse.control"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.control

--- a/docs/api/counter.md
+++ b/docs/api/counter.md
@@ -2,4 +2,8 @@
 title: "egse.counter"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.counter

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -2,4 +2,8 @@
 title: "egse.decorators"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.decorators

--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -2,4 +2,8 @@
 title: "egse.device"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.device

--- a/docs/api/dict.md
+++ b/docs/api/dict.md
@@ -1,5 +1,0 @@
----
-title: "egse.dicts"
----
-
-::: egse.dicts

--- a/docs/api/dicts.md
+++ b/docs/api/dicts.md
@@ -1,9 +1,9 @@
 ---
-title: "egse.setup"
+title: "egse.dicts"
 ---
 
 !!! info "cgse-common"
     This code is part of the `cgse-common` package.
 
 
-::: egse.setup
+::: egse.dicts

--- a/docs/api/dummy.md
+++ b/docs/api/dummy.md
@@ -2,4 +2,8 @@
 title: "egse.dummy"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.dummy

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -2,6 +2,10 @@
 title: "egse.exceptions"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ```text
 Exception
  ├── CGSEException

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -2,4 +2,8 @@
 title: "egse.settings"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.settings

--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -2,4 +2,8 @@
 title: "egse.system"
 ---
 
+!!! info "cgse-common"
+    This code is part of the `cgse-common` package.
+
+
 ::: egse.system

--- a/libs/cgse-common/src/egse/bits.py
+++ b/libs/cgse-common/src/egse/bits.py
@@ -116,10 +116,10 @@ def bit_set(value: int, bit) -> bool:
         True if the bit is set (1).
     """
     bit_value = 1 << bit
-    return value & (bit_value) == bit_value
+    return value & bit_value == bit_value
 
 
-def bits_set(value: int, *args) -> bool:
+def bits_set(value: int, *args: tuple[int, ...]) -> bool:
     """
     Return True if all the bits are set.
 
@@ -486,14 +486,14 @@ CRC_TABLE = [
 ]
 
 
-def crc_calc(data, start: int, len: int) -> int:
+def crc_calc(data: list[Union[bytes, int]], start: int, len_: int) -> int:
     """
     Calculate the checksum for (part of) the data.
 
     Args:
         data: the data for which the checksum needs to be calculated
         start: offset into the data array [byte]
-        len: number of bytes to incorporate into the calculation
+        len_: number of bytes to incorporate into the calculation
 
     Returns:
         the calculated checksum.
@@ -510,10 +510,10 @@ def crc_calc(data, start: int, len: int) -> int:
     # and the individual elements have then type 'bytes'.
 
     if isinstance(data[0], bytes):
-        for idx in range(start, start + len):
+        for idx in range(start, start + len_):
             crc = CRC_TABLE[crc ^ (int.from_bytes(data[idx], byteorder="big") & 0xFF)]
     elif isinstance(data[0], int):
-        for idx in range(start, start + len):
+        for idx in range(start, start + len_):
             crc = CRC_TABLE[crc ^ (data[idx] & 0xFF)]
 
     return crc
@@ -563,7 +563,7 @@ def s16(value: int) -> int:
     return ctypes.c_int16(value).value
 
 
-def s32(value: int):
+def s32(value: int) -> int:
     """
     Return the signed equivalent of a hex or binary number.
 

--- a/libs/cgse-common/src/egse/calibration.py
+++ b/libs/cgse-common/src/egse/calibration.py
@@ -22,7 +22,7 @@ def apply_gain_offset(counts: float, gain: float, offset: float) -> float:
     return counts * gain + offset
 
 
-def counts_to_temperature(sensor_name: str, counts: float, sensor_info: NavigableDict, setup: Setup) -> float:
+def counts_to_temperature(sensor_name: str, counts: float, sensor_info: navdict, setup: Setup) -> float:
     """ Converts the given counts for the given sensor to temperature.
 
     This conversion can be done as follows:

--- a/libs/cgse-common/src/egse/command.py
+++ b/libs/cgse-common/src/egse/command.py
@@ -96,10 +96,11 @@ import inspect
 import logging
 import re
 from collections import namedtuple
+from typing import Any
 from typing import Callable
 
-from egse.response import Success
 from egse.exceptions import Error
+from egse.response import Success
 
 logger = logging.getLogger(__name__)
 
@@ -286,7 +287,7 @@ class InvalidCommandExecution(CommandExecution):
         **kwargs: the keyword arguments that were given
     """
 
-    def __init__(self, exc, cmd, *args, **kwargs):
+    def __init__(self, exc: Exception, cmd: type, *args: tuple, **kwargs: dict):
         super().__init__(cmd, *args, **kwargs)
         self._exc = exc
 
@@ -470,13 +471,13 @@ class Command:
 
 class ClientServerCommand(Command):
     @dry_run
-    def client_call(self, other, *args, **kwargs):
+    def client_call(self, other: type, *args: tuple, **kwargs: dict) -> Any:
         """
         This method is called at the client side. It is used by the Proxy
         as a generic command to send a command execution to the server.
 
         Args:
-            other: a sub-class of the Proxy class
+            other: a subclass of the Proxy class
             args: arguments that will be passed on to this command when executed
             kwargs: keyword arguments that will be passed on to this command when executed
 
@@ -504,13 +505,13 @@ class ClientServerCommand(Command):
 
         return rc
 
-    def server_call(self, other, *args, **kwargs):
+    def server_call(self, other: type, *args: tuple, **kwargs: dict) -> int:
         """
         This method is called at the server side. It is used by the CommandProtocol class in the
         ``execute`` method.
 
         Args:
-            other: a sub-class of the CommandProtocol
+            other: a subclass of the CommandProtocol
             args: arguments are passed on to the response method
             kwargs: keyword arguments are passed on to the response method
 
@@ -544,7 +545,7 @@ class ClientServerCommand(Command):
         return 0
 
 
-def get_method(parent_obj, method_name: str) -> Callable:
+def get_method(parent_obj: type, method_name: str) -> Callable:
     """
     Returns a bound method from a given class instance.
 
@@ -575,7 +576,7 @@ def get_method(parent_obj, method_name: str) -> Callable:
     return None
 
 
-def get_function(parent_class, method_name: str) -> Callable:
+def get_function(parent_class: type, method_name: str) -> Callable:
     """
     Returns a function (unbound method) from a given class.
 
@@ -606,7 +607,7 @@ def get_function(parent_class, method_name: str) -> Callable:
     return None
 
 
-def load_commands(protocol_class, command_settings, command_class, device_class):
+def load_commands(protocol_class: type, command_settings: dict, command_class: type, device_class: type) -> dict:
     """
     Loads the command definitions from the given ``command_settings`` and builds an internal
     dictionary containing the command names as keys and the corresponding ``Command`` class objects
@@ -616,10 +617,13 @@ def load_commands(protocol_class, command_settings, command_class, device_class)
     command definitions for the device.
 
     Args:
-        protocol_class: the CommandProtocol or a sub-class
+        protocol_class: the CommandProtocol or a subclass
         command_settings: a dictionary containing the command definitions for this device
         command_class: the type of command to create, a subclass of Command
         device_class: the type of the base device class from which the methods are loaded
+
+    Returns:
+        A dictionary with command names and their corresponding commands.
     """
     commands = {}
 

--- a/libs/cgse-common/src/egse/config.py
+++ b/libs/cgse-common/src/egse/config.py
@@ -135,7 +135,7 @@ def find_dirs(pattern: str, root: str = None) -> Generator[Path, None, None]:
                 yield Path(path) / name
 
 
-def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None):
+def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None) -> Generator[Path, None, None]:
     """
     Generator for returning file paths from a top folder, matching the pattern.
 
@@ -352,7 +352,7 @@ def get_resource_path(name: str, resource_root_dir: Union[str, PurePath] = None)
 
     Returns:
         the absolute path of the data file with the given name. The first name that matches
-          is returned. If no file with the given name or path exists, a FileNotFoundError is raised.
+            is returned. If no file with the given name or path exists, a FileNotFoundError is raised.
 
     """
     for resource_dir in get_resource_dirs(resource_root_dir):

--- a/libs/cgse-common/src/egse/control.py
+++ b/libs/cgse-common/src/egse/control.py
@@ -213,7 +213,7 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         Returns:
             Dictionary with the average execution times of all functions that have been monitored by this process.
-              The dictionary keys are the function names, and the values are the average execution times in ms.
+                The dictionary keys are the function names, and the values are the average execution times in ms.
         """
 
         return get_average_execution_times()
@@ -262,7 +262,7 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         return self.hk_delay
 
-    def set_scheduled_task_delay(self, seconds):
+    def set_scheduled_task_delay(self, seconds: float):
         """
         Sets the delay time between successive executions of scheduled tasks.
 
@@ -554,7 +554,7 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         Args:
             data (dict): a dictionary containing parameter name and value of all device housekeeping. There is also
-              a timestamp that represents the date/time when the HK was received from the device.
+                a timestamp that represents the date/time when the HK was received from the device.
         """
         pass
 

--- a/libs/cgse-common/src/egse/counter.py
+++ b/libs/cgse-common/src/egse/counter.py
@@ -48,7 +48,7 @@ def counter_exists(filename: Path) -> bool:
         True if the given filename exists, False otherwise.
 
     Raises:
-        An OSError might be raised.
+        OSError: might be raised by Path.
 
     Note:
         No checking is done if the file is indeed a counter file, i.e. if it contains the correct content.
@@ -116,7 +116,7 @@ def get_next_counter(filename: Path) -> int:
     Read the counter from a dedicated file, add one and save the counter back to the file.
 
     Args:
-        file_path: full pathname of the file that contains the required counter
+        filename: full pathname of the file that contains the required counter
 
     Returns:
         The value of the next counter, 1 if no previous files were found or if an error occurred.
@@ -132,7 +132,7 @@ def get_next_counter(filename: Path) -> int:
     return counter
 
 
-def determine_counter_from_dir_list(location, pattern, index: int = -1) -> int:
+def determine_counter_from_dir_list(location: str, pattern: str, index: int = -1) -> int:
     """
     Determine counter for a new file at the given location and with the given pattern.
     The next counter is determined from the sorted list of files that match the given pattern.

--- a/libs/cgse-common/src/egse/decorators.py
+++ b/libs/cgse-common/src/egse/decorators.py
@@ -95,7 +95,7 @@ def write_command(func):
     return func
 
 
-def average_time(*, name: str = "average_time", level: int = logging.INFO, precision: int = 6):
+def average_time(*, name: str = "average_time", level: int = logging.INFO, precision: int = 6) -> Callable:
     """
     This is a decorator that is intended mainly as a development aid. When you decorate your function with
     `@average_time`, the execution time of your function will be kept and accumulated. At anytime in your code,
@@ -182,7 +182,7 @@ def timer(*, name: str = "timer", level: int = logging.INFO, precision: int = 4)
     return actual_decorator
 
 
-def time_it(count: int = 1000, precision: int = 4):
+def time_it(count: int = 1000, precision: int = 4) -> Callable:
     """Print the runtime of the decorated function.
 
     This is a simple replacement for the builtin ``timeit`` function. The purpose is to simplify
@@ -253,7 +253,9 @@ def debug(func):
     return wrapper_debug
 
 
-def profile_func(output_file=None, sort_by='cumulative', lines_to_print=None, strip_dirs=False):
+def profile_func(
+        output_file: str = None, sort_by: str = 'cumulative', lines_to_print: int = None, strip_dirs: bool = False
+) -> Callable:
     """A time profiler decorator.
 
     Args:
@@ -481,7 +483,7 @@ def deprecate(reason: Optional[str] = None,
     Args:
         reason: provide a short explanation why this function is deprecated. Generates 'because {reason}'
         alternative: provides an alternative function/parameters to be used. Generates 'Use {alternative}
-        as an alternative'
+            as an alternative'
 
     Returns:
         The decorated function.
@@ -632,7 +634,9 @@ def spy_on_attr_change(obj: object, obj_name: str = None) -> None:
     obj.__class__.__name__ = class_name
 
 
-def retry_with_exponential_backoff(max_attempts=5, initial_wait=1.0, backoff_factor=2, exceptions: List = None):
+def retry_with_exponential_backoff(
+        max_attempts: int = 5, initial_wait: float = 1.0, backoff_factor: int = 2, exceptions: List = None
+) -> Callable:
     """
     Decorator for retrying a function with exponential backoff.
 
@@ -649,6 +653,7 @@ def retry_with_exponential_backoff(max_attempts=5, initial_wait=1.0, backoff_fac
         max_attempts: The maximum number of attempts to make.
         initial_wait: The initial waiting time in seconds before retrying after the first failure.
         backoff_factor: The factor by which the wait time increases after each failure.
+        exceptions: list of exceptions to ignore, if None all exceptions will be ignored `max_attempts`.
 
     Returns:
         The response from the executed function.
@@ -690,7 +695,7 @@ def retry_with_exponential_backoff(max_attempts=5, initial_wait=1.0, backoff_fac
     return actual_decorator
 
 
-def retry(times: int = 3, wait: float = 10.0, exceptions: List = None):
+def retry(times: int = 3, wait: float = 10.0, exceptions: List = None) -> Callable:
     """
     Decorator that retries a function multiple times with a delay between attempts.
 

--- a/libs/cgse-common/src/egse/device.py
+++ b/libs/cgse-common/src/egse/device.py
@@ -238,15 +238,12 @@ class DeviceTransport:
             command: is the command to be sent to the instrument
 
         Returns:
-            Either a string returned by the controller (on success), or an error message (on
-              failure).
+            Either a string returned by the controller (on success), or an error message (on failure).
 
         Raises:
-            DeviceConnectionError: when there was an I/O problem during communication with the
-              controller.
+            DeviceConnectionError: when there was an I/O problem during communication with the controller.
 
-            DeviceTimeoutError: when there was a timeout in either sending the command or
-              receiving the response.
+            DeviceTimeoutError: when there was a timeout in either sending the command or receiving the response.
         """
 
         raise NotImplementedError

--- a/libs/cgse-common/src/egse/dicts.py
+++ b/libs/cgse-common/src/egse/dicts.py
@@ -20,7 +20,7 @@ def log_differences(dict_1, dict_2):
     Takes two flattened dictionaries and compares them. This function only compares those
     keys that are common to both dictionaries. The key-value pairs that are unique to one
     of the dictionaries are ignored. To inspect if there are keys unique to one dictionary,
-    use the [log_key_differences()](./#egse.dicts.log_key_differences) function.
+    use the [log_key_differences()](dicts.md#egse.dicts.log_key_differences) function.
 
     The differences are logged in a Rich Table at level=INFO.
 

--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -153,10 +153,10 @@ class DummyProxy(Proxy, DummyInterface, EventInterface):
 
     def __init__(
             self,
-            protocol=ctrl_settings.PROTOCOL,
-            hostname=ctrl_settings.HOSTNAME,
-            port=ctrl_settings.COMMANDING_PORT,
-            timeout=ctrl_settings.TIMEOUT
+            protocol: str = ctrl_settings.PROTOCOL,
+            hostname: str = ctrl_settings.HOSTNAME,
+            port: int = ctrl_settings.COMMANDING_PORT,
+            timeout: int = ctrl_settings.TIMEOUT
     ):
         super().__init__(connect_address(protocol, hostname, port), timeout=timeout)
 
@@ -504,8 +504,8 @@ class DummyDeviceEthernetInterface(DeviceConnectionInterface, DeviceTransport):
             command: the command string including terminators.
 
         Raises:
-            A DeviceTimeoutError when the sendall() timed out, and a DeviceConnectionError if
-            there was a socket related error.
+            DeviceTimeoutError: when the sendall() timed out, and a DeviceConnectionError if
+                there was a socket related error.
         """
 
         # _LOGGER.debug(f"{command.encode() = }")
@@ -533,7 +533,7 @@ class DummyDeviceEthernetInterface(DeviceConnectionInterface, DeviceTransport):
 
         Raises:
             DeviceTimeoutError: when the sendall() timed out, and a DeviceConnectionError if
-            there was a socket related error.
+                there was a socket related error.
         """
         # MODULE_LOGGER.debug(f"{command.encode() = }")
 

--- a/libs/cgse-common/src/egse/protocol.py
+++ b/libs/cgse-common/src/egse/protocol.py
@@ -13,6 +13,8 @@ import abc
 import inspect
 import logging
 import pickle
+from typing import Any
+from typing import Type
 
 from prometheus_client import Counter
 from prometheus_client import Summary
@@ -482,7 +484,7 @@ class CommandProtocol(DeviceConnectionObserver, metaclass=abc.ABCMeta):
         """
         self.send(self._commands)
 
-    def load_commands(self, command_settings, command_class, device_class):
+    def load_commands(self, command_settings: dict, command_class: Type[Command], device_class: Any):
         """
         Loads the command definitions from the given ``command_settings`` and builds an internal
         dictionary containing the command names as keys and the corresponding ``Command`` class
@@ -556,7 +558,7 @@ class CommandProtocol(DeviceConnectionObserver, metaclass=abc.ABCMeta):
                 device_method=device_method,
             )
 
-    def build_device_method_lookup_table(self, device_obj):
+    def build_device_method_lookup_table(self, device_obj: Any):
         """
         Fill the lookup table with device command methods that are bound to the device object.
 
@@ -569,7 +571,7 @@ class CommandProtocol(DeviceConnectionObserver, metaclass=abc.ABCMeta):
             if method is not None:
                 self._method_lookup[method_name] = method
 
-    def handle_device_method(self, cmd: Command, *args, **kwargs):
+    def handle_device_method(self, cmd: Command, *args: list, **kwargs: dict):
         """
         Call the device method with the given arguments.
 

--- a/libs/cgse-common/src/egse/proxy.py
+++ b/libs/cgse-common/src/egse/proxy.py
@@ -9,6 +9,7 @@ import logging
 import pickle
 import types
 from types import MethodType
+from typing import Any
 
 import zmq
 
@@ -349,7 +350,7 @@ class Proxy(BaseProxy, ControlServerConnectionInterface):
     def is_cs_connected(self) -> bool:
         return self.ping()
 
-    def send(self, data, retries: int = REQUEST_RETRIES, timeout: int = None):
+    def send(self, data, retries: int = REQUEST_RETRIES, timeout: int = None) -> Any:
         """
         Sends a command to the control server and waits for a response.
 
@@ -369,7 +370,7 @@ class Proxy(BaseProxy, ControlServerConnectionInterface):
             retries (int): the number of time we should retry to send the message
 
         Returns:
-            response: the response from the control server or ``None`` when there was
+            response: the response from the control server or `None` when there was
                 a problem or a timeout.
         """
         timeout = timeout or self._timeout
@@ -500,12 +501,8 @@ class Proxy(BaseProxy, ControlServerConnectionInterface):
         self._logger.debug(f"Check if control server is available: Ping - {return_code}")
         return return_code == "Pong"
 
-    def get_endpoint(self):
-        """ Returns the endpoint.
-
-        Returns:
-            - Endpoint.
-        """
+    def get_endpoint(self) -> str:
+        """ Returns the endpoint. """
 
         return self._endpoint
 

--- a/libs/cgse-common/src/egse/setup.py
+++ b/libs/cgse-common/src/egse/setup.py
@@ -503,7 +503,7 @@ class NavigableDict(dict):
         else:
             return value
 
-    def set_private_attribute(self, key: str, value) -> None:
+    def set_private_attribute(self, key: str, value: Any) -> None:
         """Sets a private attribute for this object.
 
         The name in key will be accessible as an attribute for this object, but the key will not
@@ -695,7 +695,7 @@ class Setup(NavigableDict):
         return Setup(my_dict, label="Setup")
 
     @staticmethod
-    def from_yaml_string(yaml_content: str = None):
+    def from_yaml_string(yaml_content: str = None) -> Setup:
         """Loads a Setup from the given YAML string.
 
         This method is mainly used for easy creation of Setups from strings during unit tests.
@@ -719,7 +719,7 @@ class Setup(NavigableDict):
 
     @staticmethod
     @lru_cache(maxsize=300)
-    def from_yaml_file(filename: Union[str, Path] = None, add_local_settings: bool = True):
+    def from_yaml_file(filename: Union[str, Path] = None, add_local_settings: bool = True) -> Setup:
         """Loads a Setup from the given YAML file.
 
         Args:
@@ -728,6 +728,9 @@ class Setup(NavigableDict):
 
         Returns:
             a Setup that was loaded from the given location.
+
+        Raises:
+            ValueError: when no filename is given.
         """
 
         if not filename:
@@ -808,7 +811,7 @@ class Setup(NavigableDict):
     #     return devices
 
     @staticmethod
-    def find_devices(node: NavigableDict, devices: dict = None) -> dict:
+    def find_devices(node: NavigableDict, devices: dict = None) -> dict[str, tuple[str, tuple]]:
         """
         Returns a dictionary with the devices that are included in the setup.  The keys
         in the dictionary are taken from the "device_name" entries in the setup file. The
@@ -820,7 +823,8 @@ class Setup(NavigableDict):
             devices: Dictionary in which to include the devices in the setup.
 
         Returns:
-            Dictionary with the devices that are included in the setup.
+            Dictionary with the devices that are included in the setup. The keys are the device name,
+                the values are tuples with the 'device' raw value and the device arguments as a tuple.
         """
         devices = devices or {}
 
@@ -846,7 +850,7 @@ class Setup(NavigableDict):
         return devices
 
     @staticmethod
-    def walk(node: dict, key_of_interest, leaf_list) -> list:
+    def walk(node: dict, key_of_interest: str, leaf_list: list) -> list:
 
         """
         Walk through the given dictionary, in a recursive way, appending the leaf with
@@ -871,6 +875,8 @@ class Setup(NavigableDict):
             elif key == key_of_interest:
 
                 leaf_list.append(sub_node)
+
+        return leaf_list
 
     def __rich__(self) -> Tree:
         tree = super().__rich__()

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -196,7 +196,7 @@ def format_datetime(
         a string representation of the current time in UTC, e.g. `2020-04-29T12:30:04.862+0000`.
 
     Raises:
-        A ValueError will be raised when the given dt argument string is not understood.
+        ValueError: will be raised when the given dt argument string is not understood.
     """
     dt = dt or datetime.datetime.now(tz=datetime.timezone.utc)
     if isinstance(dt, str):
@@ -345,7 +345,7 @@ def time_since_epoch_1958(datetime_string: str) -> float:
     return time_since_epoch_1970 + EPOCH_1958_1970
 
 
-class Timer(object):
+class Timer:
     """
     Context manager to benchmark some lines of code.
 
@@ -361,11 +361,8 @@ class Timer(object):
     Args:
         name (str): a name for the Timer, will be printed in the logging message
         precision (int): the precision for the presentation of the elapsed time
-            (number of digits behind the comma ;)
+            (number of digits behind the comma)
         log_level (int): the log level to report the timing [default=INFO]
-
-    Returns:
-        a context manager class that records the elapsed time.
 
     Example:
         ```Python
@@ -687,7 +684,7 @@ def recursive_dict_update(this: dict, other: dict) -> dict:
     return this
 
 
-def flatten_dict(source_dict: dict):
+def flatten_dict(source_dict: dict) -> dict:
     """
     Flatten the given dictionary concatenating the keys with a colon '`:`'.
 
@@ -927,7 +924,7 @@ def waiting_for(
         The duration until the condition was met.
 
     Raises:
-        A TimeoutError when the condition was not fulfilled within the timeout period.
+        TimeoutError: when the condition was not fulfilled within the timeout period.
     """
 
     if inspect.isfunction(condition) or inspect.ismethod(condition):
@@ -985,7 +982,7 @@ def has_internet(host: str = "8.8.8.8", port: int = 53, timeout: float = 3.0):
             s.close()
 
 
-def do_every(period: float, func: callable, *args) -> None:
+def do_every(period: float, func: callable, *args: tuple[int, ...]) -> None:
     """
 
     This method executes a function periodically, taking into account
@@ -1048,7 +1045,7 @@ def chdir(dirname=None):
 
 
 @contextlib.contextmanager
-def env_var(**kwargs):
+def env_var(**kwargs: dict[str, str]):
     """
     Context manager to run some code that need alternate settings for environment variables.
 
@@ -1082,7 +1079,7 @@ def env_var(**kwargs):
             os.environ[k] = v
 
 
-def filter_by_attr(elements: Iterable, **attrs) -> List:
+def filter_by_attr(elements: Iterable, **attrs: dict[str, Any]) -> List:
     """
     A helper that returns the elements from the iterable that meet all the traits passed in `attrs`.
 
@@ -1210,7 +1207,7 @@ def read_last_lines(filename: str | Path, num_lines: int) -> List[str]:
 
     Returns:
         Last lines of a text file as a list of strings. An empty list is returned
-          when the file doesn't exist.
+            when the file doesn't exist.
     """
 
     # See: https://www.geeksforgeeks.org/python-reading-last-n-lines-of-a-file/
@@ -1375,7 +1372,7 @@ def get_package_location(module: str) -> List[Path]:
         return [] if location is None else [location]
 
 
-def get_module_location(arg) -> Path | None:
+def get_module_location(arg: Any) -> Path | None:
     """
     Returns the location of the module as a Path object.
 
@@ -1387,7 +1384,7 @@ def get_module_location(arg) -> Path | None:
 
     Returns:
         The location of the module as a Path object or None when the location can not be determined or
-          an invalid argument was provided.
+            an invalid argument was provided.
 
     Example:
         ```python
@@ -1402,8 +1399,9 @@ def get_module_location(arg) -> Path | None:
         If the module is not found or is not a valid module, None is returned.
 
     Warning:
-        If the module is a namespace, None will be returned. Use the function [is_namespace()](
-        ./#egse.system.is_namespace) to determine if the 'module' is a namespace.
+        If the module is a namespace, None will be returned. Use the function
+            [is_namespace()](system.md#egse.system.is_namespace) to determine if the 'module'
+            is a namespace.
 
     """
     if isinstance(arg, FunctionType):
@@ -1483,7 +1481,7 @@ def find_class(class_name: str) -> Type:
     """Find and returns a class based on the fully qualified name.
 
     A class name can be preceded with the string `class//`. This is used in YAML
-    files where the class is then instantiated on load by the [Setup](../setup/#egse.setup.Setup).
+    files where the class is then instantiated on load by the [Setup](setup.md#egse.setup.Setup).
 
     Args:
         class_name (str): a fully qualified name for the class
@@ -1542,7 +1540,7 @@ def check_str_for_slash(arg: str):
         ValueError(f"The given argument can not contain slashes, {arg=}.")
 
 
-def check_is_a_string(var, allow_none=False):
+def check_is_a_string(var: Any, allow_none=False):
     """
     Checks if the given variable is a string and raises a TypeError if the check fails.
 
@@ -1717,7 +1715,7 @@ def execution_time(func):
     if you want —by default and always— have an idea of the average execution time
     of the given function.
 
-    Use this in conjunction with the [get_average_execution_time()](./#egse.system.get_average_execution_time)
+    Use this in conjunction with the [get_average_execution_time()](system.md#egse.system.get_average_execution_time)
     function to retrieve the average execution time for the given function.
     """
 
@@ -1734,7 +1732,7 @@ def save_average_execution_time(func: Callable, *args, **kwargs):
     arguments (in args) and keyword arguments (in kwargs) are passed into the function. The execution
     time is saved in a deque of maximum 100 elements. When more times are added, the oldest times are
     discarded. This function is used in conjunction with the
-    [get_average_execution_time()](./#egse.system.get_average_execution_time) function.
+    [get_average_execution_time()](system.md#egse.system.get_average_execution_time) function.
     """
 
     with Timer(log_level=logging.NOTSET) as timer:
@@ -1751,9 +1749,10 @@ def save_average_execution_time(func: Callable, *args, **kwargs):
 def get_average_execution_time(func: Callable) -> float:
     """
     Returns the average execution time of the given function. The function 'func' shall be previously executed using
-    the [save_average_execution_time()](./#egse.system.save_average_execution_time) function which remembers the last
+    the [save_average_execution_time()](system.md#egse.system.save_average_execution_time) function which remembers the
+    last
     100 execution times of the function.
-    You can also decorate your function with [@execution_time](./#egse.system.execution_time) to permanently
+    You can also decorate your function with [@execution_time](system.md#egse.system.execution_time) to permanently
     monitor it.
     The average time is a moving average over the last 100 times. If the function was never called before, 0.0 is
     returned.

--- a/libs/cgse-common/tests/test_setup.py
+++ b/libs/cgse-common/tests/test_setup.py
@@ -1040,3 +1040,63 @@ def test_beer_factory():
     assert isinstance(beer, Beer)
     assert beer.name == "Achel Blond Extra"
     assert beer.alcohol == 9.5
+
+
+def test_walk():
+
+    setup = Setup.from_yaml_string(
+        """
+        xxx:
+            device: dev-xxx
+        
+        yyy:
+            device: dev-yyy
+        
+        zzz:
+            aaa:
+                device-args: [1,2,3]
+                device: dev-zzz-aaa
+            bbb:
+                device-name: BBB
+                device: dev-zzz-bbb
+        """
+    )
+
+    leafs = []
+    Setup.walk(setup, "device", leafs)
+
+    assert len(leafs) == 4
+    assert "dev-yyy" in leafs
+    assert "dev-zzz-aaa" in leafs
+
+
+def test_find_devices():
+
+    setup = Setup.from_yaml_string(
+        """
+        xxx:
+            device: dev-xxx
+            device_name: XXX
+        
+        yyy:
+            device: dev-yyy
+            device_name: YYY
+        
+        zzz:
+            aaa:
+                device_args: [1,2,3]
+                device_name: AAA
+                device: dev-zzz-aaa
+            bbb:
+                device_name: BBB
+                device: dev-zzz-bbb
+        
+        """
+    )
+
+    devices = {}
+    devices = Setup.find_devices(setup, devices)
+
+    assert len(devices) == 4
+    assert devices["BBB"] == ("dev-zzz-bbb", ())
+    assert devices["AAA"] == ("dev-zzz-aaa", [1, 2, 3])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,8 +110,8 @@ plugins:
                     - "^__init__$"
 
 watch:
-  - overrides/
   - libs/cgse-common/src/egse
+  - libs/cgse-core/src/egse
 
 extra_css:
   - stylesheets/custom.css
@@ -168,7 +168,7 @@ nav:
       - api/counter.md
       - api/decorators.md
       - api/device.md
-      - api/dict.md
+      - api/dicts.md
       - api/dummy.md
       - api/exceptions.md
       - api/settings.md


### PR DESCRIPTION
Generating the API documentation generated a lot of warnings about arguments and return types. These have now been fixed.

The unit tests for `cgse-common` still result in all green.
 