### PR TITLE
Introduced 'nox' to test different Python environments

### DIFF
--- a/libs/cgse-common/noxfile.py
+++ b/libs/cgse-common/noxfile.py
@@ -1,0 +1,25 @@
+import nox
+
+
+@nox.session(python=['3.9', '3.10', '3.11', '3.12'])
+def tests(session: nox.Session):
+    """
+    Run the unit and regular tests.
+    """
+    print(f"{session.python = }")
+
+    py_version = ["--python", f"{session.python}"]
+    uv_run_cmd = ["uv", "run", "--active", *py_version]
+
+    session.run_install("uv", "python", "pin", f"{session.python}")
+
+    session.run_install("uv", "venv", *py_version)
+
+    session.run_install(
+        "uv", "sync", "--active", *py_version, "--all-packages", "--extra=test",
+        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+
+    session.run(*uv_run_cmd, "python", "-V")
+
+    session.run(*uv_run_cmd, "pytest", "-v", *session.posargs)

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -23,15 +23,25 @@ dependencies = [
     "deepdiff>=8.1.1",
     "distro>=1.9.0",
     "gitpython>=3.1.44",
-    "numpy==1.22.4",
-    "pandas>=1.5.1",
+#    "numpy==1.22.4",
+#    "pandas>=1.5.1",
     "pip>=24.3.1", # only used in setup
     "prometheus-client>=0.21.1",
     "psutil>=6.1.1",
     "pyyaml>=6.0.2",
-    "pyzmq == 23.2.1",
+#    "pyzmq == 23.2.1",
     "rich>=13.9.4",
     "typer>=0.15.1",
+
+    # Python 3.9 specific dependencies
+    "numpy==1.26.4; python_version == '3.9'",
+    "pandas==1.5.1; python_version == '3.9'",
+    "pyzmq==23.2.1; python_version == '3.9'",
+
+    # Python 3.10+ specific dependencies
+    "numpy>=2.1; python_version >= '3.10'",
+    "pandas>=2.2.0; python_version >= '3.10'",
+    "pyzmq>=25.1.0; python_version >= '3.10'",
 ]
 
 [project.scripts]
@@ -86,4 +96,5 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.14.0",
     "ruff>=0.9.0",
+    "nox",
 ]

--- a/libs/cgse-common/src/egse/decorators.py
+++ b/libs/cgse-common/src/egse/decorators.py
@@ -44,7 +44,7 @@ def static_vars(**kwargs):
     return decorator
 
 
-def dynamic_interface(func):
+def dynamic_interface(func) -> Callable:
     """Adds a static variable `__dynamic_interface` to a method.
 
     The intended use of this function is as a decorator for functions in an interface class.

--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -110,7 +110,7 @@ commands = attrdict(
 )
 
 
-def is_dummy_cs_active():
+def is_dummy_cs_active() -> bool:
     """Returns True if the dummy device control server is active."""
     return is_control_server_active(
         endpoint=connect_address(ctrl_settings.PROTOCOL, ctrl_settings.HOSTNAME, ctrl_settings.COMMANDING_PORT)

--- a/libs/cgse-common/src/egse/zmq_ser.py
+++ b/libs/cgse-common/src/egse/zmq_ser.py
@@ -3,28 +3,28 @@ import zlib
 from enum import IntEnum
 
 
-def connect_address(transport, address, port):
+def connect_address(transport: str, address: str, port: int) -> str:
     """Returns a properly formatted URL to connect to."""
     return f"{transport}://{address}:{port}"
 
 
-def bind_address(transport, port):
+def bind_address(transport: str, port: int) -> str:
     """Returns a properly formatted url to bind a socket to."""
     return f"{transport}://*:{port}"
 
 
-def set_address_port(url: str, port: int):
+def set_address_port(url: str, port: int) -> str:
     """Returns a url where the 'port' part is replaced with the given port."""
     transport, address, old_port = split_address(url)
 
     return f"{transport}://{address}:{port}"
 
 
-def split_address(url: str):
+def split_address(url: str) -> tuple[str, str, int]:
     transport, address, port = url.split(":")
     if address.startswith("//"):
         address = address[2:]
-    return transport, address, port
+    return transport, address, int(port)
 
 
 def send_zipped_pickle(socket, obj, flags=0, protocol=-1):

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -22,9 +22,6 @@ keywords = [
 dependencies = [
     "cgse-common",
     "matplotlib>=3.8.4",
-    "numpy==1.22.4",
-    "pandas>=1.5.1",
-    "pip>=24.3.1",
     "transforms3d>=0.4.2",
 ]
 

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "cgse-common",
     "plato-spw",
     "astropy>=6.0.1",
-    "numpy==1.22.4",
 ]
 
 [project.optional-dependencies]

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -20,7 +20,6 @@ keywords = [
 ]
 dependencies = [
     "cgse-common",
-    "numpy==1.22.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- 'nox' is now used to run unit tests for different Python environments
- `pyproject.toml` adapted to fix dependencies for Python 3.9, 3.10, 3.11, and 3.12
- added some type hints