### PR TITLE
Fix python 3.12+ backward incompatible changes

### DIFF
--- a/libs/cgse-common/noxfile.py
+++ b/libs/cgse-common/noxfile.py
@@ -1,26 +1,46 @@
 import nox
 
+python_versions = ['3.9', '3.10', '3.11', '3.12', '3.13']
 
-@nox.session(python=['3.9', '3.10', '3.11', '3.12'])
-def tests(session: nox.Session):
+
+@nox.session(python=python_versions)
+def uv_tests(session: nox.Session):
     """
-    Run the unit and regular tests.
+    Run the unit and regular tests using `uv`.
     """
     print(f"{session.python = }")
 
     py_version = ["--python", f"{session.python}"]
+
     uv_run_cmd = ["uv", "run", "--active", *py_version]
     uv_sync_cmd = ["uv", "sync", "--active", *py_version]
 
-    session.run_install("uv", "python", "pin", f"{session.python}")
+    # session.run_install("uv", "python", "pin", f"{session.python}")
 
     session.run_install("uv", "venv", *py_version)
 
     session.run_install(
-        *uv_sync_cmd, "--all-packages", "--extra=test",
+        *uv_sync_cmd, # "--all-packages",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
     session.run(*uv_run_cmd, "python", "-V")
-
+    session.run(*uv_run_cmd, "python", "-m", "site")
     session.run(*uv_run_cmd, "pytest", "-v", *session.posargs)
+
+
+@nox.session(python=python_versions)
+def py_tests(session: nox.Session):
+    """
+    Run the unit and regular tests using plain Python.
+    """
+    print(f"{session.python = }")
+
+    session.install(".")
+    session.install("pytest")
+    session.install("pytest-cov")
+    session.install("pytest-mock")
+
+    session.run("python", "-V")
+    session.run("python", "-m", "site")
+    session.run("pytest", "-v", *session.posargs)

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -23,25 +23,25 @@ dependencies = [
     "deepdiff>=8.1.1",
     "distro>=1.9.0",
     "gitpython>=3.1.44",
-#    "numpy==1.22.4",
-#    "pandas>=1.5.1",
+    #    "numpy==1.22.4",
+    #    "pandas>=1.5.1",
     "pip>=24.3.1", # only used in setup
     "prometheus-client>=0.21.1",
     "psutil>=6.1.1",
     "pyyaml>=6.0.2",
-#    "pyzmq == 23.2.1",
+    #    "pyzmq == 23.2.1",
     "rich>=13.9.4",
     "typer>=0.15.1",
-
     # Python 3.9 specific dependencies
     "numpy==1.26.4; python_version == '3.9'",
     "pandas==1.5.1; python_version == '3.9'",
     "pyzmq==23.2.1; python_version == '3.9'",
-
     # Python 3.10+ specific dependencies
     "numpy>=2.1; python_version >= '3.10'",
     "pandas>=2.2.0; python_version >= '3.10'",
     "pyzmq>=25.1.0; python_version >= '3.10'",
+    # Python 3.10+ entrypoints interface changed
+    "importlib_metadata>=4.6.0; python_version == '3.9'",
 ]
 
 [project.scripts]
@@ -97,4 +97,5 @@ dev = [
     "pytest-mock>=3.14.0",
     "ruff>=0.9.0",
     "nox",
+    "setuptools>=75.8.2",  # needed by PyCharm
 ]

--- a/libs/cgse-common/src/egse/control.py
+++ b/libs/cgse-common/src/egse/control.py
@@ -22,9 +22,9 @@ from egse.system import SignalCatcher
 from egse.system import time_in_ms
 
 try:
+    # This function is only available when the cgse-core package is installed
     from egse.logger import close_all_zmq_handlers
 except ImportError:
-
     def close_all_zmq_handlers():  # noqa
         pass
 

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -12,8 +12,15 @@ import os
 import sys
 import textwrap
 import traceback
-from importlib.metadata import EntryPoint
 from pathlib import Path
+
+if sys.version_info >= (3, 10):    # Use the standard library version (Python 3.10+)
+    from importlib.metadata import entry_points as lib_entry_points
+    from importlib.metadata import EntryPoint
+else:
+    # Fall back to the backport for Python 3.9
+    from importlib_metadata import entry_points as lib_entry_points
+    from importlib_metadata import EntryPoint
 
 import click
 import rich
@@ -21,17 +28,15 @@ import rich
 _LOGGER = logging.getLogger(__name__)
 
 
-def entry_points(name: str) -> set[EntryPoint]:
+def entry_points(group: str) -> set[EntryPoint]:
     """
     Returns a set with all entry-points for the given group name.
 
     When the name is not known as an entry-point group, an empty set will be returned.
     """
 
-    import importlib.metadata
-
     try:
-        x = importlib.metadata.entry_points()[name]
+        x = lib_entry_points().select(group=group)
         return {ep for ep in x}  # use of set here to remove duplicates
     except KeyError:
         return set()

--- a/libs/cgse-common/src/egse/process.py
+++ b/libs/cgse-common/src/egse/process.py
@@ -478,7 +478,7 @@ def list_processes(
     return result
 
 
-def list_zombies():
+def list_zombies() -> list[dict]:
     """
     Returns a list of zombie processes.
 

--- a/libs/cgse-common/src/egse/settings.py
+++ b/libs/cgse-common/src/egse/settings.py
@@ -19,36 +19,41 @@ available as instance variables of the returned class.
 
 The intended use is as follows:
 
-    from egse.settings import Settings
+```python
+from egse.settings import Settings
 
-    dsi_settings = Settings.load("DSI")
+dsi_settings = Settings.load("DSI")
 
-    if 0x000C <= dsi_settings.RMAP_BASE_ADDRESS <= 0x00FF:
-        ...  # do something here
-    else:
-        raise RMAPError("Attempt to access outside the RMAP memory map.")
+if 0x000C <= dsi_settings.RMAP_BASE_ADDRESS <= 0x00FF:
+    ...  # do something here
+else:
+    raise RMAPError("Attempt to access outside the RMAP memory map.")
+```
 
 The above code reads the settings from the default YAML file for a group called `DSI`.
 The settings will then be available as variables of the returned class, in this case
 `dsi_settings`. The returned class is and behaves also like a dictionary, so you can
 check if a configuration parameter is defined like this:
 
-    if "DSI_FEE_IP_ADDRESS" not in dsi_settings:
-        # define the IP address of the DSI
-
+```python
+if "DSI_FEE_IP_ADDRESS" not in dsi_settings:
+    # define the IP address of the DSI
+```
 The YAML section for the above code looks like this:
 
-    DSI:
+```text
+DSI:
 
-        # DSI Specific Settings
+    # DSI Specific Settings
 
-        DSI_FEE_IP_ADDRESS  10.33.178.144   # IP address of the DSI EtherSpaceLink interface
-        LINK_SPEED:                   100   # SpW link speed used for both up- and downlink
+    DSI_FEE_IP_ADDRESS  10.33.178.144   # IP address of the DSI EtherSpaceLink interface
+    LINK_SPEED:                   100   # SpW link speed used for both up- and downlink
 
-        # RMAP Specific Settings
+    # RMAP Specific Settings
 
-        RMAP_BASE_ADDRESS:     0x00000000   # The start of the RMAP memory map managed by the FEE
-        RMAP_MEMORY_SIZE:            4096   # The size of the RMAP memory map managed by the FEE
+    RMAP_BASE_ADDRESS:     0x00000000   # The start of the RMAP memory map managed by the FEE
+    RMAP_MEMORY_SIZE:            4096   # The size of the RMAP memory map managed by the FEE
+```
 
 When you want to read settings from another YAML file, specify the `filename=` keyword.
 If that file is located at a specific location, also use the `location=` keyword.

--- a/libs/cgse-common/tests/scripts/handle_sigterm.py
+++ b/libs/cgse-common/tests/scripts/handle_sigterm.py
@@ -15,6 +15,9 @@ logger = logging.getLogger("egse.test.process")
 def main(ignore_sigterm: bool = False):
     logging.basicConfig(level=logging.INFO)
 
+    logger.info(f"{sys.version_info = }")
+    logger.info(f"{ignore_sigterm = }")
+
     if ignore_sigterm:
         rc = _ignore_sigterm()
     else:
@@ -27,9 +30,11 @@ def _handle_sigterm():
     killer = SignalCatcher()
 
     while "waiting for a SIGTERM signal":
-        if killer.term_signal_received and killer.signal_number == signal.SIGTERM:
-            logger.info("SIGTERM received, terminating...")
-            return 42
+        if killer.term_signal_received:
+            logger.info(f"{killer.signal_number = }")
+            if killer.signal_number == signal.SIGTERM:
+                logger.info("SIGTERM received, terminating...")
+                return 42
 
     # The following code will never execute
     return 0
@@ -39,20 +44,26 @@ def _ignore_sigterm():
     killer = SignalCatcher()
 
     while "ignoring a SIGTERM signal":
-        if killer.term_signal_received and killer.signal_number == signal.SIGTERM:
-            logger.info("SIGTERM received and ignored.")
-            killer.clear(term=True)
-            continue
+        if killer.term_signal_received:
+            logger.info(f"{killer.signal_number = }")
+            if killer.signal_number == signal.SIGTERM:
+                logger.info("SIGTERM received and ignored.")
+                killer.clear(term=True)
+                continue
 
     # The following code will never execute
     return 0
 
 
 if __name__ == "__main__":
-    import egse.logger  # noqa : activate egse logger
-
     print(f"{sys.argv=}")
     print(f"pid={os.getpid()}")
+
+    try:
+        from egse.logger import replace_zmq_handler
+    except (ModuleNotFoundError, ImportError):
+        def replace_zmq_handler():
+            ...
 
     try:
         app()

--- a/libs/cgse-common/tests/test_process.py
+++ b/libs/cgse-common/tests/test_process.py
@@ -156,7 +156,7 @@ def test_quit_process():
     )
 
     assert process.execute()
-    time.sleep(0.5)  # allow process to start
+    time.sleep(1.0)  # allow process to start
     assert process.is_running()
     rc = process.quit()
     logger.info(f"After quit() -> {rc = }")
@@ -173,7 +173,7 @@ def test_quit_process():
     process = SubProcess("Handle SIGTERM", [sys.executable, str(find_file("handle_sigterm.py").resolve())])
 
     assert process.execute()
-    time.sleep(0.5)  # allow process to start
+    time.sleep(1.0)  # allow process to start
     assert process.is_running()
     rc = process.quit()
     logger.info(f"After quit() -> {rc = }")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ omit = [
 [tool.coverage.report]
 # fail_under = 80
 
+[tool.uv]
+default-groups = ["dev", "docs"]
+
 [tool.uv.sources]
 cgse-common = { workspace = true }
 cgse-core = { workspace = true }


### PR DESCRIPTION
This pull request fixes some issues with testing the cgse-common for different python environments using `nox`.

- The `entrypoints()` in `importlib.metadata` had a breaking change in 3.12+
- The `nox` now has a session to run unit tests using `uv` and another session to use `standard pip`
- The `pyproject.toml` now has conditional dependencies for Python versions 3.9 and 3.10+
- The `egse.plugin` now handles he `entry points` fix
- some editorial and type hint changes