### PR TITLE
Refactoring of protocol

### DIFF
--- a/libs/cgse-common/src/egse/bits.py
+++ b/libs/cgse-common/src/egse/bits.py
@@ -1,6 +1,7 @@
 """
 This module contains a number of convenience functions to work with bits, bytes and integers.
 """
+
 from __future__ import annotations
 
 import ctypes
@@ -169,7 +170,7 @@ def beautify_binary(value: int, sep: str = " ", group: int = 8, prefix: str = ""
 
     b_str = f"{value:0{size}b}"
 
-    return prefix + sep.join([b_str[i:i + group] for i in range(0, len(b_str), group)])
+    return prefix + sep.join([b_str[i : i + group] for i in range(0, len(b_str), group)])
 
 
 def humanize_bytes(n: int, base: Union[int, str] = 2, precision: int = 3) -> str:

--- a/libs/cgse-common/src/egse/bits.py
+++ b/libs/cgse-common/src/egse/bits.py
@@ -1,6 +1,7 @@
 """
 This module contains a number of convenience functions to work with bits, bytes and integers.
 """
+from __future__ import annotations
 
 import ctypes
 from typing import Union
@@ -119,7 +120,7 @@ def bit_set(value: int, bit) -> bool:
     return value & bit_value == bit_value
 
 
-def bits_set(value: int, *args: tuple[int, ...]) -> bool:
+def bits_set(value: int, *args: list[int] | tuple[int]) -> bool:
     """
     Return True if all the bits are set.
 
@@ -168,12 +169,12 @@ def beautify_binary(value: int, sep: str = " ", group: int = 8, prefix: str = ""
 
     b_str = f"{value:0{size}b}"
 
-    return prefix + sep.join([b_str[i : i + group] for i in range(0, len(b_str), group)])
+    return prefix + sep.join([b_str[i:i + group] for i in range(0, len(b_str), group)])
 
 
 def humanize_bytes(n: int, base: Union[int, str] = 2, precision: int = 3) -> str:
     """
-    Represents the size `n` in human readable form, i.e. as byte, KiB, MiB, GiB, ...
+    Represents the size `n` in human-readable form, i.e. as byte, KiB, MiB, GiB, ...
 
     Args:
         n (int): number of byte
@@ -181,7 +182,7 @@ def humanize_bytes(n: int, base: Union[int, str] = 2, precision: int = 3) -> str
         precision (int): the number of decimal places [default=3]
 
     Returns:
-        a human readable size, like 512 byte or 2.300 TiB
+        a human-readable size, like 512 byte or 2.300 TiB
 
     Raises:
         ValueError: when base is different from 2 (binary) or 10 (decimal).
@@ -205,7 +206,7 @@ def humanize_bytes(n: int, base: Union[int, str] = 2, precision: int = 3) -> str
     if base not in [2, 10, "binary", "decimal"]:
         raise ValueError(f"Only base 2 (binary) and 10 (decimal) are supported, got {base}.")
 
-    # By default we assume base == 2 or base == "binary"
+    # By default, we assume base == 2 or base == "binary"
 
     one_kilo = 1024
     units = ["KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]

--- a/libs/cgse-common/src/egse/bits.py
+++ b/libs/cgse-common/src/egse/bits.py
@@ -517,6 +517,8 @@ def crc_calc(data: list[Union[bytes, int]], start: int, len_: int) -> int:
     elif isinstance(data[0], int):
         for idx in range(start, start + len_):
             crc = CRC_TABLE[crc ^ (data[idx] & 0xFF)]
+    else:
+        ...
 
     return crc
 

--- a/libs/cgse-common/src/egse/command.py
+++ b/libs/cgse-common/src/egse/command.py
@@ -99,6 +99,7 @@ from collections import namedtuple
 from typing import Any
 from typing import Callable
 
+from egse.decorators import deprecate
 from egse.exceptions import Error
 from egse.response import Success
 
@@ -545,6 +546,7 @@ class ClientServerCommand(Command):
         return 0
 
 
+@deprecate(reason="it is a duplicate of get_method() from egse.protocol")
 def get_method(parent_obj: type, method_name: str) -> Callable:
     """
     Returns a bound method from a given class instance.
@@ -576,6 +578,7 @@ def get_method(parent_obj: type, method_name: str) -> Callable:
     return None
 
 
+@deprecate(reason="it is a duplicate of get_function() from egse.protocol")
 def get_function(parent_class: type, method_name: str) -> Callable:
     """
     Returns a function (unbound method) from a given class.

--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -218,8 +218,7 @@ class DummyProtocol(CommandProtocol):
     """
 
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.device_controller = DummyController(control_server)
 

--- a/libs/cgse-common/src/egse/monitoring.py
+++ b/libs/cgse-common/src/egse/monitoring.py
@@ -25,8 +25,7 @@ _LOGGER = logging.getLogger("egse.monitoring")
 
 class MonitoringProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
     def get_bind_address(self):
         return bind_address(self.control_server.get_communication_protocol(), self.control_server.get_monitoring_port())

--- a/libs/cgse-common/src/egse/services.py
+++ b/libs/cgse-common/src/egse/services.py
@@ -34,16 +34,23 @@ class ServiceCommand(ClientServerCommand):
 
 class ServiceProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.load_commands(SERVICE_SETTINGS.Commands, ServiceCommand, ServiceProtocol)
 
     def get_bind_address(self):
-        return bind_address(self.control_server.get_communication_protocol(), self.control_server.get_service_port())
+        """
+        Returns a string with the bind address, the endpoint, for accepting connections
+        and bind a socket to. The port to connect to is the service port in this case,
+        not the commanding port.
 
-    def get_status(self):
-        return super().get_status()
+        Returns:
+            a string with the protocol and port to bind a socket to.
+        """
+        return bind_address(
+            self._control_server.get_communication_protocol(),
+            self._control_server.get_service_port(),
+        )
 
     def handle_set_monitoring_frequency(self, freq: float):
         """
@@ -57,7 +64,7 @@ class ServiceProtocol(CommandProtocol):
         Returns:
             Sends back the selected delay time in milliseconds.
         """
-        delay = self.control_server.set_mon_delay(1.0 / freq)
+        delay = self.get_control_server().set_mon_delay(1.0 / freq)
 
         LOGGER.debug(f"Set monitoring frequency to {freq}Hz, ± every {delay:.0f}ms.")
 
@@ -75,7 +82,7 @@ class ServiceProtocol(CommandProtocol):
         Returns:
             Sends back the selected delay time in milliseconds.
         """
-        delay = self.control_server.set_hk_delay(1.0 / freq)
+        delay = self.get_control_server().set_hk_delay(1.0 / freq)
 
         LOGGER.debug(f"Set housekeeping frequency to {freq}Hz, ± every {delay:.0f}ms.")
 

--- a/libs/cgse-common/tests/test_bits.py
+++ b/libs/cgse-common/tests/test_bits.py
@@ -9,6 +9,7 @@ from egse.bits import bits_set
 from egse.bits import clear_bit
 from egse.bits import clear_bits
 from egse.bits import crc_calc
+from egse.bits import extract_bits
 from egse.bits import humanize_bytes
 from egse.bits import s16
 from egse.bits import s32
@@ -18,6 +19,14 @@ from egse.bits import toggle_bit
 
 logger = logging.getLogger(__name__)
 
+
+def test_extract_bits():
+
+    bf = 0b0010_1110
+
+    assert extract_bits(bf, 0, 3) == 0b0110
+    assert extract_bits(0b1001_0101, 0, 1) == 0b0001
+    assert extract_bits(0b1111_0000, 3, 2) == 0b0010
 
 def test_clear_bit():
     bf = 0b11111111
@@ -86,6 +95,10 @@ def test_beautify_binary():
     assert beautify_binary(0b0010, group=4) == "0000 0010"
     assert beautify_binary(0b1111_1111, group=4) == "1111 1111"
     assert beautify_binary(0b0000_0001_1111_1111) == "00000001 11111111"
+
+    assert beautify_binary(0b0010, group=4, size=4) == "0010"
+    assert beautify_binary(0b1111_1111, group=4, size=12) == "0000 1111 1111"
+    assert beautify_binary(0b0000_0001_1111_1111, group=12, size=12) == "000111111111"
 
     assert beautify_binary(2**7) == "10000000"
     assert beautify_binary(2**8) == "00000001 00000000"
@@ -170,6 +183,8 @@ def test_crc_calc():
 
     with pytest.raises(IndexError):
         assert crc_calc(b, 0, 28) == 0x63
+
+    assert crc_calc([0.0, 1.0, 2.0, 3.0], 0, 4) == 0
 
 
 def test_humanize_bytes():

--- a/libs/cgse-common/tests/test_process.py
+++ b/libs/cgse-common/tests/test_process.py
@@ -316,7 +316,10 @@ def test_raise_value_error():
 
 
 def test_process_status():
-    status = ProcessStatus()
+
+    # Need to provide a prefix here otherwise we will get a duplicate metrics error when a control server is created.
+
+    status = ProcessStatus(metrics_prefix="X372")
 
     sd = status.as_dict()
 

--- a/libs/cgse-common/tests/test_protocol.py
+++ b/libs/cgse-common/tests/test_protocol.py
@@ -1,0 +1,123 @@
+import pickle
+import types
+from abc import ABC
+from typing import Any
+
+from egse.control import ControlServer
+from egse.decorators import dynamic_interface
+from egse.protocol import CommandProtocol
+from egse.protocol import get_function
+from egse.protocol import get_method
+from egse.zmq_ser import bind_address
+
+
+class _T:
+    """A test class for the get_method() and get_function() functions."""
+    _a = None
+
+    def _m(self):
+        ...
+
+    @dynamic_interface
+    def _di(self):
+        ...
+
+
+def test_get_method():
+
+    assert get_method(_T, "_m") is None  # _m is a function for _T which is a class
+    assert get_method(_T(), "") is None
+    assert get_method(_T(), "None") is None
+    assert get_method(_T(), None) is None
+
+    assert get_method(_T(), "unknown") is None
+
+    assert isinstance(get_method(_T(), "_m"), types.MethodType)
+    assert isinstance(get_method(_T(), "_di"), types.MethodType)
+
+    assert isinstance(get_method(_T(), "__getattribute__"), types.MethodWrapperType)
+
+
+def test_get_function():
+
+    assert get_function(_T, "") is None
+    assert get_function(_T, "None") is None
+    assert get_function(_T, None) is None
+
+    assert get_function(_T, "unknown") is None
+    assert get_function(_T, "_a") is None
+
+    assert isinstance(get_function(_T, "_m"), types.FunctionType)
+    assert isinstance(get_function(_T, "_di"), types.FunctionType)
+
+
+class InternalCommunication:
+    def __init__(self):
+        self._status = 0
+        self._pickle_string: bytes = bytes()
+
+    def send(self, data):
+        self._pickle_string = pickle.dumps(data)
+
+    def receive(self) -> Any:
+        """
+        Returns an object based on the last command that was sent and based on
+        the status of the internal communication.
+        """
+        data = pickle.loads(self._pickle_string)
+        return data
+
+
+class ControlServerMock(ControlServer):
+    def __init__(self):
+        super().__init__()
+        self.mon_delay = 23
+
+    def get_communication_protocol(self) -> str:
+        return "tcp"
+
+    def get_commanding_port(self) -> int:
+        return 55555
+
+    def get_service_port(self) -> int:
+        return 55556
+
+    def get_monitoring_port(self) -> int:
+        return 55557
+
+
+# Why are there only two abstract methods?
+# - get_status()
+# - get_bind_address()
+# Why are the following methods also not abstract?
+# - get_housekeeping()
+# -
+class _TestCommandProtocol(CommandProtocol):
+    """A test class to unit test the CommandProtocol."""
+    def __init__(self):
+        super().__init__(ControlServerMock())
+        self._comm = InternalCommunication()
+
+    def get_status(self) -> dict:
+        return super().get_status()
+
+    def get_bind_address(self) -> str:
+        return bind_address(self.control_server.get_communication_protocol(), self.control_server.get_commanding_port())
+
+    def receive(self) -> Any:
+        """Overwrites the parent class method """
+        response = self._comm.receive()
+        return response
+
+    def send(self, data):
+        self._comm.send(data)
+
+
+def test_command_protocol():
+
+    tcp = _TestCommandProtocol()
+
+    status = tcp.get_status()
+
+    assert "timestamp" in status
+    assert "PID" in status

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1005,8 +1005,7 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
 
 class ConfigurationManagerProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.controller = ConfigurationManagerController(control_server)
 

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -112,11 +112,7 @@ class ProcessManagerProtocol(CommandProtocol):
                               to the Controller.
         """
 
-        super().__init__()
-
-        # Control Server for Process Management
-
-        self.control_server = control_server
+        super().__init__(control_server)
 
         # Create a new Controller for Process Management
 

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -1094,8 +1094,7 @@ class StorageProxy(Proxy, StorageInterface, EventInterface):
 
 class StorageProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.controller = StorageController(control_server)
 

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_protocol.py
@@ -25,8 +25,7 @@ class JoranCommand(ClientServerCommand):
 
 class JoranProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)
 

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_protocol.py
@@ -29,8 +29,7 @@ class PunaCommand(ClientServerCommand):
 
 class PunaProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer, simulator: bool = False):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
         self.simulator = simulator
 
         # self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_protocol.py
@@ -24,8 +24,7 @@ class ZondaCommand(ClientServerCommand):
 
 class ZondaProtocol(CommandProtocol):
     def __init__(self, control_server: ControlServer):
-        super().__init__()
-        self.control_server = control_server
+        super().__init__(control_server)
 
         self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)
 


### PR DESCRIPTION
First round of refactoring for CommandProtocol.

- CommandProtocol now inherits from BaseCommandProtocol
- Improve typing hints
- control_server is now a mandatory argument on the base class
- extract methods into the base class
- simple initial unit test
- deprecated get_function() and get_method() in egse.command, use the functions in egse.protocol
