### PR TITLE
Maintenance/bump version

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -3,12 +3,16 @@ This script bumps the version of all libs and projects in this monorepo to the v
 is currently in the `pyproject.toml` file in the root folder of the monorepo.
 
 Usage:
-    $ python bump.py
+    $ python bump.py <part>
+
+where `<part>` should be 'patch', 'minor', or 'major'.
 
 Note:
     You are expected to be in the minimal virtual environment associated with this monorepo,
     being a `pyenv` or Poetry environment, or your global environment shall include the tomlkit
     and the rich package.
+
+    Alternatively (and preferably) you can use `uv run build.py <part>` to run this script.
 
 """
 
@@ -17,14 +21,35 @@ Note:
 # dependencies = [
 #   "tomlkit",
 #   "rich",
+#   "typer",
 # ]
 # ///
 import os
 import pathlib
+import sys
 
 import rich
 import tomlkit
 import tomlkit.exceptions
+import typer
+
+
+def bump_version(version, part='patch'):
+    major, minor, patch = map(int, version.split('.'))
+
+    if part == 'major':
+        major += 1
+        minor = 0
+        patch = 0
+    elif part == 'minor':
+        minor += 1
+        patch = 0
+    elif part == 'patch':
+        patch += 1
+    else:
+        raise ValueError("Part must be 'major', 'minor', or 'patch'")
+
+    return f"{major}.{minor}.{patch}"
 
 
 def get_master_version(master_pyproject_path):
@@ -56,30 +81,57 @@ def update_project_version(project_dir, new_version):
         rich.print(f"[red]\[project.version] is not defined in pyproject.toml in {project_dir}[/]")
 
 
-def update_all_projects_in_monorepo(root_dir):
-    """Updates all pyproject.toml files with the master version number."""
+def update_all_projects_in_monorepo(root_dir: pathlib.Path, part: str, dry_run: bool = False, verbose: bool = True):
+    """
+    Updates all pyproject.toml files with the master version number.
+
+    Parameters:
+        root_dir:
+        part:
+        dry_run:
+        verbose:
+    """
 
     excluded_subdirs = ["__pycache__", ".venv", ".git", ".idea", "cgse/build", "cgse/dist"]
 
     master_version = get_master_version(os.path.join(root_dir, "pyproject.toml"))
 
-    rich.print(f"Projects will be bumped to version {master_version}")
+    new_version = bump_version(master_version, part=part)
+
+    rich.print(f"Projects will be bumped from version {master_version} to version {new_version}")
 
     for subdir, dirs, files in os.walk(root_dir):
         if subdir == "." or subdir == ".." or any(excluded in subdir for excluded in excluded_subdirs):
             # rich.print(f"rejected {subdir = }")
             continue
-        if "pyproject.toml" in files and subdir != str(root_dir):  # Skip the master pyproject.toml
-            print(f"Updating version for project in {subdir}")
-            update_project_version(subdir, master_version)
+        if subdir != str(root_dir):
+            # continue  # skip the root project file
+            pass
+        if "pyproject.toml" in files:
+            verbose and print(f"Updating version for project in {subdir}")
+            if not dry_run:
+                update_project_version(subdir, master_version)
 
 
-if __name__ == "__main__":
+app = typer.Typer()
+
+
+@app.command()
+def main(part: str, dry_run: bool = False, verbose: bool = True):
+
     monorepo_root = pathlib.Path(__file__).parent.resolve()
 
     cwd = os.getcwd()
     os.chdir(monorepo_root)
 
-    update_all_projects_in_monorepo(monorepo_root)
+    try:
+        update_all_projects_in_monorepo(monorepo_root, part, dry_run, verbose)
+    except ValueError as exc:
+        rich.print(f"[red]{exc.__class__.__name__}: {exc}[/]")
+        sys.exit(1)
+    finally:
+        os.chdir(cwd)
 
-    os.chdir(cwd)
+
+if __name__ == "__main__":
+    app()

--- a/docs/dev_guide/uv.md
+++ b/docs/dev_guide/uv.md
@@ -169,7 +169,7 @@ $ uv remove flask
 We have chosen for one and the same version number for all packages in the `cgse` monorepo. That means that whenever 
 we make a change to one of the packages and want to release that change, all packages shall be rebuild and published.
 
-!!! inline end warning
+!!! warning inline end
 
     When working in a workspace, keep in mind that the commands `uv run` and `uv sync` by default work on the 
     workspace root. That means that when you run the `uv run pip install <package>` command, the `.venv` at the 
@@ -184,10 +184,13 @@ and then bump the versions. Before building, clean up the `dist` folder, then yo
 
 ```shell
 $ cd <monorepo root>
-$ uv run bump.py
+$ uv run bump.py <part>
 $ rm -r dist
 $ uv build --all-packages
 ```
+where `<monorepo root>` is the root folder of your local clone, e.g. `~/github/cgse`, and 
+`<part>` stands for the _part_ of the version number that shall be bumped, i.e. 'patch', 'minor',
+or 'major'.
 
 Publish all packages in the root dist folder to PyPI. The UV_PUBLISH_TOKEN can be defined in a (read protected) ~/.
 setenv.bash file:

--- a/libs/cgse-common/src/egse/config.py
+++ b/libs/cgse-common/src/egse/config.py
@@ -174,7 +174,7 @@ def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None) ->
             yield Path(path) / name
 
 
-def find_file(name: str, root: str = None, in_dir: str = None) -> Path | None:
+def find_file(name: str, root: PurePath | str = None, in_dir: str = None) -> Path | None:
     """
     Find the path to the given file starting from the root directory of the
     distribution.
@@ -194,7 +194,7 @@ def find_file(name: str, root: str = None, in_dir: str = None) -> Path | None:
 
     Args:
         name (str): the name of the file
-        root (str): the top level folder to search [default=common-egse-root]
+        root (Path | str): the top level folder to search [default=common-egse-root]
         in_dir (str): the 'leaf' directory in which the file shall be
 
     Returns:

--- a/libs/cgse-common/tests/scripts/handle_sigterm.py
+++ b/libs/cgse-common/tests/scripts/handle_sigterm.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import signal
+import sys
+
+import typer
+
+from egse.system import SignalCatcher
+
+app = typer.Typer()
+logger = logging.getLogger("egse.test.process")
+
+
+@app.command()
+def main(ignore_sigterm: bool = False):
+
+    logging.basicConfig(level=logging.INFO)
+
+    if ignore_sigterm:
+        rc = _ignore_sigterm()
+    else:
+        rc = _handle_sigterm()
+
+    raise typer.Exit(code=rc)
+
+
+def _handle_sigterm():
+
+    killer = SignalCatcher()
+
+    while "waiting for a SIGTERM signal":
+        if (
+                killer.term_signal_received and
+                killer.signal_number == signal.SIGTERM
+        ):
+            logger.info("SIGTERM received, terminating...")
+            return 42
+
+    # The following code will never execute
+    return 0
+
+
+def _ignore_sigterm():
+
+    killer = SignalCatcher()
+
+    while "ignoring a SIGTERM signal":
+        if (
+                killer.term_signal_received and
+                killer.signal_number == signal.SIGTERM
+        ):
+            logger.info("SIGTERM received and ignored.")
+            killer.clear(term=True)
+            continue
+
+    # The following code will never execute
+    return 0
+
+
+if __name__ == "__main__":
+
+    import egse.logger  # noqa : activate egse logger
+
+    print(f"{sys.argv=}")
+    print(f"pid={os.getpid()}")
+
+    try:
+        app()
+    except typer.Exit as e:
+        raise SystemExit(e.exit_code)

--- a/libs/cgse-common/tests/scripts/process_with_children.py
+++ b/libs/cgse-common/tests/scripts/process_with_children.py
@@ -13,17 +13,25 @@ import logging
 import pickle
 import sys
 import time
+from pathlib import Path
 
 import zmq
 
+from egse.config import find_file
 from egse.process import ProcessStatus
+from egse.process import SubProcess
 
 LOGGER = logging.getLogger("egse.tests")
-
-PORT = 5556
+HERE = Path(__file__).parent
+PORT = 5557
 
 
 def main():
+
+    # Start a SubProcess
+
+    empty = SubProcess("Child", [sys.executable, str(find_file('empty_process.py', root=HERE).resolve())])
+    empty.execute()
 
     status = ProcessStatus()
 
@@ -56,6 +64,7 @@ def main():
         #  Do some 'work'
         time.sleep(0.1)
 
+    empty.quit()
     process_socket.close(linger=0)
 
 

--- a/libs/cgse-common/tests/scripts/raise_value_error.py
+++ b/libs/cgse-common/tests/scripts/raise_value_error.py
@@ -1,0 +1,23 @@
+import json
+import sys
+import time
+import traceback
+
+
+def main():
+    time.sleep(1.0)
+
+    try:
+        raise ValueError("for testing purposes")
+    except Exception as e:
+        error_info = {
+            "type": type(e).__name__,
+            "message": str(e),
+            "traceback": traceback.format_exc()
+        }
+        print(json.dumps(error_info), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ testpaths = [
     "libs/cgse-coordinates/tests",
 ]
 addopts = "-rA --cov --cov-branch --cov-report html"
+log_cli = true
+log_cli_level = "INFO"
 filterwarnings = [
     "ignore::DeprecationWarning"
 ]
@@ -37,7 +39,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 80
+# fail_under = 80
 
 [tool.uv.sources]
 cgse-common = { workspace = true }
@@ -63,6 +65,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "setuptools",  # needed by PyCharm
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.14.0",


### PR DESCRIPTION
The `bump.py` script now accepts a mandatory parameter to indicate which _part_ of the version number must be incremented. Additionally, the command has two new optional arguments:

* `--dry-run` – print what will be done, but don't do it
* `--no-verbose` – be less verbose

So, in order to update the minor version number, as an example:

```
$ uv run bump.py minor --dry-run --no-verbose
Projects will be bumped from version 0.5.1 to version 0.6.0
```

