### PR TITLE
add registry services to the core services functionality

### DIFF
--- a/libs/cgse-common/src/egse/decorators.py
+++ b/libs/cgse-common/src/egse/decorators.py
@@ -44,6 +44,40 @@ def static_vars(**kwargs):
     return decorator
 
 
+def implements_protocol(protocol):
+    """
+    Decorator to verify and document protocol compliance at class definition time.
+
+    Usage:
+        @implements_protocol(AsyncRegistryBackend)
+        class MyBackend:
+            ...
+    """
+
+    def decorator(cls):
+        # Add protocol documentation
+        if cls.__doc__:
+            cls.__doc__ += f"\n\nThis class implements the {protocol.__name__} protocol."
+        else:
+            cls.__doc__ = f"This class implements the {protocol.__name__} protocol."
+
+        # Store the protocol for reference
+        cls.__implements_protocol__ = protocol
+
+        # Add runtime verification method
+        def _verify_protocol_compliance(self):
+            if not isinstance(self, protocol):
+                raise TypeError(f"{self.__class__.__name__} does not correctly implement {protocol.__name__}")
+            return True
+
+        cls.verify_protocol_compliance = _verify_protocol_compliance
+
+        # Return the modified class
+        return cls
+
+    return decorator
+
+
 def dynamic_interface(func) -> Callable:
     """Adds a static variable `__dynamic_interface` to a method.
 

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -12,6 +12,7 @@ The module has external dependencies to:
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import collections
 import contextlib
@@ -53,11 +54,33 @@ import psutil
 from rich.console import Console
 from rich.text import Text
 from rich.tree import Tree
+from typer.core import TyperCommand
 
 EPOCH_1958_1970 = 378691200
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
 logger = logging.getLogger(__name__)
+
+
+class TyperAsyncCommand(TyperCommand):
+    """Runs an asyncio Typer command.
+
+    Example:
+
+        @add.command(cls=TyperAsyncCommand)
+        async def start():
+            ...
+
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        old_callback = self.callback
+
+        def new_callback(*args, **kwargs):
+            return asyncio.run(old_callback(*args, **kwargs))
+
+        self.callback = new_callback
 
 
 @contextmanager

--- a/libs/cgse-common/src/egse/zmq_ser.py
+++ b/libs/cgse-common/src/egse/zmq_ser.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import pickle
 import zlib
 from enum import IntEnum
+
+import zmq
 
 
 def connect_address(transport: str, address: str, port: int) -> str:
@@ -39,6 +43,19 @@ def recv_zipped_pickle(socket, flags=0, protocol=-1):
     z = socket.recv(flags)
     p = zlib.decompress(z)
     return pickle.loads(p)
+
+
+def get_port_number(socket: zmq.Socket) -> int | None:
+    """
+    Returns the port number associated with this socket. Returns None for sockets
+    that do not bind to a TCP or IPC transport.
+    """
+    endpoint = socket.getsockopt(zmq.LAST_ENDPOINT)
+    if endpoint:
+        port = endpoint.decode("utf-8").split(':')[-1]
+        return int(port)
+    else:
+        return None
 
 
 class MessageIdentifier(IntEnum):

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -21,6 +21,8 @@ keywords = [
 dependencies = [
     "cgse-common",
     "apscheduler>=3.11.0",
+    "aiosqlite>=0.21.0",
+    "aiohttp>=3.11.16",
 ]
 
 [project.scripts]
@@ -44,10 +46,14 @@ explore = "cgse_core.cgse_explore"
 [tool.pytest.ini_options]
 pythonpath = "src"
 testpaths = ["tests"]
-addopts = "-ra --cov --cov-report html"
+addopts = "-rA --cov --cov-branch --cov-report html"
 filterwarnings = [
     "ignore::DeprecationWarning"
 ]
+log_cli = true
+log_cli_level = "WARNING"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.coverage.run]
 omit = [
@@ -79,6 +85,9 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.0.0",
+    "pytest-mock>=3.14.0",
+    "pytest-timeout>=2.3.1",
     "ruff>=0.9.0",
 ]

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -5,6 +5,18 @@ from pathlib import Path
 import rich
 
 
+def start_rs_cs():
+    rich.print("Starting the registry service core service...")
+
+    out = open(Path('~/.rs_cs.start.out').expanduser(), 'w')
+
+    subprocess.Popen(
+        [sys.executable, '-m', 'egse.registry.server', 'start'],
+        stdout=out, stderr=out, stdin=subprocess.DEVNULL,
+        close_fds=True
+    )
+
+
 def start_log_cs():
     rich.print("Starting the logging core service...")
 

--- a/libs/cgse-core/src/cgse_core/_status.py
+++ b/libs/cgse-core/src/cgse_core/_status.py
@@ -1,18 +1,39 @@
 import asyncio
 # import subprocess
 import sys
+import textwrap
 
 import rich
+
+from egse.registry.client import AsyncRegistryClient
 
 
 async def run_all_status(full: bool = False):
     tasks = [
+        status_rs_cs(),
         status_log_cs(),
         status_sm_cs(full),
         status_cm_cs(),
     ]
 
     await asyncio.gather(*tasks)
+
+
+async def status_rs_cs():
+    client = AsyncRegistryClient()
+    response = await client.server_status()
+
+    status_report = textwrap.dedent(
+        f"""\
+        Registry Service:
+            Status: {response['status']}
+            Requests port: {response['req_port']}
+            Notifications port: {response['pub_port']}
+            Registrations: {", ".join([f"({x['name']}, {x['health']})" for x in response['services']])}\
+        """
+    )
+
+    rich.print(status_report)
 
 
 async def status_log_cs():

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -5,6 +5,18 @@ from pathlib import Path
 import rich
 
 
+def stop_rs_cs():
+    rich.print("Terminating the registry service core service...")
+
+    out = open(Path('~/.rs_cs.stop.out').expanduser(), 'w')
+
+    subprocess.Popen(
+        [sys.executable, '-m', 'egse.registry.server', 'stop'],
+        stdout=out, stderr=out, stdin=subprocess.DEVNULL,
+        close_fds=True
+    )
+
+
 def stop_log_cs():
     rich.print("Terminating the logging core service...")
 

--- a/libs/cgse-core/src/cgse_core/cgse_explore.py
+++ b/libs/cgse-core/src/cgse_core/cgse_explore.py
@@ -7,4 +7,4 @@ from egse.process import ps_egrep
 
 def show_processes():
     """Show the lines from the `ps -ef` command that match processes from this package."""
-    return ps_egrep("(log|confman|storage|procman)_cs")
+    return ps_egrep("(log|confman|storage|procman)_cs|registry.server")

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -3,8 +3,8 @@ import asyncio
 import rich
 import typer
 
-from ._start import start_log_cs, start_sm_cs, start_cm_cs
-from ._stop import stop_log_cs, stop_sm_cs, stop_cm_cs
+from ._start import start_rs_cs, start_log_cs, start_sm_cs, start_cm_cs
+from ._stop import stop_rs_cs, stop_log_cs, stop_sm_cs, stop_cm_cs
 from ._status import run_all_status
 
 app = typer.Typer(
@@ -20,6 +20,7 @@ def start_core_services():
 
     rich.print("[green]Starting the core services...[/]")
 
+    start_rs_cs()
     start_log_cs()
     start_sm_cs()
     start_cm_cs()
@@ -34,6 +35,7 @@ def stop_core_services():
     stop_cm_cs()
     stop_sm_cs()
     stop_log_cs()
+    stop_rs_cs()
 
 
 @app.command(name="status")
@@ -44,7 +46,3 @@ def status_core_services(full: bool = False):
     rich.print("[green]Status of the core services...[/]")
 
     asyncio.run(run_all_status(full))
-
-    # status_log_cs()
-    # status_sm_cs()
-    # status_cm_cs()

--- a/libs/cgse-core/src/egse/logger/log_cs.py
+++ b/libs/cgse-core/src/egse/logger/log_cs.py
@@ -232,6 +232,8 @@ def handle_command(command) -> dict:
     elif command.lower() == 'status':
         response.update(dict(
             status="ACK",
+            logging_port=CTRL_SETTINGS.LOGGING_PORT,
+            commanding_port=CTRL_SETTINGS.COMMANDING_PORT,
             file_logger_level=logging.getLevelName(LOG_LEVEL_FILE),
             stream_logger_level=logging.getLevelName(LOG_LEVEL_STREAM),
             file_logger_location=file_handler.baseFilename,
@@ -277,6 +279,8 @@ def status():
     if response.get("status") == "ACK":
         rich.print("Log Manager:")
         rich.print("    Status: [green]active")
+        rich.print(f"    Logging port: {response.get('logging_port')}")
+        rich.print(f"    Commanding port: {response.get('commanding_port')}")
         rich.print(f"    Level [grey50](file)[black]: {response.get('file_logger_level')}")
         rich.print(f"    Level [grey50](stdout)[black]: {response.get('stream_logger_level')}")
         rich.print(f"    Log file location: {response.get('file_logger_location')}")

--- a/libs/cgse-core/src/egse/registry/__init__.py
+++ b/libs/cgse-core/src/egse/registry/__init__.py
@@ -1,0 +1,4 @@
+
+# Default ports that are assigned to REQ-REP and PUB-SUB protocols of the registry services
+DEFAULT_RS_REQ_PORT = 4242
+DEFAULT_RS_PUB_PORT = 4243

--- a/libs/cgse-core/src/egse/registry/backend.py
+++ b/libs/cgse-core/src/egse/registry/backend.py
@@ -1,0 +1,620 @@
+"""
+Asynchronous Registry Backend Protocol and Implementations.
+
+This file defines:
+1. A Protocol for async registry backends
+2. The AsyncSQLiteBackend implementation
+3. The AsyncInMemoryBackend for testing
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
+
+import aiosqlite
+
+from egse.decorators import implements_protocol
+
+module_logger_name = "async_registry_backend"
+module_logger = logging.getLogger(module_logger_name)
+
+
+@runtime_checkable
+class AsyncRegistryBackend(Protocol):
+    """Protocol defining the interface for asynchronous registry backends."""
+
+    async def initialize(self) -> None:
+        """Initialize the backend."""
+        ...
+
+    async def close(self) -> None:
+        """Close the backend and release resources."""
+        ...
+
+    async def clean_expired_services(self) -> list[str]:
+        """
+        Remove services that haven't sent a heartbeat within their TTL.
+
+        Returns:
+            List of service IDs that were removed.
+        """
+        ...
+
+    async def register(self, service_id: str, service_info: dict[str, Any], ttl: int = 30) -> bool:
+        """
+        Register a service with the registry.
+
+        FIXME: describe what is mandatory in the service_info dictionary.
+
+        Args:
+            service_id: Unique identifier for the service
+            service_info: Service information (host, port, metadata, etc.)
+            ttl: Time to live in seconds
+
+        Returns:
+            True if registration was successful, False otherwise
+        """
+        ...
+
+    async def deregister(self, service_id: str) -> bool:
+        """
+        Remove a service from the registry.
+
+        Args:
+            service_id: Unique identifier for the service
+
+        Returns:
+            True if de-registration was successful, False otherwise
+        """
+        ...
+
+    async def renew(self, service_id: str) -> bool:
+        """
+        Renew a service's TTL in the registry.
+
+        Args:
+            service_id: Unique identifier for the service
+
+        Returns:
+            True if renewal was successful, False otherwise
+        """
+        ...
+
+    async def get_service(self, service_id: str) -> dict[str, Any] | None:
+        """
+        Get information about a specific service.
+
+        Args:
+            service_id: Unique identifier for the service
+
+        Returns:
+            Service information or None if not found
+        """
+        ...
+
+    async def list_services(self, service_type: str | None = None) -> list[dict[str, Any]]:
+        """
+        List all registered services, optionally filtered by type.
+
+        Args:
+            service_type: Optional service type to filter by
+
+        Returns:
+            List of service information dictionaries
+        """
+        ...
+
+    async def discover_service(self, service_type: str) -> dict[str, Any] | None:
+        """
+        Find a healthy service of the specified type using load balancing.
+
+        Args:
+            service_type: Type of service to discover
+
+        Returns:
+            Service information or None if no healthy service is found
+        """
+        ...
+
+
+@implements_protocol(AsyncRegistryBackend)
+class AsyncSQLiteBackend:
+    """Asynchronous persistent storage backend using SQLite."""
+
+    def __init__(self, db_path: str = "service_registry.db", logger: logging.Logger = None):
+        """
+        Initialize the SQLite backend.
+
+        Args:
+            db_path: Path to the SQLite database file
+            logger: Optional logger to use (defaults to component logger)
+        """
+        self.db_path = db_path
+        self.logger = logger or logging.getLogger(f"{module_logger_name}.sqlite")
+        self._lock = asyncio.Lock()
+        self._db = None
+
+    async def initialize(self) -> None:
+        """Initialize the database connection and schema."""
+        self._db = await aiosqlite.connect(self.db_path)
+
+        # Enable WAL mode for better concurrency
+        await self._db.execute("PRAGMA journal_mode=WAL")
+
+        # Initialize schema
+        await self._init_db()
+
+        self.logger.info(f"SQLite backend initialized with database: {self.db_path}")
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._db:
+            await self._db.close()
+            self._db = None
+            self.logger.info("SQLite backend closed")
+
+    @asynccontextmanager
+    async def _db_cursor(self):
+        """Async context manager for database operations with automatic commit/rollback."""
+        async with self._lock:  # Ensure thread safety
+            try:
+                cursor = await self._db.cursor()
+                yield cursor
+                await self._db.commit()
+            except Exception as exc:
+                await self._db.rollback()
+                self.logger.error(f"Database error: {exc}")
+                raise
+
+    async def _init_db(self) -> None:
+        """Initialize the database schema if it doesn't exist."""
+        async with self._db_cursor() as cursor:
+            # Create services table
+            await cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS services (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    host TEXT NOT NULL,
+                    port INTEGER NOT NULL,
+                    metadata TEXT,
+                    ttl INTEGER NOT NULL,
+                    last_heartbeat INTEGER NOT NULL,
+                    tags TEXT
+                )
+                """
+            )
+
+    async def clean_expired_services(self) -> list[str]:
+        """Remove services that haven't sent a heartbeat within their TTL."""
+        current_time = int(time.time())
+
+        async with self._db_cursor() as cursor:
+            # Find expired services first (for return value)
+            await cursor.execute(
+                """
+                SELECT id FROM services 
+                WHERE last_heartbeat + ttl < ?
+                """,
+                (current_time,),
+            )
+
+            expired_ids = [row[0] async for row in cursor]
+
+            # Then delete them
+            if expired_ids:
+                await cursor.execute(
+                    """
+                    DELETE FROM services 
+                    WHERE last_heartbeat + ttl < ?
+                    """,
+                    (current_time,),
+                )
+
+                self.logger.info(f"Cleaned up {len(expired_ids)} expired services")
+
+            return expired_ids
+
+    async def register(self, service_id: str, service_info: dict[str, Any], ttl: int = 30) -> bool:
+        """Register a service with the registry."""
+        try:
+            current_time = int(time.time())
+
+            # Prepare data for insertion
+            name = service_info.get("name", service_id)
+            host = service_info.get("host", "127.0.0.1")
+            port = service_info.get("port", 8000)
+
+            metadata = service_info.get("metadata", {}).copy()
+            tags = service_info.get("tags", []).copy()
+            service_type = service_info.get("type")
+
+            if service_type:
+                if service_type not in tags:
+                    tags.append(service_type)
+                if "type" in metadata:
+                    self.logger.warning(
+                        f"The 'type' key is found in both 'service_info' ({service_type}) and 'metadata' "
+                        f"({metadata['type']}), overwriting in 'metadata."
+                    )
+                metadata["type"] = service_info["type"]
+
+            # Convert metadata and tags to JSON strings
+            metadata_json = json.dumps(metadata)
+            tags_json = json.dumps(tags)
+
+            async with self._db_cursor() as cursor:
+                # Check if service already exists
+                await cursor.execute("SELECT id FROM services WHERE id = ?", (service_id,))
+                exists = await cursor.fetchone() is not None
+
+                if exists:
+                    # Update existing service
+                    await cursor.execute(
+                        """
+                        UPDATE services
+                        SET name = ?, host = ?, port = ?, metadata = ?, 
+                            ttl = ?, last_heartbeat = ?, tags = ?
+                        WHERE id = ?
+                        """,
+                        (name, host, port, metadata_json, ttl, current_time, tags_json, service_id),
+                    )
+                else:
+                    # Insert new service
+                    await cursor.execute(
+                        """
+                        INSERT INTO services 
+                        (id, name, host, port, metadata, ttl, last_heartbeat, tags)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (service_id, name, host, port, metadata_json, ttl, current_time, tags_json),
+                    )
+
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to register service {service_id}: {exc}")
+            return False
+
+    async def deregister(self, service_id: str) -> bool:
+        """Remove a service from the registry."""
+        try:
+            async with self._db_cursor() as cursor:
+                await cursor.execute("DELETE FROM services WHERE id = ?", (service_id,))
+                return cursor.rowcount > 0
+        except Exception as exc:
+            self.logger.error(f"Failed to deregister service {service_id}: {exc}")
+            return False
+
+    async def renew(self, service_id: str) -> bool:
+        """Renew a service's TTL in the registry."""
+        try:
+            current_time = int(time.time())
+
+            async with self._db_cursor() as cursor:
+                await cursor.execute(
+                    """
+                    UPDATE services
+                    SET last_heartbeat = ?
+                    WHERE id = ?
+                    """,
+                    (current_time, service_id),
+                )
+
+                return cursor.rowcount > 0
+        except Exception as exc:
+            self.logger.error(f"Failed to renew service {service_id}: {exc}")
+            return False
+
+    async def get_service(self, service_id: str) -> dict[str, Any] | None:
+        """Get information about a specific service."""
+        try:
+            async with self._db_cursor() as cursor:
+                await cursor.execute(
+                    """
+                    SELECT id, name, host, port, metadata, ttl, last_heartbeat, tags
+                    FROM services
+                    WHERE id = ?
+                    """,
+                    (service_id,),
+                )
+
+                row = await cursor.fetchone()
+
+                if row:
+                    current_time = int(time.time())
+                    return {
+                        "id": row[0],
+                        "name": row[1],
+                        "host": row[2],
+                        "port": row[3],
+                        "metadata": json.loads(row[4]) if row[4] else {},
+                        "ttl": row[5],
+                        "last_heartbeat": row[6],
+                        "tags": json.loads(row[7]) if row[7] else [],
+                        "health": "passing" if current_time - row[6] <= row[5] else "critical",
+                    }
+
+                return None
+        except Exception as exc:
+            self.logger.error(f"Failed to get service {service_id}: {exc}")
+            return None
+
+    async def list_services(self, service_type: str | None = None) -> list[dict[str, Any]]:
+        """List all registered services, optionally filtered by type."""
+        try:
+            async with self._db_cursor() as cursor:
+                await cursor.execute(
+                    """
+                    SELECT id, name, host, port, metadata, ttl, last_heartbeat, tags
+                    FROM services
+                    """
+                )
+
+                services = []
+                current_time = int(time.time())
+
+                async for row in cursor:
+                    tags = json.loads(row[7]) if row[7] else []
+                    metadata = json.loads(row[4]) if row[4] else {}
+
+                    # Check if we need to filter by service type
+                    if service_type and service_type not in tags and metadata.get("type") != service_type:
+                        continue
+
+                    services.append(
+                        {
+                            "id": row[0],
+                            "name": row[1],
+                            "host": row[2],
+                            "port": row[3],
+                            "metadata": metadata,
+                            "ttl": row[5],
+                            "last_heartbeat": row[6],
+                            "tags": tags,
+                            "health": "passing" if current_time - row[6] <= row[5] else "critical",
+                        }
+                    )
+
+                return services
+        except Exception as exc:
+            self.logger.error(f"Failed to list services: {exc}")
+            return []
+
+    async def discover_service(self, service_type: str) -> dict[str, Any] | None:
+        """Find a healthy service of the specified type using load balancing."""
+        services = await self.list_services(service_type)
+
+        # Filter only healthy services
+        healthy_services = [s for s in services if s.get("health") == "passing"]
+
+        if healthy_services:
+            # Simple load balancing - random selection
+            import random
+
+            return random.choice(healthy_services)
+
+        return None
+
+
+@implements_protocol(AsyncRegistryBackend)
+class AsyncInMemoryBackend:
+    """
+    In-memory backend implementation for testing or simple deployments.
+
+    This backend keeps all service information in memory and is not persistent
+    between restarts.
+    """
+
+    def __init__(self, logger: logging.Logger = None):
+        """Initialize the in-memory backend."""
+        self.logger = logger or logging.getLogger(f"{module_logger_name}.memory")
+        self._services = {}  # Dictionary to store services
+        self._lock = asyncio.Lock()  # Async lock for thread safety
+
+    async def initialize(self) -> None:
+        """Initialize the backend (no-op for in-memory)."""
+        self.logger.info("In-memory backend initialized")
+
+    async def close(self) -> None:
+        """Close the backend (no-op for in-memory)."""
+        self.logger.info("In-memory backend closed")
+
+    async def clean_expired_services(self) -> list[str]:
+        """Remove services that haven't sent a heartbeat within their TTL.
+
+        Returns:
+            A list of the expired and removed id's.
+        """
+        current_time = int(time.time())
+        expired_ids = []
+
+        async with self._lock:
+            for service_id, service_data in list(self._services.items()):
+                last_heartbeat = service_data.get("last_heartbeat", 0)
+                ttl = service_data.get("ttl", 30)
+
+                if current_time - last_heartbeat > ttl:
+                    expired_ids.append(service_id)
+                    del self._services[service_id]
+
+        if expired_ids:
+            self.logger.info(f"Cleaned up {len(expired_ids)} expired services")
+
+        return expired_ids
+
+    async def register(self, service_id: str, service_info: dict[str, Any], ttl: int = 30) -> bool:
+        """Register a service with the registry.
+
+        Returns:
+            True when the service was properly registered, False is an error occurred.
+        """
+        try:
+            current_time = int(time.time())
+
+            self.logger.info(f"{service_id}: {service_info = }")
+
+            # Make a deepcopy of the service_info
+            service_data = json.loads(json.dumps(service_info.copy()))
+
+            # Add TTL and heartbeat information
+            service_data["ttl"] = ttl
+            service_data["last_heartbeat"] = current_time
+
+            if "metadata" not in service_data:
+                service_data["metadata"] = {}
+            if "tags" not in service_data:
+                service_data["tags"] = []
+
+            # Always add service_type to tags (used for discovery) and to metadata
+            service_type = service_data.get('type')
+            if service_type:
+                if service_type not in service_data["tags"]:
+                    service_data["tags"].append(service_type)
+                if "type" in service_data["metadata"]:
+                    self.logger.warning(
+                        f"The 'type' key is found in both 'service_info' ({service_type}) and 'metadata' "
+                        f"({service_data['metadata']['type']}), overwriting in 'metadata."
+                    )
+
+                service_data["metadata"]["type"] = service_type
+
+            async with self._lock:
+                self._services[service_id] = service_data
+                self.logger.info(f"{service_id}: {service_data = }")
+
+            return True
+        except Exception as exc:
+            self.logger.error(f"Failed to register service {service_id}: {exc}")
+            return False
+
+    async def deregister(self, service_id: str) -> bool:
+        """Remove a service from the registry.
+
+        Returns:
+            True when the service was properly de-registered, False when an error
+                occurred or when the `service_id` was not found.
+        """
+        try:
+            async with self._lock:
+                if service_id in self._services:
+                    del self._services[service_id]
+                    return True
+                return False
+        except Exception as exc:
+            self.logger.error(f"Failed to deregister service {service_id}: {exc}")
+            return False
+
+    async def renew(self, service_id: str) -> bool:
+        """Renew a service's TTL in the registry.
+
+        Returns:
+            True when the new TTL could be set, False if an error occurred or when
+                the `service_id` was not found.
+        """
+        try:
+            current_time = int(time.time())
+
+            async with self._lock:
+                if service_id in self._services:
+                    self._services[service_id]["last_heartbeat"] = current_time
+                    return True
+                return False
+        except Exception as exc:
+            self.logger.error(f"Failed to renew service {service_id}: {exc}")
+            return False
+
+    async def get_service(self, service_id: str) -> dict[str, Any] | None:
+        """Get information about a specific service.
+
+        Returns:
+            A dictionary with information about the service, or None when an
+                error occurred or the `service_id` could not be found.
+        """
+        try:
+            async with self._lock:
+                if service_id in self._services:
+                    service_data = self._services[service_id].copy()
+
+                    # Add the ID to the service data (this was missing!)
+                    service_data["id"] = service_id
+
+                    # Add health status
+                    current_time = int(time.time())
+                    last_heartbeat = service_data.get("last_heartbeat", 0)
+                    ttl = service_data.get("ttl", 30)
+                    service_data["health"] = "passing" if current_time - last_heartbeat <= ttl else "critical"
+
+                    return service_data
+                return None
+        except Exception as exc:
+            self.logger.error(f"Failed to get service {service_id}: {exc}")
+            return None
+
+    async def list_services(self, service_type: str | None = None) -> list[dict[str, Any]]:
+        """List all registered services, optionally filtered by type.
+
+        Returns:
+            A list of dictionaries containing information about the services that
+                are registered. An empty list is returned whn no services are registered
+                or when an error occurred.
+        """
+        try:
+            services = []
+            current_time = int(time.time())
+
+            async with self._lock:
+                for service_id, service_data in self._services.items():
+                    # Make a copy to avoid modifying the original
+                    service = service_data.copy()
+
+                    # Add health status
+                    last_heartbeat = service.get("last_heartbeat", 0)
+                    ttl = service.get("ttl", 30)
+                    service["health"] = "passing" if current_time - last_heartbeat <= ttl else "critical"
+
+                    # Check if we need to filter by service type
+                    if service_type:
+                        tags = service.get("tags", [])
+                        metadata = service.get("metadata", {})
+
+                        if service_type not in tags and metadata.get("type") != service_type:
+                            continue
+
+                    services.append(service)
+
+            return services
+        except Exception as exc:
+            self.logger.error(f"Failed to list services: {exc}")
+            return []
+
+    async def discover_service(self, service_type: str) -> dict[str, Any] | None:
+        """
+        Find a healthy service of the specified type using load balancing.
+
+        Only healthy services will be returned, and if more than one healthy service exists
+        for the given service_type, ony of them will be returned by random choice.
+
+        Returns:
+            A dictionary with the information for the service. If no healthy service is
+                available for the given service type, None will be returned.
+        """
+        services = await self.list_services(service_type)
+
+        # Filter only healthy services
+        healthy_services = [s for s in services if s.get("health") == "passing"]
+
+        if healthy_services:
+            # Simple load balancing - pick one of the services by random selection
+            # In practice, there will be only one service of a given type, but if you
+            # need to get your hands on all services of that type, use `list_services()`.
+            import random
+            return random.choice(healthy_services)
+
+        return None

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -1,0 +1,897 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from typing import Callable
+from typing import Union
+
+import zmq
+import zmq.asyncio
+
+from egse.registry import DEFAULT_RS_PUB_PORT
+from egse.registry import DEFAULT_RS_REQ_PORT
+
+
+class RegistryClient:
+    """
+    Synchronous client for the service registry.
+    """
+    def __init__(
+        self,
+        registry_req_endpoint: str = None,
+        registry_sub_endpoint: str = None,
+        request_timeout: int = 5000
+    ):
+        """
+        Initialize the async registry client.
+
+        Args:
+            registry_req_endpoint: ZeroMQ endpoint for REQ-REP socket, defaults to DEFAULT_RS_REQ_PORT on localhost.
+            registry_sub_endpoint: ZeroMQ endpoint for SUB socket, defaults to DEFAULT_RS_PUB_PORT on localhost.
+            request_timeout: Timeout for requests in milliseconds, defaults to 5000.
+        """
+        self.registry_req_endpoint = registry_req_endpoint or f"tcp://localhost:{DEFAULT_RS_REQ_PORT}"
+        self.registry_sub_endpoint = registry_sub_endpoint or f"tcp://localhost:{DEFAULT_RS_PUB_PORT}"
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("registry_client")
+
+        # Service state
+        self._service_id = None
+        self._service_info = None
+        self._ttl = None
+
+        self.context = zmq.Context()
+
+        # REQ socket for request-reply pattern
+        self.req_socket = self.context.socket(zmq.REQ)
+        self.req_socket.connect(self.registry_req_endpoint)
+
+        # SUB socket for receiving events
+        self.sub_socket = self.context.socket(zmq.SUB)
+        self.sub_socket.connect(self.registry_sub_endpoint)
+        # Default to receiving all events
+        self.sub_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        # Create a poller
+        self.poller = zmq.Poller()
+        self.poller.register(self.req_socket, zmq.POLLIN)
+
+    def _send_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Send a request to the registry and get the response.
+
+        Args:
+            request: The request to send
+
+        Returns:
+            The response from the registry.
+        """
+        try:
+            self.req_socket.send_string(json.dumps(request))
+
+            # Wait for the response with timeout
+            if self.poller.poll(timeout=self.request_timeout):
+                response_json = self.req_socket.recv_string()
+                return json.loads(response_json)
+            else:
+                self.logger.error(f"Request timed out after {self.request_timeout}ms")
+                # Reset the socket to avoid invalid state
+                self.req_socket.close()
+                self.req_socket = self.context.socket(zmq.REQ)
+                self.req_socket.connect(self.registry_req_endpoint)
+                return {'success': False, 'error': 'Request timed out'}
+        except zmq.ZMQError as e:
+            self.logger.error(f"ZMQ error: {e}")
+            return {'success': False, 'error': str(e)}
+        except Exception as e:
+            self.logger.error(f"Error sending request: {e}")
+            return {'success': False, 'error': str(e)}
+
+    def register(
+            self,
+            name: str,
+            host: str,
+            port: int,
+            service_type: str | None = None,
+            metadata: dict[str, Any] | None
+            = None,
+            ttl: int = 30
+            ) -> str | None:
+        """
+        Register this service with the registry.
+
+        Args:
+            name: Service name
+            host: Service host/IP
+            port: Service port
+            service_type: Service type (for discovery)
+            metadata: Additional service metadata
+            ttl: Time-to-live in seconds
+
+        Returns:
+            The service ID if successful, None otherwise
+        """
+        # Prepare service info
+        service_info = {
+            'name': name,
+            'host': host,
+            'port': port
+        }
+
+        # Add optional fields
+        if service_type:
+            service_info['type'] = service_type
+
+        if metadata:
+            service_info['metadata'] = metadata
+
+        # Prepare tags for easier discovery
+        tags = []
+        if service_type:
+            tags.append(service_type)
+        service_info['tags'] = tags
+
+        # Send registration request
+        request = {
+            'action': 'register',
+            'service_info': service_info,
+            'ttl': ttl
+        }
+
+        response = self._send_request(request)
+
+        if response.get('success'):
+            # Store service information for later use
+            self._service_id = response.get('service_id')
+            self._service_info = service_info
+            self._ttl = ttl
+
+            self.logger.info(f"Service registered with ID: {self._service_id}")
+            return self._service_id
+        else:
+            self.logger.error(f"Failed to register service: {response.get('error')}")
+            return None
+
+    def deregister(self) -> bool:
+        """
+        Deregister this service from the registry.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        if not self._service_id:
+            self.logger.warning("Cannot deregister: no service is registered")
+            return False
+
+        request = {
+            'action': 'deregister',
+            'service_id': self._service_id
+        }
+
+        response = self._send_request(request)
+
+        if response.get('success'):
+            self.logger.info(f"Service deregistered: {self._service_id}")
+            self._service_id = None
+            self._service_info = None
+            self._ttl = None
+            return True
+        else:
+            self.logger.error(f"Failed to deregister service: {response.get('error')}")
+            return False
+
+    def discover_service(self, service_type: str, use_cache: bool = False) -> dict[str, Any] | None:
+        """
+        Discover a service of the specified type. The service is guaranteed to be healthy at the time of discovery.
+
+        The returned information contains:
+
+        - name: the name of the service
+        - host: the ip address or hostname of the service
+        - port: the port number for requests to the microservice
+
+        Args:
+            service_type: Type of service to discover
+            use_cache: Whether to use cached service information
+
+        Returns:
+            Service information if found, None otherwise
+        """
+        # Try to use cache first if enabled
+        if use_cache:
+            self.logger.info("Cache not yet implemented.")
+
+        request = {
+            'action': 'discover',
+            'service_type': service_type
+        }
+
+        response = self._send_request(request)
+
+        self.logger.debug(f"{response = }")
+
+        if response.get('success'):
+            service = response.get('service')
+            return service
+        else:
+            self.logger.warning(f"Service discovery failed: {response.get('error')}")
+            return None
+
+    def get_service(self, service_id: str, use_cache: bool = True) -> dict[str, Any] | None:
+        """
+        Get information about a specific service.
+
+        Args:
+            service_id: ID of the service to get
+            use_cache: Whether to use cached service information
+
+        Returns:
+            Service information if found, None otherwise.
+        """
+
+        request = {
+            'action': 'get',
+            'service_id': service_id
+        }
+
+        response = self._send_request(request)
+
+        if response.get('success'):
+            service = response.get('service')
+            return service
+        else:
+            self.logger.warning(f"Get service failed: {response.get('error')}")
+            return None
+
+    def list_services(self, service_type: str | None = None) -> list[dict[str, Any]]:
+        """
+        List all registered services, optionally filtered by type.
+
+        Args:
+            service_type: Type of services to list
+
+        Returns:
+            List of service information.
+        """
+        request = {
+            'action': 'list',
+            'service_type': service_type
+        }
+
+        response = self._send_request(request)
+
+        if response.get('success'):
+            services = response.get('services', [])
+            return services
+        else:
+            self.logger.warning(f"List services failed: {response.get('error')}")
+            return []
+
+    def health_check(self) -> bool:
+        """
+        Check if the registry server is healthy.
+
+        Returns:
+            True if healthy, False otherwise
+        """
+        request = {
+            'action': 'health'
+        }
+
+        response = self._send_request(request)
+        return response.get('success', False)
+
+    def close(self) -> None:
+        """Clean up resources."""
+        try:
+            if hasattr(self, 'req_socket') and self.req_socket:
+                self.req_socket.close()
+
+            if hasattr(self, 'sub_socket') and self.sub_socket:
+                self.sub_socket.close()
+
+            if hasattr(self, 'context') and self.context:
+                self.context.term()
+        except Exception as exc:
+            self.logger.error(f"Error during cleanup: {exc}")
+
+
+class AsyncRegistryClient:
+    """
+    Asynchronous client for interacting with the ZeroMQ-based service registry.
+
+    This class uses asyncio and ZeroMQ's async API for non-blocking operations.
+    """
+
+    def __init__(
+            self,
+            registry_req_endpoint: str = None,
+            registry_sub_endpoint: str = None,
+            request_timeout: int = 5000
+            ):
+        """
+        Initialize the async registry client.
+
+        Args:
+            registry_req_endpoint: ZeroMQ endpoint for REQ-REP socket, defaults to DEFAULT_RS_REQ_PORT on localhost.
+            registry_sub_endpoint: ZeroMQ endpoint for SUB socket, defaults to DEFAULT_RS_PUB_PORT on localhost.
+            request_timeout: Timeout for requests in milliseconds, defaults to 5000.
+        """
+        self.registry_req_endpoint = registry_req_endpoint or f"tcp://localhost:{DEFAULT_RS_REQ_PORT}"
+        self.registry_sub_endpoint = registry_sub_endpoint or f"tcp://localhost:{DEFAULT_RS_PUB_PORT}"
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("async_registry_client")
+
+        # Service state
+        self._service_id = None
+        self._service_info = None
+        self._ttl = None
+
+        # ZeroMQ setup
+        self.context = zmq.asyncio.Context()
+
+        # REQ socket for request-reply pattern
+        self.req_socket = self.context.socket(zmq.REQ)
+        self.req_socket.connect(self.registry_req_endpoint)
+
+        # SUB socket for receiving events
+        self.sub_socket = self.context.socket(zmq.SUB)
+        self.sub_socket.connect(self.registry_sub_endpoint)
+        # Default to receiving all events
+        self.sub_socket.setsockopt_string(zmq.SUBSCRIBE, "")
+
+        # Thread control
+        self._running = False
+        self._tasks = set()
+        self._heartbeat_task = None
+        self._event_listener_task = None
+
+        # Event handlers
+        self._event_handlers = {}
+
+        # Service cache (for discovery)
+        self._service_cache = {}
+        self._service_cache_lock = None
+
+    def _get_service_cache_lock(self):
+        if self._service_cache_lock is None:
+            self._service_cache_lock = asyncio.Lock()
+        return self._service_cache_lock
+
+    async def _send_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Send a request to the registry and get the response.
+
+        Args:
+            request: The request to send to the service registry server.
+
+        Returns:
+            The response from the registry as a dictionary.
+        """
+        try:
+            # Send the request
+            await self.req_socket.send_string(json.dumps(request))
+
+            # Wait for the response with timeout
+            try:
+                response_json = await asyncio.wait_for(
+                    self.req_socket.recv_string(),
+                    timeout=self.request_timeout / 1000  # Convert ms to seconds
+                )
+                return json.loads(response_json)
+            except asyncio.TimeoutError:
+                self.logger.error(f"Request timed out after {self.request_timeout}ms")
+                # Reset the socket to avoid invalid state
+                self.req_socket.close()
+                self.req_socket = self.context.socket(zmq.REQ)
+                self.req_socket.connect(self.registry_req_endpoint)
+                return {'success': False, 'error': 'Request timed out'}
+        except zmq.ZMQError as e:
+            self.logger.error(f"ZMQ error: {e}")
+            return {'success': False, 'error': str(e)}
+        except Exception as e:
+            self.logger.error(f"Error sending request: {e}")
+            return {'success': False, 'error': str(e)}
+
+    async def register(
+            self,
+            name: str,
+            host: str,
+            port: int,
+            service_type: str | None = None,
+            metadata: dict[str, Any] | None
+            = None,
+            ttl: int = 30
+            ) -> str | None:
+        """
+        Register this service with the registry.
+
+        Args:
+            name: Service name
+            host: Service host/IP
+            port: Service port
+            service_type: Service type (for discovery)
+            metadata: Additional service metadata
+            ttl: Time-to-live in seconds
+
+        Returns:
+            The service ID if successful, None otherwise
+        """
+        # Prepare service info
+        service_info = {
+            'name': name,
+            'host': host,
+            'port': port
+        }
+
+        # Add optional fields
+        if service_type:
+            service_info['type'] = service_type
+
+        if metadata:
+            service_info['metadata'] = metadata
+
+        # Prepare tags for easier discovery
+        tags = []
+        if service_type:
+            tags.append(service_type)
+        service_info['tags'] = tags
+
+        # Send registration request
+        request = {
+            'action': 'register',
+            'service_info': service_info,
+            'ttl': ttl
+        }
+
+        response = await self._send_request(request)
+
+        if response.get('success'):
+            # Store service information for later use
+            self._service_id = response.get('service_id')
+            self._service_info = service_info
+            self._ttl = ttl
+
+            self.logger.info(f"Service registered with ID: {self._service_id}")
+            return self._service_id
+        else:
+            self.logger.error(f"Failed to register service: {response.get('error')}")
+            return None
+
+    async def deregister(self) -> bool:
+        """
+        Deregister this service from the registry.
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self._service_id:
+            self.logger.warning("Cannot deregister: no service is registered")
+            return False
+
+        request = {
+            'action': 'deregister',
+            'service_id': self._service_id
+        }
+
+        response = await self._send_request(request)
+
+        if response.get('success'):
+            self.logger.info(f"Service deregistered: {self._service_id}")
+            self._service_id = None
+            self._service_info = None
+            self._ttl = None
+            return True
+        else:
+            self.logger.error(f"Failed to deregister service: {response.get('error')}")
+            return False
+
+    async def start_heartbeat(self, interval: int | None = None) -> asyncio.Task | None:
+        """
+        Start sending heartbeats to the registry.
+
+        Args:
+            interval: Heartbeat interval in seconds (default: 1/3 of TTL)
+
+        Returns:
+            The heartbeat task
+        """
+        if not self._service_id:
+            self.logger.warning("Cannot start heartbeat: no service is registered")
+            return None
+
+        # Cancel existing heartbeat task if present
+        await self.stop_heartbeat()
+
+        # If interval not specified, use 1/3 of TTL
+        if interval is None:
+            interval = max(1, self._ttl // 3)
+
+        self._running = True
+
+        async def heartbeat_loop():
+            try:
+                while self._running and self._service_id:
+                    try:
+                        request = {
+                            'action': 'renew',
+                            'service_id': self._service_id
+                        }
+
+                        response = await self._send_request(request)
+
+                        if not response.get('success'):
+                            self.logger.warning(f"Heartbeat failed: {response.get('error')}")
+
+                            # Try to re-register if heartbeat fails
+                            if self._service_info:
+                                self.logger.info("Attempting to re-register service")
+                                new_request = {
+                                    'action': 'register',
+                                    'service_info': self._service_info,
+                                    'ttl': self._ttl
+                                }
+                                await self._send_request(new_request)
+                        else:
+                            self.logger.info(response.get("message"))
+                    except Exception as exc:
+                        self.logger.error(f"Error in heartbeat loop: {exc}")
+
+                    # Sleep until next heartbeat
+                    await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                self.logger.info("Heartbeat task cancelled")
+
+        # Start the heartbeat task
+        task = asyncio.create_task(heartbeat_loop())
+        self._tasks.add(task)
+        task.add_done_callback(lambda t: self._tasks.discard(t))
+
+        self.logger.info(f"Started heartbeat task with interval {interval}s")
+        return task
+
+    async def stop_heartbeat(self) -> None:
+        """Stop the running heartbeat task."""
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._tasks.discard(self._heartbeat_task)
+            self._heartbeat_task = None
+            self.logger.info("Stopped heartbeat task")
+
+    async def stop_event_listener(self) -> None:
+        """Stop the running event listener task."""
+        if self._event_listener_task is not None:
+            self._event_listener_task.cancel()
+            try:
+                await self._event_listener_task
+            except asyncio.CancelledError:
+                pass
+            self._tasks.discard(self._event_listener_task)
+            self._event_listener_task = None
+            self.logger.info("Stopped event listener task")
+
+    async def stop_all_tasks(self) -> None:
+        self._running = False
+
+        # Cancel all tasks
+        for task in self._tasks:
+            task.cancel()
+
+        # Wait for tasks to complete (with timeout)
+        if self._tasks:
+            try:
+                await asyncio.wait(self._tasks, timeout=2.0)
+            except asyncio.CancelledError:
+                pass
+
+        self._tasks.clear()
+        self.logger.info("Stopped all background tasks")
+
+    def on_event(self, event_type: str, handler: Callable[[dict[str, Any]], Union[None, asyncio.coroutine]]) -> None:
+        """
+        Register a handler for a specific event type.
+
+        Args:
+            event_type: Type of event to handle (register, deregister, expire)
+            handler: Function or coroutine to call with event data
+        """
+        if event_type not in self._event_handlers:
+            self._event_handlers[event_type] = []
+
+            # Subscribe to this specific event type
+            self.sub_socket.setsockopt_string(zmq.SUBSCRIBE, event_type)
+
+        self._event_handlers[event_type].append(handler)
+        self.logger.debug(f"Registered handler for {event_type} events")
+
+    async def start_event_listener(self) -> asyncio.Task:
+        """
+        Start listening for registry events.
+
+        Returns:
+            The event listener task
+        """
+        # Cancel existing event listener task if present
+        await self.stop_event_listener()
+
+        self._running = True
+
+        async def subscription_loop():
+            try:
+                while self._running:
+                    try:
+                        # Use a timeout to allow for clean shutdown
+                        try:
+                            message = await asyncio.wait_for(
+                                self.sub_socket.recv_multipart(),
+                                timeout=1.0
+                            )
+                        except asyncio.TimeoutError:
+                            continue
+
+                        # Parse the message
+                        event_type_bytes, event_json_bytes = message
+                        event_type = event_type_bytes.decode('utf-8')
+                        event = json.loads(event_json_bytes.decode('utf-8'))
+
+                        self.logger.debug(f"Received event: {event_type}")
+
+                        # Update service cache based on events
+                        await self._update_cache_from_event(event_type, event)
+
+                        # Call registered handlers
+                        handlers = self._event_handlers.get(event_type, [])
+                        for handler in handlers:
+                            try:
+                                # Check if handler is a coroutine function
+                                if asyncio.iscoroutinefunction(handler):
+                                    await handler(event['data'])
+                                else:
+                                    handler(event['data'])
+                            except Exception as exc:
+                                self.logger.error(f"Error in event handler: {exc}")
+                    except zmq.ZMQError as exc:
+                        self.logger.error(f"ZMQ error in event listener: {exc}")
+                    except Exception as exc:
+                        self.logger.error(f"Error in event listener: {exc}")
+                        await asyncio.sleep(1)  # Prevent tight loop on error
+            except asyncio.CancelledError:
+                self.logger.info("Event listener task cancelled")
+
+        # Start the subscription task
+        task = asyncio.create_task(subscription_loop())
+        self._tasks.add(task)
+        task.add_done_callback(lambda t: self._tasks.discard(t))
+
+        self.logger.info("Started event listener task")
+        return task
+
+    async def _update_cache_from_event(self, event_type: str, event: dict[str, Any]) -> None:
+        """
+        Update the service cache based on registry events.
+
+        Args:
+            event_type: Type of event
+            event: Event data
+        """
+        async with self._get_service_cache_lock():
+            data = event.get('data', {})
+            service_id = data.get('service_id')
+
+            if not service_id:
+                return
+
+            if event_type == 'register':
+                service_info = data.get('service_info', {})
+                if service_info:
+                    self._service_cache[service_id] = service_info
+            elif event_type in ('deregister', 'expire'):
+                if service_id in self._service_cache:
+                    del self._service_cache[service_id]
+
+    async def discover_service(self, service_type: str, use_cache: bool = True) -> dict[str, Any] | None:
+        """
+        Discover a service of the specified type. The service is guaranteed to be healthy at the time of discovery.
+
+        The returned information contains:
+
+        - name: the name of the service
+        - host: the ip address or hostname of the service
+        - port: the port number for requests to the microservice
+
+        Args:
+            service_type: Type of service to discover
+            use_cache: Whether to use cached service information
+
+        Returns:
+            Service information if found, None otherwise
+        """
+        # Try to use cache first if enabled
+        if use_cache:
+            async with self._get_service_cache_lock():
+                # Find services of the specified type
+                matching_services = []
+                for service_id, service_info in self._service_cache.items():
+                    if (service_info.get('type') == service_type or
+                            service_type in service_info.get('tags', [])):
+                        matching_services.append(service_info)
+
+                if matching_services:
+                    # Simple load balancing - random selection
+                    import random
+                    return random.choice(matching_services)
+
+        # If not found in cache or cache disabled, ask the registry
+        request = {
+            'action': 'discover',
+            'service_type': service_type
+        }
+
+        response = await self._send_request(request)
+
+        self.logger.debug(f"{response = }")
+
+        if response.get('success'):
+            service = response.get('service')
+
+            # Update cache
+            if service and 'id' in service:
+                async with self._get_service_cache_lock():
+                    self._service_cache[service['id']] = service
+
+            return service
+        else:
+            self.logger.warning(f"Service discovery failed: {response.get('error')}")
+            return None
+
+    async def get_service(self, service_id: str, use_cache: bool = True) -> dict[str, Any] | None:
+        """
+        Get information about a specific service.
+
+        Args:
+            service_id: ID of the service to get
+            use_cache: Whether to use cached service information
+
+        Returns:
+            Service information if found, None otherwise
+        """
+        # Try to use cache first if enabled
+        if use_cache:
+            async with self._get_service_cache_lock():
+                if service_id in self._service_cache:
+                    return self._service_cache[service_id]
+
+        # If not found in cache or cache disabled, ask the registry
+        request = {
+            'action': 'get',
+            'service_id': service_id
+        }
+
+        response = await self._send_request(request)
+
+        if response.get('success'):
+            service = response.get('service')
+
+            # Update cache
+            if service:
+                async with self._get_service_cache_lock():
+                    self._service_cache[service_id] = service
+
+            return service
+        else:
+            self.logger.warning(f"Get service failed: {response.get('error')}")
+            return None
+
+    async def list_services(self, service_type: str | None = None) -> list[dict[str, Any]]:
+        """
+        List all registered services, optionally filtered by type.
+
+        Args:
+            service_type: Type of services to list
+
+        Returns:
+            List of service information
+        """
+        request = {
+            'action': 'list',
+            'service_type': service_type
+        }
+
+        response = await self._send_request(request)
+
+        if response.get('success'):
+            services = response.get('services', [])
+
+            # Update cache
+            async with self._get_service_cache_lock():
+                for service in services:
+                    if 'id' in service:
+                        self._service_cache[service['id']] = service
+
+            return services
+        else:
+            self.logger.warning(f"List services failed: {response.get('error')}")
+            return []
+
+    async def health_check(self) -> bool:
+        """
+        Check if the registry server is healthy.
+
+        Returns:
+            True if healthy, False otherwise
+        """
+        request = {
+            'action': 'health'
+        }
+
+        response = await self._send_request(request)
+        return response.get('success', False)
+
+    async def terminate_registry_server(self) -> bool:
+        """
+        Send a terminate request to the service registry server.
+        """
+        request = {
+            'action': 'terminate'
+        }
+        response = await self._send_request(request)
+        return response.get('success', False)
+
+    async def server_status(self) -> dict[str, Any]:
+        request = {
+            'action': 'info',
+        }
+        response = await self._send_request(request)
+        return response
+
+    async def close(self) -> None:
+        """Clean up resources."""
+        await self.stop_heartbeat()  # This stops all tasks
+
+        try:
+            if hasattr(self, 'req_socket') and self.req_socket:
+                self.req_socket.close()
+
+            if hasattr(self, 'sub_socket') and self.sub_socket:
+                self.sub_socket.close()
+
+            if hasattr(self, 'context') and self.context:
+                self.context.term()
+        except Exception as exc:
+            self.logger.error(f"Error during cleanup: {exc}")
+
+    @asynccontextmanager
+    async def register_context(self, *args, **kwargs):
+        """
+        Async context manager for service registration.
+
+        Example:
+            async with client.register_context("my-service", "localhost", 8080):
+                # Service is registered
+                await app.start()
+            # Service is automatically deregistered
+        """
+        service_id = await self.register(*args, **kwargs)
+
+        if not service_id:
+            raise RuntimeError("Failed to register service")
+
+        # Start heartbeat and event listener
+        await self.start_heartbeat()
+        await self.start_event_listener()
+
+        try:
+            yield service_id
+        finally:
+            # Clean up
+            await self.stop_event_listener()
+            await self.stop_heartbeat()
+            await self.deregister()
+            await self.close()

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -1,0 +1,527 @@
+"""
+Registry Service – core service
+
+
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import signal
+import sys
+import time
+import uuid
+from typing import Any
+from typing import Callable
+
+import typer
+import zmq
+import zmq.asyncio
+
+from egse.registry import DEFAULT_RS_REQ_PORT
+from egse.registry import DEFAULT_RS_PUB_PORT
+from egse.registry.backend import AsyncRegistryBackend
+from egse.registry.backend import AsyncSQLiteBackend
+from egse.registry.client import AsyncRegistryClient
+from egse.system import TyperAsyncCommand
+
+module_logger_name = "async_registry_server"
+module_logger = logging.getLogger(module_logger_name)
+
+
+app = typer.Typer(name="rs_cs", no_args_is_help=True)
+
+
+class AsyncRegistryServer:
+    """
+    Asynchronous ZeroMQ-based service registry server.
+
+    This server uses the ZeroMQ async API and asyncio for non-blocking operations.
+
+    Args:
+        req_port: Port for REQ-REP socket (service requests) [default=4242]
+        pub_port: Port for PUB socket (service notifications) [default=4243]
+        backend: a registry backend, [default=AsyncSQLiteBackend]
+        db_path: Path to the SQLite database file [default='service_registry.db']
+        cleanup_interval: How often to clean up expired services (seconds) [default=10]
+    """
+
+    def __init__(
+            self,
+            req_port: int = DEFAULT_RS_REQ_PORT,
+            pub_port: int = DEFAULT_RS_PUB_PORT,
+            backend: AsyncRegistryBackend | None = None,
+            db_path: str = 'service_registry.db',
+            cleanup_interval: int = 10
+    ):
+        self.req_port = req_port
+        self.pub_port = pub_port
+        self.db_path = db_path
+        self.cleanup_interval = cleanup_interval
+        self.logger = logging.getLogger("async_registry_server.zmq")
+
+        # Set ZeroMQ to use asyncio
+        self.context = zmq.asyncio.Context()
+
+        # Socket to handle REQ-REP pattern
+        self.req_rep_socket = self.context.socket(zmq.REP)
+        self.req_rep_socket.bind(f"tcp://*:{req_port}")
+
+        # Socket to publish service events
+        self.pub_socket = self.context.socket(zmq.PUB)
+        self.pub_socket.bind(f"tcp://*:{pub_port}")
+
+        # Initialize the storage backend
+        self.backend = backend or AsyncSQLiteBackend(db_path)
+
+        # Running flag and event for clean shutdown
+        self._running = False
+        self._shutdown_event = asyncio.Event()
+
+        # Tasks
+        self._tasks = set()
+
+    async def initialize(self):
+        """Initialize the server."""
+        await self.backend.initialize()
+
+    async def start(self):
+        """Start the registry server."""
+        if self._running:
+            return
+
+        # Initialize the backend
+        await self.initialize()
+
+        self._running = True
+        self.logger.info(
+            f"Async registry server started on ports {self.req_port} (REQ-REP) and {self.pub_port} (PUB)"
+            )
+
+        # Start the cleanup task
+        cleanup_task = asyncio.create_task(self._cleanup_loop())
+        self._tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._tasks.discard)
+
+        # Start the request handler task
+        request_task = asyncio.create_task(self._handle_requests())
+        self._tasks.add(request_task)
+        request_task.add_done_callback(self._tasks.discard)
+
+        # Wait for shutdown
+        await self._shutdown_event.wait()
+
+        # Clean shutdown
+        await self._shutdown()
+
+    async def _shutdown(self):
+        """Perform clean shutdown."""
+        self._running = False
+        self.logger.info("Shutting down async registry server...")
+
+        # Cancel all tasks
+        for task in self._tasks:
+            task.cancel()
+
+        # Wait for tasks to complete (with timeout)
+        if self._tasks:
+            try:
+                await asyncio.wait(self._tasks, timeout=2.0)
+            except asyncio.CancelledError:
+                pass
+
+        # Close database
+        await self.backend.close()
+
+        # Close ZeroMQ sockets
+        self.req_rep_socket.close()
+        self.pub_socket.close()
+
+        # Close context
+        self.context.term()
+
+        self.logger.info("Async registry server shutdown complete")
+
+    def stop(self):
+        """Signal the server to stop."""
+        self._shutdown_event.set()
+
+    async def _cleanup_loop(self):
+        """Background task that periodically cleans up expired services."""
+        self.logger.info(f"Started cleanup task with interval {self.cleanup_interval}s")
+
+        try:
+            while self._running:
+                try:
+                    # Clean up expired services
+                    expired_ids = await self.backend.clean_expired_services()
+
+                    # Publish de-registration events for expired services
+                    for service_id in expired_ids:
+                        await self._publish_event('expire', {'service_id': service_id})
+                except Exception as exc:
+                    self.logger.error(f"Error in cleanup task: {exc}")
+
+                # Sleep for the specified interval
+                await asyncio.sleep(self.cleanup_interval)
+        except asyncio.CancelledError:
+            self.logger.info("Cleanup task cancelled")
+
+    async def _handle_requests(self):
+        """Task that handles incoming requests."""
+        self.logger.info("Started request handler task")
+
+        try:
+            while self._running:
+                try:
+                    # Wait for a request with timeout to allow checking if still running
+                    try:
+                        # self.logger.info("Waiting for a request with 1s timeout...")
+                        message_json = await asyncio.wait_for(
+                            self.req_rep_socket.recv_string(),
+                            timeout=1.0
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+
+                    # Parse the request
+                    request = json.loads(message_json)
+                    self.logger.info(f"Received request: {request}")
+
+                    # Process the request
+                    response = await self._process_request(request)
+
+                    # Send the response
+                    await self.req_rep_socket.send_string(json.dumps(response))
+                except zmq.ZMQError as exc:
+                    self.logger.error(f"ZMQ error: {exc}")
+                except json.JSONDecodeError as exc:
+                    self.logger.error(f"Invalid JSON received: {exc}")
+                    await self.req_rep_socket.send_string(
+                        json.dumps(
+                            {
+                                'success': False,
+                                'error': 'Invalid JSON format'
+                            }
+                        )
+                    )
+                except Exception as exc:
+                    self.logger.error(f"Error handling request: {exc}")
+                    try:
+                        await self.req_rep_socket.send_string(
+                            json.dumps(
+                                {
+                                    'success': False,
+                                    'error': str(exc)
+                                }
+                            )
+                        )
+                    except Exception:
+                        pass
+        except asyncio.CancelledError:
+            self.logger.info("Request handler task cancelled")
+
+    async def _publish_event(self, event_type: str, data: dict[str, Any]):
+        """
+        Publish an event to subscribers.
+
+        Args:
+            event_type: Type of event (register, deregister, expire, etc.)
+            data: Event payload
+        """
+        event = {
+            'type': event_type,
+            'timestamp': int(time.time()),
+            'data': data
+        }
+
+        try:
+            # Prefix with event type for subscribers that filter by type
+            await self.pub_socket.send_multipart(
+                [
+                    event_type.encode('utf-8'),
+                    json.dumps(event).encode('utf-8')
+                ]
+            )
+            self.logger.debug(f"Published {event_type} event: {data}")
+        except Exception as exc:
+            self.logger.error(f"Failed to publish event: {exc}")
+
+    async def _process_request(self, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Process a client request and generate a response.
+
+        Args:
+            request: The request message
+
+        Returns:
+            The response message
+        """
+        action = request.get('action')
+        if not action:
+            return {'success': False, 'error': 'Missing required field: action'}
+
+        handlers: dict[str, Callable] = {
+            'register': self._handle_register,
+            'deregister': self._handle_deregister,
+            'renew': self._handle_renew,
+            'info': self._handle_info,
+            'get': self._handle_get,
+            'list': self._handle_list,
+            'discover': self._handle_discover,
+            'health': self._handle_health,
+            'terminate': self._handle_terminate,
+        }
+
+        handler = handlers.get(action)
+        if not handler:
+            return {'success': False, 'error': f'Unknown action: {action}'}
+
+        return await handler(request)
+
+    async def _handle_register(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a service registration request."""
+        if 'service_info' not in request:
+            return {'success': False, 'error': 'Missing required field: service_info'}
+
+        service_info = request['service_info']
+
+        # Validate required fields
+        required_fields = ['name', 'host', 'port']
+        for field in required_fields:
+            if field not in service_info:
+                return {'success': False, 'error': f'Missing required field in service_info: {field}'}
+
+        self.logger.info(f"Registration request for {service_info['name']}")
+
+        # Generate ID if not provided
+        service_id = service_info.get('id')
+        if not service_id:
+            service_id = f"{service_info['name']}-{uuid.uuid4()}"
+            service_info['id'] = service_id
+
+        # Get TTL
+        ttl = request.get('ttl', 30)
+
+        # Register the service
+        success = await self.backend.register(service_id, service_info, ttl)
+
+        if success:
+            # Publish registration event
+            await self._publish_event(
+                'register', {
+                    'service_id': service_id,
+                    'service_info': service_info
+                }
+            )
+
+            return {
+                'success': True,
+                'service_id': service_id,
+                'message': 'Service registered successfully'
+            }
+
+        return {'success': False, 'error': 'Failed to register service'}
+
+    async def _handle_deregister(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a service de-registration request."""
+        service_id = request.get('service_id')
+
+        self.logger.info(f"De-registration request for {service_id}")
+
+        if not service_id:
+            return {'success': False, 'error': 'Missing required field: service_id'}
+
+        # Get service details before de-registering (for event)
+        service_info = await self.backend.get_service(service_id)
+
+        # Deregister the service
+        success = await self.backend.deregister(service_id)
+
+        if success:
+            # Publish de-registration event
+            await self._publish_event(
+                'deregister', {
+                    'service_id': service_id,
+                    'service_info': service_info
+                }
+            )
+
+            return {
+                'success': True,
+                'message': 'Service deregistered successfully'
+            }
+
+        return {'success': False, 'error': 'Service not found or could not be deregistered'}
+
+    async def _handle_renew(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a service heartbeat request."""
+        service_id = request.get('service_id')
+
+        self.logger.info(f"Renew request for {service_id}")
+
+        if not service_id:
+            return {'success': False, 'error': 'Missing required field: service_id'}
+
+        # Renew the service
+        success = await self.backend.renew(service_id)
+
+        if success:
+            return {
+                'success': True,
+                'message': 'Service renewed successfully'
+            }
+
+        return {'success': False, 'error': 'Service not found or could not be renewed'}
+
+    async def _handle_get(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a request to get a specific service."""
+
+        service_id = request.get('service_id')
+
+        self.logger.info(f"Get request for {service_id}")
+
+        if not service_id:
+            return {'success': False, 'error': 'Missing required field: service_id'}
+
+        # Get the service
+        service = await self.backend.get_service(service_id)
+
+        if service:
+            return {
+                'success': True,
+                'service': service
+            }
+
+        return {'success': False, 'error': 'Service not found'}
+
+    async def _handle_list(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a request to list services."""
+        service_type = request.get('service_type')
+
+        self.logger.info(f"List request for {service_type}")
+
+        # List the services
+        services = await self.backend.list_services(service_type)
+
+        return {
+            'success': True,
+            'services': services,
+        }
+
+    async def _handle_discover(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a service discovery request."""
+        service_type = request.get('service_type')
+
+        self.logger.info(f"Discover request for service type: {service_type}")
+
+        if not service_type:
+            return {'success': False, 'error': 'Missing required field: service_type'}
+
+        # Discover a service
+        service = await self.backend.discover_service(service_type)
+
+        if service:
+            return {
+                'success': True,
+                'service': service
+            }
+
+        return {'success': False, 'error': f'No healthy service of type {service_type} found'}
+
+    async def _handle_info(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle the info request and send information about the registry server."""
+
+        self.logger.info(f"Health request for {request}")
+
+        # List the services
+        services = await self.backend.list_services()
+
+        return {
+            'success': True,
+            'status': 'ok',
+            'req_port': self.req_port,
+            'pub_port': self.pub_port,
+            'services': services,
+        }
+
+    async def _handle_health(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a health check request."""
+
+        self.logger.info(f"Health request for {request}")
+
+        return {
+            'success': True,
+            'status': 'ok',
+            'timestamp': int(time.time())
+        }
+
+    async def _handle_terminate(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a termination request."""
+
+        self.logger.info(f"Termination request for {request}")
+
+        self.stop()
+
+        return {
+            'success': True,
+            'status': 'terminating',
+            'timestamp': time.time(),
+        }
+
+
+@app.command(cls=TyperAsyncCommand)
+async def start(
+        req_port: int = 4242,
+        pub_port: int = 4243,
+        db_path: str = 'service_registry.db',
+        cleanup_interval: int = 10,
+):
+    """Run the registry server with signal handling."""
+
+    # Create server
+    server = AsyncRegistryServer(
+        req_port=req_port,
+        pub_port=pub_port,
+        db_path=db_path,
+        cleanup_interval=cleanup_interval
+    )
+
+    # Set up signal handlers
+    loop = asyncio.get_running_loop()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(
+            sig,
+            lambda: asyncio.create_task(handle_signal(server))
+        )
+
+    # Start server
+    await server.start()
+
+
+async def handle_signal(server):
+    """Handle termination signals."""
+    module_logger.info("Received termination signal")
+    server.stop()
+
+
+@app.command(cls=TyperAsyncCommand)
+async def stop():
+
+    client = AsyncRegistryClient()
+    response = await client.terminate_registry_server()
+
+    if response:
+        module_logger.info("Service registry server terminated.")
+
+
+if __name__ == "__main__":
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="[%(asctime)s] %(threadName)-12s %(levelname)-8s %(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+    )
+
+    sys.exit(app())

--- a/libs/cgse-core/src/egse/registry/service.py
+++ b/libs/cgse-core/src/egse/registry/service.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+from typing import Callable
+
+import zmq
+import zmq.asyncio
+
+from egse.registry import DEFAULT_RS_PUB_PORT
+from egse.registry import DEFAULT_RS_REQ_PORT
+from egse.registry.client import AsyncRegistryClient
+from egse.system import get_host_ip
+from egse.zmq_ser import get_port_number
+
+module_module_logger_name = "async_microservice"
+module_logger = logging.getLogger(module_module_logger_name)
+
+
+class ZMQMicroservice:
+    """
+    A pure ZeroMQ-based microservice implementation.
+
+    This service:
+    1. Registers with the service registry.
+       Default endpoints are "tcp://localhost:4242" for the REQ-REP, and
+       "tcp://localhost:4243" for the PUB-SUB (events, notifications)
+    2. Exposes ZeroMQ sockets for its functionality
+    3. Can discover and call other services
+    """
+
+    def __init__(
+        self,
+        service_name: str,
+        service_type: str,
+        rep_port: int = 0,
+        pub_port: int | None = None,
+        registry_req_endpoint: str | None = None,
+        registry_sub_endpoint: str | None = None,
+        metadata: dict[str, Any] | None = None
+    ):
+        """
+        Initialize the microservice. When port numbers for rep_port and pub_port
+        are set to 0, the system will automatically assign a dynamic port number
+        that will be reported to the service registry.
+
+        Args:
+            service_name: Human-readable name for this service
+            service_type: Type of service (for discovery)
+            rep_port: Port for REP socket (service API) [default=0]
+            pub_port: Optional port for PUB socket (events/notifications)
+            registry_req_endpoint: ZeroMQ endpoint for registry REQ socket
+            registry_sub_endpoint: ZeroMQ endpoint for registry SUB socket
+            metadata: Additional service metadata
+        """
+        self.service_name = service_name
+        self.service_type = service_type
+        self.rep_port = rep_port
+        self.pub_port = pub_port
+        self.registry_req_endpoint = registry_req_endpoint or f"tcp://localhost:{DEFAULT_RS_REQ_PORT}"
+        self.registry_sub_endpoint = registry_sub_endpoint or f"tcp://localhost:{DEFAULT_RS_PUB_PORT}"
+        self.metadata = metadata or {}
+
+        self.host_ip = get_host_ip()
+
+        # Service ID will be set when registered
+        self.service_id = None
+
+        # ZeroMQ context
+        self.context = zmq.asyncio.Context()
+
+        # REP socket for service API
+        self.rep_socket = self.context.socket(zmq.REP)
+        self.rep_socket.bind(f"tcp://*:{rep_port}")
+
+        # Determine the dynamically assigned port number
+        if rep_port == 0:
+            self.rep_port = get_port_number(self.rep_socket)
+
+        # PUB socket for events/notifications (optional)
+        if pub_port is not None:
+            self.pub_socket = self.context.socket(zmq.PUB)
+            self.pub_socket.bind(f"tcp://*:{pub_port}")
+        else:
+            self.pub_socket = None
+
+        # Determine the dynamically assigned port number
+        if pub_port == 0:
+            self.pub_port = get_port_number(self.pub_socket)
+
+        self.registry_client = AsyncRegistryClient(
+            registry_req_endpoint=self.registry_req_endpoint,
+            registry_sub_endpoint=self.registry_sub_endpoint
+        )
+
+        self.command_handlers = {}
+
+        self._register_default_handlers()
+
+        # Shutdown will be 'set' to terminate the service.
+        self._shutdown = asyncio.Event()
+
+        self._tasks = set()
+
+    def _register_default_handlers(self):
+        """Register default command handlers."""
+        self.register_handler("ping", self._handle_ping)
+        self.register_handler("info", self._handle_info)
+        self.register_handler("health", self._handle_health)
+
+    def register_handler(self, command: str, handler: Callable):
+        """
+        Register a command handler.
+
+        Args:
+            command: Command name
+            handler: Async function that will handle the command
+        """
+        self.command_handlers[command] = handler
+        module_logger.info(f"Registered handler for command: {command}")
+
+    async def _handle_ping(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle ping command."""
+        return {
+            "status": "ok",
+            "message": "pong",
+            "timestamp": time.time()
+        }
+
+    async def _handle_info(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle info command."""
+        return {
+            "status": "ok",
+            "service_id": self.service_id,
+            "service_name": self.service_name,
+            "service_type": self.service_type,
+            "host": self.host_ip,
+            "rep_port": self.rep_port,
+            "pub_port": self.pub_port,
+            "metadata": self.metadata
+        }
+
+    async def _handle_health(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle health command."""
+        return {
+            "status": "ok",
+            "timestamp": time.time()
+        }
+
+    async def start(self):
+        """Start the microservice. This will:
+
+        - register the service to the service registry
+        - start the service heartbeat
+        - start the service event listener
+        - start the background task to handle requests
+        """
+        module_logger.info(f"Starting {self.service_name} ({self.service_type}) on {self.host_ip}:{self.rep_port}")
+
+        # Register with the registry
+        self.service_id = await self.registry_client.register(
+            self.service_name,
+            self.host_ip,
+            self.rep_port,
+            service_type=self.service_type,
+            metadata={
+                **self.metadata,
+                "pub_port": self.pub_port
+            }
+        )
+
+        if not self.service_id:
+            module_logger.error("Failed to register with the service registry")
+            return True
+
+        module_logger.info(f"Registered with service ID: {self.service_id}")
+
+        # Start heartbeat and event listener
+        await self.registry_client.start_heartbeat()
+        await self.registry_client.start_event_listener()
+
+        # Start request handler
+        request_task = asyncio.create_task(self._handle_requests())
+        self._tasks.add(request_task)
+        request_task.add_done_callback(self._tasks.discard)
+
+        # Wait for shutdown signal
+        await self._shutdown.wait()
+
+        # Clean shutdown
+        await self._cleanup()
+
+        return False
+
+    async def _handle_requests(self):
+        """Handle incoming requests."""
+        module_logger.info("Started request handler")
+
+        try:
+            while not self._shutdown.is_set():
+                try:
+                    # Wait for a request with timeout
+                    try:
+                        request_json = await asyncio.wait_for(
+                            self.rep_socket.recv_string(),
+                            timeout=1.0
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+
+                    # Parse the request
+                    request = json.loads(request_json)
+                    command = request.get("command")
+
+                    if not command:
+                        response = {
+                            "status": "error",
+                            "error": "Missing 'command' field"
+                        }
+                    elif command not in self.command_handlers:
+                        response = {
+                            "status": "error",
+                            "error": f"Unknown command: {command}"
+                        }
+                    else:
+                        # Call the handler
+                        try:
+                            handler = self.command_handlers[command]
+                            response = await handler(request)
+                        except Exception as exc:
+                            module_logger.error(f"Error handling command {command}: {exc}")
+                            response = {
+                                "status": "error",
+                                "error": f"Error handling command: {str(exc)}"
+                            }
+
+                    # Send the response
+                    await self.rep_socket.send_string(json.dumps(response))
+                except zmq.ZMQError as exc:
+                    module_logger.error(f"ZMQ error: {exc}")
+                except json.JSONDecodeError:
+                    module_logger.error("Invalid JSON received")
+                    try:
+                        await self.rep_socket.send_string(json.dumps(
+                            {
+                                "status": "error",
+                                "error": "Invalid JSON format"
+                            }
+                        ))
+                    except Exception as exc:
+                        module_logger.warning(f"Caught {type(exc).__name__}: {exc}")
+                except Exception as exc:
+                    module_logger.error(f"Error handling request: {exc}")
+                    try:
+                        await self.rep_socket.send_string(json.dumps(
+                            {
+                                "status": "error",
+                                "error": str(exc)
+                            }
+                        ))
+                    except Exception as exc:
+                        module_logger.warning(f"Caught {type(exc).__name__}: {exc}")
+        except asyncio.CancelledError:
+            module_logger.info("Request handler task cancelled")
+
+    async def stop(self):
+        """Signal the service to stop."""
+        self._shutdown.set()
+
+    async def _cleanup(self):
+        """Clean up resources."""
+        module_logger.info("Cleaning up resources...")
+
+        # Cancel all tasks
+        for task in self._tasks:
+            task.cancel()
+
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+
+        # Deregister from the registry
+        if self.service_id:
+            await self.registry_client.deregister()
+            module_logger.info(f"Deregistered service: {self.service_id}")
+
+        # Close registry client
+        await self.registry_client.close()
+
+        # Close ZeroMQ sockets
+        if hasattr(self, 'rep_socket') and self.rep_socket:
+            self.rep_socket.close()
+
+        if hasattr(self, 'pub_socket') and self.pub_socket:
+            self.pub_socket.close()
+
+        if hasattr(self, 'context') and self.context:
+            self.context.term()
+
+        module_logger.info("Cleanup complete")
+
+    async def publish_event(self, event_type: str, data: dict[str, Any]):
+        """
+        Publish an event to subscribers.
+
+        Args:
+            event_type: Type of event
+            data: Event data
+        """
+        if not self.pub_socket:
+            module_logger.warning("Cannot publish event: no PUB socket")
+            return
+
+        event = {
+            "type": event_type,
+            "service_id": self.service_id,
+            "timestamp": time.time(),
+            "data": data
+        }
+
+        try:
+            await self.pub_socket.send_multipart([
+                event_type.encode(
+                    'utf-8'),
+                    json.dumps(event).encode('utf-8')
+            ])
+            module_logger.debug(f"Published event: {event_type}")
+        except Exception as exc:
+            module_logger.error(f"Failed to publish event: {exc}")
+
+    async def call_service(self, service_type: str, command: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """
+        Call another service.
+
+        Args:
+            service_type: Type of service to call
+            command: Command to invoke
+            data: Command parameters
+
+        Returns:
+            Response from the service
+        """
+        # Discover the service
+        service = await self.registry_client.discover_service(service_type)
+
+        if not service:
+            raise ValueError(f"No service of type '{service_type}' found")
+
+        # Prepare the request
+        request = {
+            "command": command,
+            **(data or {})
+        }
+
+        # Create a REQ socket
+        socket = self.context.socket(zmq.REQ)
+        socket.setsockopt(zmq.RCVTIMEO, 5000)  # 5 second timeout
+
+        try:
+            # Connect to the service
+            socket.connect(f"tcp://{service['host']}:{service['port']}")
+
+            # Send the request
+            await socket.send_string(json.dumps(request))
+
+            # Wait for the response
+            response_json = await socket.recv_string()
+            return json.loads(response_json)
+        finally:
+            socket.close()
+
+    async def subscribe_to_service_events(
+            self, service_type: str, event_types: list[str], callback: Callable[[dict[str, Any]], None]):
+        """
+        Subscribe to events from another service.
+
+        Args:
+            service_type: Type of service to subscribe to
+            event_types: List of event types to subscribe to
+            callback: Function to call with events
+
+        Returns:
+            Subscription task
+        """
+        # Discover the service
+        service = await self.registry_client.discover_service(service_type)
+
+        if not service:
+            raise ValueError(f"No service of type '{service_type}' found")
+
+        # Get PUB port from metadata
+        pub_port = service.get('metadata', {}).get('pub_port')
+
+        if not pub_port:
+            raise ValueError("Service does not expose a PUB socket")
+
+        # Create a SUB socket
+        socket = self.context.socket(zmq.SUB)
+
+        # Subscribe to specified event types
+        for event_type in event_types:
+            socket.setsockopt_string(zmq.SUBSCRIBE, event_type)
+
+        # Connect to the service
+        socket.connect(f"tcp://{service['host']}:{pub_port}")
+
+        async def subscription_loop():
+            try:
+                module_logger.info(f"Subscribed to events from {service['name']} ({service_type})")
+
+                while not self._shutdown.is_set():
+                    try:
+                        # Wait for an event with timeout
+                        if socket.poll(timeout=1000) == 0:
+                            continue
+
+                        # Receive the event
+                        event_type_bytes, event_json_bytes = await socket.recv_multipart()
+                        event_type = event_type_bytes.decode('utf-8')
+                        event = json.loads(event_json_bytes.decode('utf-8'))
+
+                        # Call the callback
+                        try:
+                            if asyncio.iscoroutinefunction(callback):
+                                await callback(event)
+                            else:
+                                callback(event)
+                        except Exception as exc:
+                            module_logger.error(f"Error in event callback: {exc}")
+                    except zmq.ZMQError as exc:
+                        if exc.errno == zmq.EAGAIN:
+                            # Timeout, just continue
+                            continue
+                        module_logger.error(f"ZMQ error in subscription: {exc}")
+                    except Exception as exc:
+                        module_logger.error(f"Error in subscription loop: {exc}")
+                        await asyncio.sleep(1)  # Prevent tight loop on error
+            except asyncio.CancelledError:
+                module_logger.info(f"Subscription to {service_type} cancelled")
+            finally:
+                socket.close()
+
+        # Start the subscription task
+        task = asyncio.create_task(subscription_loop())
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+        return task

--- a/libs/cgse-core/tests/script_test_async_registry_client.py
+++ b/libs/cgse-core/tests/script_test_async_registry_client.py
@@ -1,0 +1,237 @@
+"""
+Example client for the service registry. This example app allows you to inspect
+the service registry and connect to services.
+
+Usage:
+    $ uv run py tests/script_service_client.py
+
+You will need the service registry server to be running and at least one of the
+services in the `services.py` module, user, product, or order.
+
+The server can be started with:
+    $ uv run py -m egse.registry.server
+
+The microservices can be run with:
+    $ uv run tests/services.py user
+    $ uv run tests/services.py product
+    $ uv run tests/services.py order
+
+"""
+import asyncio
+import json
+import logging
+
+import rich
+import zmq
+import zmq.asyncio
+
+from egse.registry.client import AsyncRegistryClient
+
+
+async def run_async_client():
+    """
+    Example client that communicates with the microservices.
+
+    This demonstrates how to call the registry service, subscribe to events and communicate with the microservice.
+    """
+
+    context = zmq.asyncio.Context()
+
+    async def call_service(service_type, command, data=None):
+        """
+        Sends a command to a microservice.
+        """
+        registry_client = AsyncRegistryClient()
+
+        try:
+            service = await registry_client.discover_service(service_type)
+
+            if not service:
+                print(f"No service of type '{service_type}' found")
+                return None
+
+            rich.print(f"Information about the discovered service: {service_type}")
+            rich.print(service)
+
+            socket = context.socket(zmq.REQ)
+            socket.setsockopt(zmq.RCVTIMEO, 5000)  # 5 second timeout
+
+            try:
+                # Connect to the service
+                socket.connect(f"tcp://{service['host']}:{service['port']}")
+
+                # Prepare the request
+                request = {
+                    "command": command, **(data or {})
+                }
+
+                # Send the request
+                await socket.send_string(json.dumps(request))
+
+                # Wait for the response
+                response_json = await socket.recv_string()
+                return json.loads(response_json)
+            finally:
+                socket.close()
+        finally:
+            await registry_client.close()
+
+    # Function to subscribe to service events
+    async def subscribe_to_events(service_type, event_types):
+        # Create a registry client
+        registry_client = AsyncRegistryClient()
+
+        try:
+            # Discover the service
+            service = await registry_client.discover_service(service_type)
+
+            if not service:
+                print(f"No service of type '{service_type}' found")
+                return
+
+            # Get PUB port from metadata
+            pub_port = service.get('metadata', {}).get('pub_port')
+
+            if not pub_port:
+                print(f"Service {service_type} does not expose a PUB socket")
+                return
+
+            # Create a SUB socket
+            socket = context.socket(zmq.SUB)
+
+            # Subscribe to specified event types
+            for event_type in event_types:
+                socket.setsockopt_string(zmq.SUBSCRIBE, event_type)
+
+            # Connect to the service
+            socket.connect(f"tcp://{service['host']}:{pub_port}")
+
+            print(f"Subscribed to {service_type} events: {', '.join(event_types)}")
+
+            try:
+                while True:
+                    # Wait for an event
+                    event_type_bytes, event_json_bytes = await socket.recv_multipart()
+                    event_type = event_type_bytes.decode('utf-8')
+                    event = json.loads(event_json_bytes.decode('utf-8'))
+
+                    print(f"\nReceived event: {event_type}")
+                    print(f"Data: {json.dumps(event, indent=2)}")
+            finally:
+                socket.close()
+        finally:
+            await registry_client.close()
+
+    print("\nZeroMQ Microservices Client")
+    print("===========================")
+
+    while True:
+        print("\nAvailable actions:")
+        print("1. List users")
+        print("2. Get user")
+        print("3. Create user")
+        print("4. List products")
+        print("5. Search products")
+        print("6. Create order")
+        print("7. Subscribe to order events")
+        print("0. Exit")
+
+        choice = input("\nEnter your choice: ")
+
+        if choice == '0':
+            break
+
+        elif choice == '1':
+            response = await call_service("user-service", "list_users")
+            if response and response.get('status') == 'ok':
+                users = response.get('users', [])
+                print("\nUsers:")
+                for user in users:
+                    print(f"  {user['id']}: {user['name']} ({user['email']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '2':
+            user_id = input("Enter user ID: ")
+            response = await call_service("user-service", "get_user", {"user_id": user_id})
+            if response and response.get('status') == 'ok':
+                user = response.get('user', {})
+                print(f"\nUser: {user['name']}")
+                print(f"Email: {user['email']}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '3':
+            name = input("Enter user name: ")
+            email = input("Enter user email: ")
+            response = await call_service(
+                "user-service", "create_user", {
+                    "user": {"name": name, "email": email}
+                }
+            )
+            if response and response.get('status') == 'ok':
+                user = response.get('user', {})
+                print(f"\nCreated user: {user['id']} - {user['name']}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '4':
+            response = await call_service("product-service", "list_products")
+            if response and response.get('status') == 'ok':
+                products = response.get('products', [])
+                print("\nProducts:")
+                for product in products:
+                    print(f"  {product['id']}: {product['name']} - ${product['price']} ({product['category']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '5':
+            query = input("Enter search query: ")
+            response = await call_service("product-service", "search_products", {"query": query})
+            if response and response.get('status') == 'ok':
+                results = response.get('results', [])
+                print(f"\nSearch results for '{query}':")
+                for product in results:
+                    print(f"  {product['id']}: {product['name']} - ${product['price']} ({product['category']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '6':
+            user_id = input("Enter user ID: ")
+            product_ids_input = input("Enter product IDs (comma-separated): ")
+            product_ids = [pid.strip() for pid in product_ids_input.split(",") if pid.strip()]
+
+            response = await call_service(
+                "order-service", "create_order", {
+                    "user_id": user_id, "product_ids": product_ids
+                }
+            )
+
+            if response and response.get('status') == 'ok':
+                order = response.get('order', {})
+                print(f"\nCreated order: {order['id']}")
+                print(f"User: {order['user_name']}")
+                print(f"Products: {len(order['products'])}")
+                print(f"Total: ${order['total_price']:.2f}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '7':
+            print("Subscribing to order events. Press Ctrl+C to stop.")
+            try:
+                await subscribe_to_events("order-service", ["order_created"])
+            except KeyboardInterrupt:
+                print("\nSubscription stopped.")
+
+    # Clean up
+    context.term()
+
+
+if __name__ == "__main__":
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(threadName)-12s %(levelname)-8s %(name)-12s %(lineno)5d:%(module)-20s %(message)s"
+    )
+
+    asyncio.run(run_async_client())

--- a/libs/cgse-core/tests/script_test_service_registry_server.py
+++ b/libs/cgse-core/tests/script_test_service_registry_server.py
@@ -1,0 +1,350 @@
+"""
+ZeroMQ tests with proper resource sharing between tests.
+
+Usage:
+    $ uv run py tests/script_test_service_registry_server.py
+"""
+
+import asyncio
+import json
+import logging
+import random
+import re
+import time
+
+import pytest
+import zmq
+import zmq.asyncio
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+           "%(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+)
+
+logger = logging.getLogger("zmq_test")
+
+# Use dynamic test ports to avoid conflicts between test runs
+TEST_REQ_PORT = random.randint(15000, 16000)
+TEST_PUB_PORT = TEST_REQ_PORT + 1
+
+logger.info(f"Using test ports - REQ: {TEST_REQ_PORT}, PUB: {TEST_PUB_PORT}")
+
+# Test-specific socket options
+SOCKET_OPTIONS = {
+    zmq.LINGER: 0,        # Don't wait when closing sockets
+    zmq.RCVTIMEO: 5000,   # 5 second receive timeout
+    zmq.SNDTIMEO: 5000,   # 5 second send timeout
+    zmq.IMMEDIATE: 1      # Don't queue messages if no connection
+}
+
+# Use pytest-asyncio for async tests
+pytestmark = pytest.mark.asyncio
+
+
+def test_uuid_response_with_regex(response, prefix: str = "test-service"):
+
+    # Define the expected pattern: prefix followed by UUID format
+    pattern = rf'^{prefix}' + r'-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+    # Assert the response matches the pattern
+    assert re.match(pattern, response), f"Response '{response}' does not match expected pattern"
+
+
+async def test_basic_zmq_req_rep():
+    """
+    Simple test of ZeroMQ REQ-REP pattern to verify basic functionality.
+    This helps isolate whether the issue is with ZeroMQ itself or something else.
+    """
+    # Create a context
+    context = zmq.asyncio.Context()
+
+    try:
+        # Create sockets
+        rep_socket = context.socket(zmq.REP)
+        for k, v in SOCKET_OPTIONS.items():
+            rep_socket.setsockopt(k, v)
+
+        # Bind to a random port
+        port = rep_socket.bind_to_random_port("tcp://127.0.0.1")
+        logger.info(f"Basic test bound to port {port}")
+
+        req_socket = context.socket(zmq.REQ)
+        for k, v in SOCKET_OPTIONS.items():
+            req_socket.setsockopt(k, v)
+        req_socket.connect(f"tcp://127.0.0.1:{port}")
+
+        # Start a task to handle requests
+        async def handle_requests():
+            while True:
+                try:
+                    message = await rep_socket.recv_string()
+                    logger.info(f"Basic test received: {message}")
+                    await rep_socket.send_string(f"REPLY: {message}")
+                except zmq.ZMQError as e:
+                    if e.errno == zmq.EAGAIN:
+                        # Socket closed or timeout
+                        break
+                    logger.error(f"ZMQ error in handler: {e}")
+                    break
+                except asyncio.CancelledError:
+                    break
+                except Exception as e:
+                    logger.error(f"Error in handler: {e}")
+                    break
+
+        # Start the handler task
+        handler_task = asyncio.create_task(handle_requests())
+
+        # Send a request
+        await req_socket.send_string("HELLO")
+        logger.info("Basic test sent request")
+
+        # Get the response with timeout
+        if await req_socket.poll(timeout=5000):
+            response = await req_socket.recv_string()
+            logger.info(f"Basic test got response: {response}")
+            assert response == "REPLY: HELLO"
+        else:
+            logger.error("Timeout waiting for response in basic test")
+            assert False, "ZeroMQ basic test failed - no response"
+
+        # Clean up
+        handler_task.cancel()
+        await asyncio.gather(handler_task, return_exceptions=True)
+    finally:
+        # Clean up sockets
+        rep_socket.close()
+        req_socket.close()
+        context.term()
+
+
+async def setup_registry_server():
+    """
+    Set up the registry server and return it along with its task.
+
+    Returns:
+        Tuple of (server, server_task, backend)
+    """
+    from egse.registry.backend import AsyncInMemoryBackend
+    from egse.registry.server import AsyncRegistryServer
+
+    logger.info("Setting up registry server")
+
+    # Create backend
+    backend = AsyncInMemoryBackend()
+    await backend.initialize()
+
+    # Create server with test ports
+    server = AsyncRegistryServer(
+        req_port=TEST_REQ_PORT,
+        pub_port=TEST_PUB_PORT,
+        backend=backend
+    )
+
+    # Start server
+    server_task = asyncio.create_task(server.start())
+    logger.info(f"Server starting on ports {TEST_REQ_PORT}/{TEST_PUB_PORT}")
+
+    # Wait a bit for server to start
+    await asyncio.sleep(0.5)
+
+    return server, server_task, backend
+
+
+async def cleanup_registry_server(server, server_task, backend):
+    """
+    Clean up the registry server resources.
+    """
+    logger.info("Cleaning up registry server")
+    server.stop()
+    await asyncio.gather(server_task, return_exceptions=True)
+    await backend.close()
+    logger.info("Registry server cleaned up")
+
+
+async def send_request(request, timeout=5.0):
+    """
+    Send a request with a fresh socket each time.
+
+    Args:
+        request: The request to send
+        timeout: Timeout in seconds
+
+    Returns:
+        The response as a dictionary
+    """
+    logger.debug(f"Sending request: {request}")
+    start_time = time.time()
+
+    # Create a fresh socket for this request
+    context = zmq.asyncio.Context.instance()
+    socket = context.socket(zmq.REQ)
+    for k, v in SOCKET_OPTIONS.items():
+        socket.setsockopt(k, v)
+
+    socket.connect(f"tcp://localhost:{TEST_REQ_PORT}")
+    logger.debug("Connected fresh socket")
+
+    try:
+        # Send the request
+        logger.debug(f"Sending: {json.dumps(request)}")
+        await asyncio.wait_for(
+            socket.send_string(json.dumps(request)),
+            timeout=timeout
+        )
+        logger.debug("Request sent, waiting for response")
+
+        # Wait for response with poll and timeout
+        if await socket.poll(timeout=timeout * 1000) == 0:
+            logger.error(f"Timeout polling for response to {request.get('action')}")
+            raise TimeoutError(f"Timeout waiting for response to {request.get('action')}")
+
+        # Receive the response
+        logger.debug("Poll successful, receiving response")
+        response_json = await asyncio.wait_for(
+            socket.recv_string(),
+            timeout=timeout
+        )
+        logger.debug(f"Response received: {response_json[:100]}...")
+
+        # Parse and return
+        return json.loads(response_json)
+
+    except Exception as e:
+        elapsed = time.time() - start_time
+        logger.error(f"Error in send_request after {elapsed:.2f}s: {str(e)}")
+        raise
+    finally:
+        # Clean up
+        socket.close(linger=0)
+        logger.debug("Request socket closed")
+
+
+async def test_registry_server_health():
+    """
+    Test the registry server's health check endpoint.
+    """
+    # Send health check request
+    response = await send_request({"action": "health"})
+    logger.info(f"Health check response: {response}")
+
+    # Verify response
+    assert response.get("success") is True
+    assert "status" in response
+    assert response["status"] == "ok"
+
+    return True
+
+
+async def test_registry_server_registration():
+    """
+    Test registering a service with the registry.
+    """
+    # Service info
+    service_info = {
+        "name": "test-service",
+        "host": "localhost",
+        "port": 8080,
+        "type": "test",
+        "tags": ["test"],
+        "metadata": {"version": "1.0.0"}
+    }
+
+    # Register the service
+    response = await send_request({
+        "action": "register",
+        "service_info": service_info
+    })
+    logger.info(f"Registration response: {response}")
+
+    # Verify response
+    assert response.get("success") is True
+    assert "service_id" in response
+
+    # Get the service ID for future use
+    service_id = response["service_id"]
+
+    # Now try to get the service
+    response = await send_request({
+        "action": "get",
+        "service_id": service_id
+    })
+    logger.info(f"Get service response: {response}")
+
+    # Verify response
+    assert response.get("success") is True
+    assert "service" in response
+    assert response["service"]["name"] == "test-service"
+
+    return service_id
+
+
+async def test_registry_server_listing():
+    """
+    Test listing services from the registry.
+    """
+    # List all services
+    response = await send_request({"action": "list"})
+    logger.info(f"List services response: {response}")
+
+    # Verify response
+    assert response.get("success") is True
+    assert "services" in response
+
+    # There should be at least one service (from the registration test)
+    assert len(response["services"]) >= 1
+
+    return True
+
+
+async def run_all_tests():
+    """
+    Run all tests in sequence, properly sharing resources.
+    """
+    # First test basic ZeroMQ functionality
+    logger.info("\n=== Testing basic ZeroMQ functionality ===")
+    await test_basic_zmq_req_rep()
+
+    # Now test the registry server
+    logger.info("\n=== Setting up registry server ===")
+    server, server_task, backend = await setup_registry_server()
+
+    try:
+        # Wait for 10s to inspect logs coming from the server
+
+        logger.info("\n=== Waiting 10s to inspect server logs ===")
+        await asyncio.sleep(10.0)
+
+        # Test server health
+        logger.info("\n=== Testing registry server health ===")
+        await test_registry_server_health()
+
+        # Test registration
+        logger.info("\n=== Testing service registration ===")
+        service_id = await test_registry_server_registration()
+        test_uuid_response_with_regex(service_id)
+
+        # Test listing
+        logger.info("\n=== Testing service listing ===")
+        await test_registry_server_listing()
+
+        # More tests can be added here...
+
+        logger.info("\n=== All tests passed successfully! ===")
+        return 0
+    except Exception as e:
+        logger.error(f"\n=== Test failed: {e} ===")
+        import traceback
+        traceback.print_exc()
+        return 1
+    finally:
+        # Clean up resources
+        logger.info("\n=== Cleaning up resources ===")
+        await cleanup_registry_server(server, server_task, backend)
+
+
+if __name__ == "__main__":
+    # This allows running these tests directly without pytest
+    import sys
+    sys.exit(asyncio.run(run_all_tests()))

--- a/libs/cgse-core/tests/script_test_sync_registry_client.py
+++ b/libs/cgse-core/tests/script_test_sync_registry_client.py
@@ -1,0 +1,227 @@
+"""
+Example client for the service registry. This example app allows you to inspect
+the service registry and connect to services.
+
+Usage:
+    $ uv run py tests/script_service_client.py
+
+You will need the service registry server to be running and at least one of the
+services in the `services.py` module, user, product, or order.
+
+The server can be started with:
+    $ uv run py -m egse.registry.server
+
+The microservices can be run with:
+    $ uv run tests/services.py user
+    $ uv run tests/services.py product
+    $ uv run tests/services.py order
+
+"""
+
+import json
+import logging
+
+import rich
+import zmq
+
+from egse.registry.client import RegistryClient
+
+
+def run_client():
+
+    context = zmq.Context()
+
+    def call_service(service_type, command, data=None):
+        """
+        Sends a command to a microservice.
+        """
+        registry_client = RegistryClient()
+
+        try:
+            service = registry_client.discover_service(service_type)
+
+            if not service:
+                print(f"No service of type '{service_type}' found")
+                return None
+
+            rich.print(f"Information about the discovered service: {service_type}")
+            rich.print(service)
+
+            socket = context.socket(zmq.REQ)
+            socket.setsockopt(zmq.RCVTIMEO, 5000)  # 5 second timeout
+
+            try:
+                # Connect to the service
+                socket.connect(f"tcp://{service['host']}:{service['port']}")
+
+                # Prepare the request
+                request = {
+                    "command": command, **(data or {})
+                }
+
+                # Send the request
+                socket.send_string(json.dumps(request))
+
+                # Wait for the response
+                response_json = socket.recv_string()
+                return json.loads(response_json)
+            finally:
+                socket.close()
+        finally:
+            registry_client.close()
+
+    def subscribe_to_events(service_type, event_types):
+        # Create a registry client
+        registry_client = RegistryClient()
+
+        try:
+            # Discover the service
+            service = registry_client.discover_service(service_type)
+
+            if not service:
+                print(f"No service of type '{service_type}' found")
+                return
+
+            # Get PUB port from metadata
+            pub_port = service.get('metadata', {}).get('pub_port')
+
+            if not pub_port:
+                print(f"Service {service_type} does not expose a PUB socket")
+                return
+
+            # Create a SUB socket
+            socket = context.socket(zmq.SUB)
+
+            # Subscribe to specified event types
+            for event_type in event_types:
+                socket.setsockopt_string(zmq.SUBSCRIBE, event_type)
+
+            # Connect to the service
+            socket.connect(f"tcp://{service['host']}:{pub_port}")
+
+            print(f"Subscribed to {service_type} events: {', '.join(event_types)}")
+
+            try:
+                while True:
+                    # Wait for an event
+                    event_type_bytes, event_json_bytes = socket.recv_multipart()
+                    event_type = event_type_bytes.decode('utf-8')
+                    event = json.loads(event_json_bytes.decode('utf-8'))
+
+                    print(f"\nReceived event: {event_type}")
+                    print(f"Data: {json.dumps(event, indent=2)}")
+            finally:
+                socket.close()
+        finally:
+            registry_client.close()
+
+    while True:
+        print("\nAvailable actions:")
+        print("1. List users")
+        print("2. Get user")
+        print("3. Create user")
+        print("4. List products")
+        print("5. Search products")
+        print("6. Create order")
+        print("7. Subscribe to order events")
+        print("0. Exit")
+
+        choice = input("\nEnter your choice: ")
+
+        if choice == '0':
+            break
+
+        elif choice == '1':
+            response = call_service("user-service", "list_users")
+            if response and response.get('status') == 'ok':
+                users = response.get('users', [])
+                print("\nUsers:")
+                for user in users:
+                    print(f"  {user['id']}: {user['name']} ({user['email']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '2':
+            user_id = input("Enter user ID: ")
+            response = call_service("user-service", "get_user", {"user_id": user_id})
+            if response and response.get('status') == 'ok':
+                user = response.get('user', {})
+                print(f"\nUser: {user['name']}")
+                print(f"Email: {user['email']}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '3':
+            name = input("Enter user name: ")
+            email = input("Enter user email: ")
+            response = call_service(
+                "user-service", "create_user", {
+                    "user": {"name": name, "email": email}
+                }
+            )
+            if response and response.get('status') == 'ok':
+                user = response.get('user', {})
+                print(f"\nCreated user: {user['id']} - {user['name']}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '4':
+            response = call_service("product-service", "list_products")
+            if response and response.get('status') == 'ok':
+                products = response.get('products', [])
+                print("\nProducts:")
+                for product in products:
+                    print(f"  {product['id']}: {product['name']} - ${product['price']} ({product['category']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '5':
+            query = input("Enter search query: ")
+            response = call_service("product-service", "search_products", {"query": query})
+            if response and response.get('status') == 'ok':
+                results = response.get('results', [])
+                print(f"\nSearch results for '{query}':")
+                for product in results:
+                    print(f"  {product['id']}: {product['name']} - ${product['price']} ({product['category']})")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '6':
+            user_id = input("Enter user ID: ")
+            product_ids_input = input("Enter product IDs (comma-separated): ")
+            product_ids = [pid.strip() for pid in product_ids_input.split(",") if pid.strip()]
+
+            response = call_service(
+                "order-service", "create_order", {
+                    "user_id": user_id, "product_ids": product_ids
+                }
+            )
+
+            if response and response.get('status') == 'ok':
+                order = response.get('order', {})
+                print(f"\nCreated order: {order['id']}")
+                print(f"User: {order['user_name']}")
+                print(f"Products: {len(order['products'])}")
+                print(f"Total: ${order['total_price']:.2f}")
+            else:
+                print(f"Error: {response.get('error') if response else 'No response'}")
+
+        elif choice == '7':
+            print("Subscribing to order events. Press Ctrl+C to stop.")
+            try:
+                subscribe_to_events("order-service", ["order_created"])
+            except KeyboardInterrupt:
+                print("\nSubscription stopped.")
+
+    # Clean up
+    context.term()
+
+
+if __name__ == "__main__":
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(threadName)-12s %(levelname)-8s %(name)-12s %(lineno)5d:%(module)-20s %(message)s"
+    )
+
+    run_client()

--- a/libs/cgse-core/tests/services.py
+++ b/libs/cgse-core/tests/services.py
@@ -1,0 +1,386 @@
+import asyncio
+import logging
+import signal
+import sys
+import time
+from typing import Any
+
+from egse.registry.service import ZMQMicroservice
+
+module_logger_name = "example-services"
+logger = logging.getLogger(module_logger_name)
+
+
+class UserService(ZMQMicroservice):
+    """
+    User management microservice.
+
+    This service provides user-related functionality:
+    - User lookup
+    - User registration
+    - User authentication
+    """
+
+    def __init__(self, rep_port: int = 0, pub_port: int = 0):
+        super().__init__(
+            service_name="user-service",
+            service_type="user-service",
+            rep_port=rep_port,
+            pub_port=pub_port,
+            metadata={"version": "1.0.0"}
+        )
+
+        self.logger = logging.getLogger(f"{module_logger_name}.user")
+
+        # Mock user database
+        self.users = {
+            "user1": {"id": "user1", "name": "John Doe", "email": "john@example.com"},
+            "user2": {"id": "user2", "name": "Jane Smith", "email": "jane@example.com"},
+            "user3": {"id": "user3", "name": "Bob Johnson", "email": "bob@example.com"}
+        }
+
+        self.register_handler("get_user", self._handle_get_user)
+        self.register_handler("list_users", self._handle_list_users)
+        self.register_handler("create_user", self._handle_create_user)
+
+    async def _handle_get_user(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle get_user command."""
+        user_id = data.get("user_id")
+
+        if not user_id:
+            return {"status": "error", "error": "Missing user_id"}
+
+        user = self.users.get(user_id)
+
+        if not user:
+            return {"status": "error", "error": "User not found"}
+
+        return {
+            "status": "ok",
+            "user": user
+        }
+
+    async def _handle_list_users(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle list_users command."""
+        return {
+            "status": "ok",
+            "users": list(self.users.values())
+        }
+
+    async def _handle_create_user(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle create_user command."""
+        user_data = data.get("user")
+
+        if not user_data or not isinstance(user_data, dict):
+            return {"status": "error", "error": "Invalid user data"}
+
+        required_fields = ["name", "email"]
+        for field in required_fields:
+            if field not in user_data:
+                return {"status": "error", "error": f"Missing required field: {field}"}
+
+        # Generate ID
+        user_id = f"user{len(self.users) + 1}"
+
+        # Create user
+        user = {
+            "id": user_id,
+            "name": user_data["name"],
+            "email": user_data["email"]
+        }
+
+        # Add to database
+        self.users[user_id] = user
+
+        # Publish event
+        await self.publish_event("user_created", {"user": user})
+
+        return {
+            "status": "ok",
+            "user": user
+        }
+
+
+class ProductService(ZMQMicroservice):
+    """
+    Product catalog microservice.
+
+    This service provides product-related functionality:
+    - Product lookup
+    - Product listing
+    - Product search
+    """
+
+    def __init__(self, rep_port: int = 0, pub_port: int = 0):
+        super().__init__(
+            service_name="product-service",
+            service_type="product-service",
+            rep_port=rep_port,
+            pub_port=pub_port,
+            metadata={"version": "1.0.0"}
+        )
+
+        self.logger = logging.getLogger(f"{module_logger_name}.product")
+
+        # Mock product database
+        self.products = {
+            "prod1": {"id": "prod1", "name": "Laptop", "price": 999.99, "category": "electronics"},
+            "prod2": {"id": "prod2", "name": "Smartphone", "price": 699.99, "category": "electronics"},
+            "prod3": {"id": "prod3", "name": "Headphones", "price": 199.99, "category": "accessories"}
+        }
+
+        # Register handlers
+        self.register_handler("get_product", self._handle_get_product)
+        self.register_handler("list_products", self._handle_list_products)
+        self.register_handler("search_products", self._handle_search_products)
+
+    async def _handle_get_product(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle get_product command."""
+        product_id = data.get("product_id")
+
+        if not product_id:
+            return {"status": "error", "error": "Missing product_id"}
+
+        product = self.products.get(product_id)
+
+        if not product:
+            return {"status": "error", "error": "Product not found"}
+
+        return {
+            "status": "ok",
+            "product": product
+        }
+
+    async def _handle_list_products(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle list_products command."""
+        category = data.get("category")
+
+        if category:
+            # Filter by category
+            products = [p for p in self.products.values() if p.get("category") == category]
+        else:
+            # Return all products
+            products = list(self.products.values())
+
+        return {
+            "status": "ok",
+            "products": products
+        }
+
+    async def _handle_search_products(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle search_products command."""
+        query = data.get("query", "").lower()
+
+        if not query:
+            return {"status": "error", "error": "Missing query parameter"}
+
+        # Simple search implementation
+        results = [
+            p for p in self.products.values()
+            if query in p["name"].lower() or query in p.get("category", "").lower()
+        ]
+
+        return {
+            "status": "ok",
+            "results": results
+        }
+
+
+class OrderService(ZMQMicroservice):
+    """
+    Order processing microservice.
+
+    This service provides order-related functionality:
+    - Create orders
+    - Get order status
+    - List user orders
+
+    It demonstrates communication with other services.
+    """
+
+    def __init__(self, rep_port: int = 0, pub_port: int = 0):
+        super().__init__(
+            service_name="order-service",
+            service_type="order-service",
+            rep_port=rep_port,
+            pub_port=pub_port,
+            metadata={"version": "1.0.0"}
+        )
+
+        self.logger = logging.getLogger(f"{module_logger_name}.order")
+
+        # Mock order database
+        self.orders = {}
+        self.next_order_id = 1
+
+        # Register handlers
+        self.register_handler("create_order", self._handle_create_order)
+        self.register_handler("get_order", self._handle_get_order)
+        self.register_handler("list_user_orders", self._handle_list_user_orders)
+
+    async def _handle_create_order(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle create_order command."""
+        user_id = data.get("user_id")
+        product_ids = data.get("product_ids", [])
+
+        if not user_id:
+            return {"status": "error", "error": "Missing user_id"}
+
+        if not product_ids or not isinstance(product_ids, list):
+            return {"status": "error", "error": "Invalid product_ids"}
+
+        try:
+            # Verify user exists
+            try:
+                user_response = await self.call_service("user-service", "get_user", {"user_id": user_id})
+
+                if user_response.get("status") != "ok":
+                    return {"status": "error", "error": f"Invalid user: {user_response.get('error')}"}
+
+                user = user_response.get("user")
+            except Exception as exc:
+                self.logger.error(f"Error calling user service: {exc}")
+                return {"status": "error", "error": "User service unavailable"}
+
+            # Verify products exist and get details
+            products = []
+            total_price = 0.0
+
+            for product_id in product_ids:
+                try:
+                    product_response = await self.call_service(
+                        "product-service", "get_product", {"product_id": product_id}
+                        )
+
+                    if product_response.get("status") != "ok":
+                        return {
+                            "status": "error", "error": f"Invalid product {product_id}: {product_response.get('error')}"
+                        }
+
+                    product = product_response.get("product")
+                    products.append(product)
+                    total_price += product.get("price", 0.0)
+                except Exception as exc:
+                    self.logger.error(f"Error calling product service: {exc}")
+                    return {"status": "error", "error": "Product service unavailable"}
+
+            # Create the order
+            order_id = f"order{self.next_order_id}"
+            self.next_order_id += 1
+
+            order = {
+                "id": order_id,
+                "user_id": user_id,
+                "user_name": user.get("name"),
+                "products": products,
+                "total_price": total_price,
+                "status": "created",
+                "created_at": time.time()
+            }
+
+            # Save the order
+            self.orders[order_id] = order
+
+            # Publish event
+            await self.publish_event("order_created", {"order": order})
+
+            return {
+                "status": "ok",
+                "order": order
+            }
+        except Exception as exc:
+            self.logger.error(f"Error creating order: {exc}")
+            return {"status": "error", "error": str(exc)}
+
+    async def _handle_get_order(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle get_order command."""
+        order_id = data.get("order_id")
+
+        if not order_id:
+            return {"status": "error", "error": "Missing order_id"}
+
+        order = self.orders.get(order_id)
+
+        if not order:
+            return {"status": "error", "error": "Order not found"}
+
+        return {
+            "status": "ok",
+            "order": order
+        }
+
+    async def _handle_list_user_orders(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle list_user_orders command."""
+        user_id = data.get("user_id")
+
+        if not user_id:
+            return {"status": "error", "error": "Missing user_id"}
+
+        # Find all orders for the user
+        user_orders = [
+            order for order in self.orders.values()
+            if order.get("user_id") == user_id
+        ]
+
+        return {
+            "status": "ok",
+            "orders": user_orders
+        }
+
+
+async def run_service(service_class, **kwargs):
+    """
+    Run a service with proper signal handling.
+
+    Args:
+        service_class: Service class to instantiate
+        **kwargs: Arguments for the service constructor
+    """
+    # Create the service
+    service = service_class(**kwargs)
+
+    # Set up signal handlers
+    loop = asyncio.get_running_loop()
+
+    def signal_handler():
+        asyncio.create_task(service.stop())
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, signal_handler)
+
+    # Start the service
+    await service.start()
+
+
+def main():
+    import argparse
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+               "%(name)-21s %(lineno)5d:%(module)-20s %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(description='Run a ZeroMQ-based microservice')
+    parser.add_argument('service', choices=['user', 'product', 'order'], help='Service to run')
+    parser.add_argument('--rep-port', type=int, help='REP socket port')
+    parser.add_argument('--pub-port', type=int, help='PUB socket port')
+
+    args = parser.parse_args()
+
+    service_kwargs = {}
+    if args.rep_port:
+        service_kwargs['rep_port'] = args.rep_port
+    if args.pub_port:
+        service_kwargs['pub_port'] = args.pub_port
+
+    if args.service == 'user':
+        asyncio.run(run_service(UserService, **service_kwargs))
+    elif args.service == 'product':
+        asyncio.run(run_service(ProductService, **service_kwargs))
+    elif args.service == 'order':
+        asyncio.run(run_service(OrderService, **service_kwargs))
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/libs/cgse-core/tests/test_registry_backend.py
+++ b/libs/cgse-core/tests/test_registry_backend.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for AsyncRegistryBackend implementations using a unified fixture approach.
+
+This file contains pytest tests for both AsyncSQLiteBackend and AsyncInMemoryBackend.
+These tests verify that the backends correctly implement the AsyncRegistryBackend protocol
+and functions as expected.
+
+To run:
+    uv run pytest -v -s test_registry_backend.py
+"""
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+from typing import Dict
+from typing import List
+
+import pytest
+import pytest_asyncio
+
+# Import the backend implementations
+from egse.registry.backend import AsyncInMemoryBackend
+from egse.registry.backend import AsyncSQLiteBackend
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+           "%(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+)
+
+logger = logging.getLogger("test_registry_backend")
+
+# Use pytest-asyncio for async tests by default
+pytestmark = pytest.mark.asyncio
+
+# Test data
+TEST_DB_PATH = "test_registry.db"
+TEST_SERVICE_ID = "test-service-1"
+TEST_SERVICE_INFO = {
+    "name": "test-service",
+    "host": "localhost",
+    "port": 8080,
+    "type": "test",
+    "metadata": {"version": "1.0.0"},
+    "tags": ["test", "unit-test"]
+}
+
+
+@pytest_asyncio.fixture(params=["sqlite", "memory"])
+async def backend(request):
+    """
+    Parameterized fixture that yields initialized backends of different types.
+
+    This fixture will run all tests twice - once with the SQLite backend and once
+    with the in-memory backend.
+    """
+    if request.param == "sqlite":
+        if os.path.exists(TEST_DB_PATH):
+            os.remove(TEST_DB_PATH)
+
+        backend = AsyncSQLiteBackend(TEST_DB_PATH)
+        await backend.initialize()
+
+        yield backend
+
+        await backend.close()
+        if os.path.exists(TEST_DB_PATH):
+            os.remove(TEST_DB_PATH)
+
+    elif request.param == "memory":
+        backend = AsyncInMemoryBackend()
+        await backend.initialize()
+
+        yield backend
+
+        await backend.close()
+
+
+# no need to specify @pytest.mark.asyncio because we have defined the `pytestmark` variable above.
+
+async def test_register_service_plain(backend):
+
+    success = await backend.register("my-unique-service-id-1234", {})
+    assert success, "Service registration should succeed"
+
+    service = await backend.get_service("my-unique-service-id-1234")
+
+    logger.info(f"{success = }")
+    logger.info(f"{service = }")
+
+
+async def test_register_service_with_type(backend):
+
+    success = await backend.register("my-unique-service-id-1234", {'type': 'plain'})
+    assert success, "Service registration should succeed"
+
+    service = await backend.get_service("my-unique-service-id-1234")
+
+    logger.info(f"{success = }")
+    logger.info(f"{service = }")
+
+
+async def test_register_service(backend):
+    """Test registering a service."""
+
+    success = await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+    assert success, "Service registration should succeed"
+
+    # Verify the service was registered
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is not None, "Should be able to retrieve the registered service"
+    assert service["id"] == TEST_SERVICE_ID, "Service ID should match"
+    assert service["name"] == TEST_SERVICE_INFO["name"], "Service name should match"
+    assert service["host"] == TEST_SERVICE_INFO["host"], "Service host should match"
+    assert service["port"] == TEST_SERVICE_INFO["port"], "Service port should match"
+    assert "test" in service["tags"], "Service tags should be preserved"
+    assert service["health"] == "passing", "New service should have passing health"
+
+
+async def test_deregister_service(backend):
+    """Test de-registering a service."""
+
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+
+    success = await backend.deregister(TEST_SERVICE_ID)
+    assert success, "Service de-registration should succeed"
+
+    # Verify the service was deregistered
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is None, "Deregistered service should not be found"
+
+
+async def test_renew_service(backend):
+    """Test renewing a service's TTL."""
+
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO, ttl=5)
+
+    # Get the initial heartbeat time
+    service = await backend.get_service(TEST_SERVICE_ID)
+    initial_heartbeat = service["last_heartbeat"]
+
+    # Wait a bit
+    await asyncio.sleep(1)
+
+    # Renew the service
+    success = await backend.renew(TEST_SERVICE_ID)
+    assert success, "Service renewal should succeed"
+
+    # Get the updated heartbeat time
+    service = await backend.get_service(TEST_SERVICE_ID)
+    updated_heartbeat = service["last_heartbeat"]
+
+    # Check that the heartbeat was updated
+    assert updated_heartbeat > initial_heartbeat, "Heartbeat time should be updated after renewal"
+
+
+async def test_list_services(backend):
+    """Test listing all services."""
+
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+    await backend.register(
+        service_id="test-service-2",
+        service_info={
+            **TEST_SERVICE_INFO,
+            "name": "second-test-service",
+            "port": 8081,
+            "type": "api"
+        }
+    )
+
+    services = await backend.list_services()
+    assert len(services) == 2, "Should list all registered services"
+
+    # Check names to ensure we have both services
+    service_names = [s["name"] for s in services]
+    assert "test-service" in service_names, "First service should be in the list"
+    assert "second-test-service" in service_names, "Second service should be in the list"
+
+
+async def test_list_services_by_type(backend):
+    """Test listing services filtered by type."""
+
+    # Register services with different types
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)  # this service is of type 'test'
+    await backend.register(
+        "test-service-2", {
+            **TEST_SERVICE_INFO,
+            "name": "second-test-service",
+            "port": 8081,
+            "type": "api",
+            "tags": ["api"]
+        }
+    )
+
+    # List services filtered by type
+    test_services = await backend.list_services("test")
+    assert len(test_services) == 1, "Should filter services by 'test' type"
+    assert test_services[0]["name"] == "test-service", "Should find the correct service"
+
+    api_services = await backend.list_services("api")
+    assert len(api_services) == 1, "Should filter services by 'api' type"
+    assert api_services[0]["name"] == "second-test-service", "Should find the correct service"
+
+
+async def test_discover_service(backend):
+    """Test discovering a service by type."""
+    # Register a service
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+
+    # Discover a service by type
+    service = await backend.discover_service("test")
+    assert service is not None, "Should discover a service of type 'test'"
+    assert service["name"] == "test-service", "Should discover the correct service"
+
+    # Try to discover a non-existent service type
+    service = await backend.discover_service("nonexistent")
+    assert service is None, "Should not discover a service of non-existent type"
+
+
+async def test_clean_expired_services(backend):
+    """Test cleaning up expired services."""
+    # Register a service with short TTL
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO, ttl=1)
+
+    # Verify the service exists
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is not None, "Service should exist initially"
+
+    # Wait for the service to expire
+    await asyncio.sleep(2)
+
+    # Clean expired services
+    expired_ids = await backend.clean_expired_services()
+    assert TEST_SERVICE_ID in expired_ids, "Service should be in the list of expired IDs"
+
+    # Verify the service was removed
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is None, "Expired service should be removed"
+
+
+async def test_health_status(backend):
+    """Test health status calculation."""
+    # Register a service with short TTL
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO, ttl=2)
+
+    # Verify initial health is passing
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service["health"] == "passing", "Initial health should be passing"
+
+    # Wait for the service to become critical
+    await asyncio.sleep(3)
+
+    # Verify health is now critical
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is not None, "Service should still exist"
+    assert service["health"] == "critical", "Health should become critical after TTL expires"
+
+
+# Edge cases and error handling
+
+async def test_register_existing_service(backend):
+    """Test registering a service with an ID that already exists."""
+    # Register a service
+    await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+
+    # Register a different service with the same ID
+    updated_info = {
+        **TEST_SERVICE_INFO,
+        "port": 9090,
+        "metadata": {"version": "2.0.0"}
+    }
+    success = await backend.register(TEST_SERVICE_ID, updated_info)
+    assert success, "Registering an existing service should succeed (update)"
+
+    # Verify the service was updated
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service["port"] == 9090, "Service port should be updated"
+    assert service["metadata"]["version"] == "2.0.0", "Service metadata should be updated"
+
+
+async def test_deregister_nonexistent_service(backend):
+    """Test de-registering a service that doesn't exist."""
+    success = await backend.deregister("nonexistent-service")
+    assert not success, "De-registering a nonexistent service should fail"
+
+
+async def test_renew_nonexistent_service(backend):
+    """Test renewing a service that doesn't exist."""
+    success = await backend.renew("nonexistent-service")
+    assert not success, "Renewing a nonexistent service should fail"
+
+
+async def test_discover_with_multiple_services(backend):
+    """Test discovery with multiple services of the same type."""
+    # Register multiple services of the same type
+    await backend.register(
+        "test-service-1", {
+            **TEST_SERVICE_INFO,
+            "name": "test-service-1"
+        }
+    )
+    await backend.register(
+        "test-service-2", {
+            **TEST_SERVICE_INFO,
+            "name": "test-service-2"
+        }
+    )
+
+    # Keep track of discovered services
+    discovered_services = set()
+
+    # Run multiple discoveries and verify load balancing
+    for _ in range(10):
+        service = await backend.discover_service("test")
+        assert service is not None, "Should discover a service"
+        discovered_services.add(service["name"])
+
+    # We should have discovered both services
+    assert len(discovered_services) == 2, "Should have discovered both services"
+    assert "test-service-1" in discovered_services, "First service should be discovered"
+    assert "test-service-2" in discovered_services, "Second service should be discovered"
+
+
+# Test concurrent operations
+async def test_concurrent_operations(backend):
+    """Test concurrent operations on the backend."""
+    # Number of concurrent operations
+    num_concurrent = 20
+
+    # Function to register a service
+    async def register_task(i: int) -> bool:
+        service_id = f"concurrent-service-{i}"
+        service_info = {
+            "name": f"concurrent-service-{i}",
+            "host": "localhost",
+            "port": 9000 + i,
+            "type": "concurrent",
+            "tags": ["concurrent"]
+        }
+        return await backend.register(service_id, service_info)
+
+    # Function to list services multiple times
+    async def list_task(i: int) -> List[Dict[str, Any]]:
+        return await backend.list_services()
+
+    # Run concurrent registrations
+    start_time = time.time()
+    register_tasks = [register_task(i) for i in range(num_concurrent)]
+    register_results = await asyncio.gather(*register_tasks)
+    register_time = time.time() - start_time
+
+    # All registrations should succeed
+    assert all(register_results), "All concurrent registrations should succeed"
+
+    # Run concurrent list operations
+    start_time = time.time()
+    list_tasks = [list_task(i) for i in range(num_concurrent)]
+    list_results = await asyncio.gather(*list_tasks)
+    list_time = time.time() - start_time
+
+    # All list operations should return the same count
+    counts = [len(result) for result in list_results]
+    assert all(count >= num_concurrent for count in counts), "All list operations should find all services"
+
+    # Output concurrency metrics
+    print(f"\nConcurrency test results for {backend.__class__.__name__}:")
+    print(f"  {num_concurrent} concurrent registrations: {register_time:.4f} seconds")
+    print(f"  {num_concurrent} concurrent list operations: {list_time:.4f} seconds")
+    print(f"  Total time: {register_time + list_time:.4f} seconds")
+
+
+# Performance tests
+async def test_backend_performance(backend):
+    """Test backend performance with many operations."""
+    # Number of services to register
+    num_services = 100
+
+    # Register many services
+    start_time = time.time()
+    for i in range(num_services):
+        service_id = f"perf-service-{i}"
+        service_info = {
+            "name": f"performance-service-{i}",
+            "host": "localhost",
+            "port": 8000 + i,
+            "type": "performance",
+            "tags": ["performance", f"group-{i % 10}"]
+        }
+        await backend.register(service_id, service_info)
+    register_time = time.time() - start_time
+
+    # List all services
+    start_time = time.time()
+    services = await backend.list_services()
+    list_time = time.time() - start_time
+    assert len(services) >= num_services, f"Should list all {num_services} registered services"
+
+    # Get many services
+    start_time = time.time()
+    for i in range(num_services):
+        service_id = f"perf-service-{i}"
+        service = await backend.get_service(service_id)
+        assert service is not None, f"Should find service {service_id}"
+    get_time = time.time() - start_time
+
+    # Discover many times
+    start_time = time.time()
+    for _ in range(100):  # 100 discoveries
+        service = await backend.discover_service("performance")
+        assert service is not None, "Should discover a performance service"
+    discover_time = time.time() - start_time
+
+    # Output performance metrics
+    print(f"\nPerformance test results for {backend.__class__.__name__}:")
+    print(f"  Register {num_services} services: {register_time:.4f} seconds")
+    print(f"  List all services: {list_time:.4f} seconds")
+    print(f"  Get {num_services} services: {get_time:.4f} seconds")
+    print(f"  Discover 100 times: {discover_time:.4f} seconds")
+    print(f"  Total time: {register_time + list_time + get_time + discover_time:.4f} seconds")
+
+
+# SQLite-specific tests need their own fixture since they don't use the parameterization
+@pytest.fixture
+async def sqlite_only():
+    """Fixture for SQLite-specific tests."""
+    if os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
+
+    yield
+
+    if os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
+
+
+@pytest.mark.parametrize("drop_db", [True, False])
+async def test_sqlite_persistence(sqlite_only, drop_db: bool) -> None:
+    """Test SQLite backend persistence across restarts."""
+    # First database connection - register a service
+    backend1 = AsyncSQLiteBackend(TEST_DB_PATH)
+    await backend1.initialize()
+    await backend1.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+    await backend1.close()
+
+    # Optionally delete the database file to test resilience
+    if drop_db and os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
+
+    # Second database connection - verify service exists
+    backend2 = AsyncSQLiteBackend(TEST_DB_PATH)
+    await backend2.initialize()
+
+    if drop_db:
+        # If we dropped the DB, service should not exist
+        service = await backend2.get_service(TEST_SERVICE_ID)
+        assert service is None, "Service should not exist after database was dropped"
+    else:
+        # If we kept the DB, service should exist
+        service = await backend2.get_service(TEST_SERVICE_ID)
+        assert service is not None, "Service should persist across database connections"
+        assert service["name"] == TEST_SERVICE_INFO["name"], "Service details should persist"
+
+    await backend2.close()
+
+
+async def test_sqlite_backend_resilience(sqlite_only) -> None:
+    """Test SQLite backend's resilience to disruptions."""
+    # Create a backend without initializing
+    backend = AsyncSQLiteBackend(TEST_DB_PATH)
+
+    # Try operations before initialization (should fail gracefully)
+    success = await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+    assert not success, "Operations before initialization should fail gracefully"
+
+    # Initialize the backend
+    await backend.initialize()
+
+    # Register a service
+    success = await backend.register(TEST_SERVICE_ID, TEST_SERVICE_INFO)
+    assert success, "Registration after initialization should succeed"
+
+    # Close the backend
+    await backend.close()
+
+    # Try operations after closing (should fail gracefully)
+    service = await backend.get_service(TEST_SERVICE_ID)
+    assert service is None, "Operations after closing should fail gracefully"
+
+
+async def test_protocol_implementation(backend):
+
+    assert "implements the AsyncRegistryBackend protocol" in backend.__doc__
+    assert backend.verify_protocol_compliance()

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -1,0 +1,958 @@
+"""
+Unit tests for AsyncRegistryServer and AsyncRegistryClient.
+
+These tests verify the functionality of the ZeroMQ-based service registry components.
+
+"""
+
+import asyncio
+import json
+import logging
+import time
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+import zmq
+import zmq.asyncio
+
+from egse.registry.backend import AsyncInMemoryBackend
+from egse.registry.client import AsyncRegistryClient
+from egse.registry.server import AsyncRegistryServer
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+           "%(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+)
+
+logger = logging.getLogger("test_registry_service")
+
+# Constants for testing
+TEST_REQ_PORT = 15556
+TEST_PUB_PORT = 15557
+
+# Wait timeout for the server to start (seconds)
+SERVER_STARTUP_TIMEOUT = 5
+
+
+################################################################################
+# Fixed Helper Functions
+################################################################################
+
+
+async def send_request(socket, request, timeout=5.0):
+    """
+    Send a request to the server and get response with proper timeout.
+
+    This improved version includes:
+    - Timeout handling
+    - Error handling
+    - Diagnostic information
+    """
+    # Record start time for diagnostics
+    start_time = time.time()
+
+    try:
+        # Send the request - add timeout to detect send failures
+        try:
+            await asyncio.wait_for(
+                socket.send_string(json.dumps(request)),
+                timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(f"Timeout sending request: {request}")
+
+        logger.info(f"Request sent: {request}")
+
+        # Wait for response with timeout
+        if await socket.poll(timeout=timeout * 1000) == 0:
+            raise TimeoutError(f"Timeout waiting for response to {request.get('action')} after {timeout} seconds")
+
+        # Receive the response with timeout
+        try:
+            response_json = await asyncio.wait_for(
+                socket.recv_string(),
+                timeout=timeout
+            )
+            return json.loads(response_json)
+        except asyncio.TimeoutError:
+            raise TimeoutError(f"Timeout receiving response for {request.get('action')}")
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON response: {e}")
+
+    except Exception as e:
+        # Add diagnostics to the error
+        elapsed = time.time() - start_time
+        diagnostic_msg = f"Error in send_request after {elapsed:.2f}s: {str(e)}"
+        print(diagnostic_msg)  # Print for immediate feedback during test run
+        raise RuntimeError(diagnostic_msg) from e
+
+
+async def wait_for_event(socket, timeout=2.0):
+    """
+    Wait for an event from the server with timeout.
+
+    This improved version includes better error handling.
+    """
+    # Wait for a message with timeout
+    if await socket.poll(timeout=timeout * 1000) == 0:
+        return None
+
+    try:
+        # Get the message with a timeout
+        _, data = await asyncio.wait_for(
+            socket.recv_multipart(),
+            timeout=timeout
+        )
+
+        # Parse and return only the data part, type was for subscribers and is also included in data
+        return json.loads(data.decode('utf-8'))
+
+    except asyncio.TimeoutError:
+        return None
+    except Exception as e:
+        print(f"Error in wait_for_event: {e}")
+        return None
+
+
+async def server_health_check(zmq_context) -> bool:
+    """
+    Verify if the server is ready by testing the health endpoint/action.
+    """
+
+    start_time = time.time()
+    test_socket = zmq_context.socket(zmq.REQ)
+    test_socket.connect(f"tcp://localhost:{TEST_REQ_PORT}")
+
+    server_ready = False
+    health_request = {"action": "health"}
+
+    # Try several times to connect to the server
+    for attempt in range(1, 11):  # 10 attempts
+        logger.info(f"Attempt to connect to the server: {attempt}")
+        try:
+            if time.time() - start_time > SERVER_STARTUP_TIMEOUT:
+                break
+
+            # Send health check request
+            await test_socket.send_string(json.dumps(health_request))
+
+            # Wait for response
+            if await test_socket.poll(timeout=1000):
+                response_json = await test_socket.recv_string()
+                response = json.loads(response_json)
+
+                if response.get("success"):
+                    server_ready = True
+                    logger.info(f"Server ready after {attempt} attempts")
+                    break
+
+        except Exception as e:
+            logger.error(f"ERROR: Attempt {attempt} failed: {e}")
+
+        # Wait before trying again
+        await asyncio.sleep(0.5)
+
+    # Clean up test socket
+    test_socket.close()
+
+    return server_ready
+
+
+################################################################################
+# Fixtures
+################################################################################
+
+@pytest_asyncio.fixture
+async def in_memory_backend():
+    """Function-scoped fixture for an in-memory backend."""
+    backend = AsyncInMemoryBackend()
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest_asyncio.fixture
+async def server(in_memory_backend, zmq_context):
+    """
+    Function-scoped fixture for AsyncRegistryServer that verifies the server
+    is ready before proceeding.
+    """
+    # Create server with specified ports
+    server = AsyncRegistryServer(
+        req_port=TEST_REQ_PORT,
+        pub_port=TEST_PUB_PORT,
+        backend=in_memory_backend,
+        cleanup_interval=1  # Fast cleanup for testing
+    )
+
+    # Start the server in a task to run in the background
+    server_task = asyncio.create_task(server.start())
+
+    server_ready = await server_health_check(zmq_context)
+
+    if not server_ready:
+        # Stop the server if it failed to start properly and raise a RuntimeError
+        await server.stop()
+        try:
+            await asyncio.wait_for(server_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+
+        raise RuntimeError(f"Server failed to start after {SERVER_STARTUP_TIMEOUT} seconds")
+
+    logger.info("Server is ready...")
+
+    yield server
+
+    # Clean shutdown
+    logger.info("Stopping server...")
+    server.stop()
+    try:
+        await asyncio.wait_for(server_task, timeout=2.0)
+    except asyncio.TimeoutError:
+        logger.warning("WARNING: Server task didn't complete in time during shutdown")
+
+
+@pytest_asyncio.fixture
+async def client(server, zmq_context):
+    """
+    Function-scoped fixture for AsyncRegistryClient with proper setup and teardown.
+    """
+    client = AsyncRegistryClient(
+        registry_req_endpoint=f"tcp://localhost:{TEST_REQ_PORT}",
+        registry_sub_endpoint=f"tcp://localhost:{TEST_PUB_PORT}",
+        request_timeout=5000  # 5 second timeout
+    )
+
+    # Verify client can connect to server
+    health = await client.health_check()
+    if not health:
+        raise RuntimeError("Client failed to connect to server")
+
+    yield client
+
+    # Proper cleanup
+    await client.close()
+
+
+@pytest_asyncio.fixture
+async def zmq_context():
+    """
+    Function-scoped fixture that provides the ZeroMQ Context.
+    """
+    context = zmq.asyncio.Context().instance()
+    logger.info("Yielding zmq context...")
+    yield context
+    logger.info("Terminating zmq context...")
+    context.term()
+
+
+@pytest_asyncio.fixture
+async def req_socket(zmq_context):
+    """
+    Function-scoped fixture for a REQ socket with proper timeout settings.
+    """
+    socket = zmq_context.socket(zmq.REQ)
+    # Set timeouts to avoid hanging
+    socket.setsockopt(zmq.LINGER, 0)  # Don't wait when closing
+    socket.setsockopt(zmq.RCVTIMEO, 5000)  # 5 second receive timeout
+    socket.setsockopt(zmq.SNDTIMEO, 5000)  # 5 second send timeout
+
+    socket.connect(f"tcp://localhost:{TEST_REQ_PORT}")
+
+    yield socket
+
+    # Properly close the socket
+    socket.close(linger=0)
+
+
+@pytest_asyncio.fixture
+async def sub_socket(zmq_context):
+    """
+    Function-scoped fixture for a SUB socket with proper timeout settings.
+    """
+    socket = zmq_context.socket(zmq.SUB)
+    # Set timeouts
+    socket.setsockopt(zmq.LINGER, 0)
+    socket.setsockopt(zmq.RCVTIMEO, 5000)
+
+    socket.connect(f"tcp://localhost:{TEST_PUB_PORT}")
+    socket.setsockopt_string(zmq.SUBSCRIBE, "")  # Subscribe to all messages
+
+    # Wait a moment for subscription to be established
+    await asyncio.sleep(0.1)
+
+    yield socket
+
+    # Properly close the socket
+    socket.close(linger=0)
+
+
+@pytest.mark.asyncio
+async def test_server_initialization(server):
+    """Test that the server initializes correctly."""
+    assert server.req_port == TEST_REQ_PORT
+    assert server.pub_port == TEST_PUB_PORT
+    assert server._running is True
+
+
+@pytest.mark.asyncio
+async def test_server_is_running(server):
+
+    # Sleep for 10s and investigate the log, server should have printed some log messages
+    await asyncio.sleep(10.0)
+
+
+@pytest.mark.asyncio
+async def test_server_health_check(server, req_socket):
+    """Test the server's health check."""
+    response = await send_request(req_socket, {"action": "health"})
+
+    assert response["success"] is True
+    assert response["status"] == "ok"
+    assert "timestamp" in response
+
+
+@pytest.mark.asyncio
+async def test_server_handles_invalid_request(server, req_socket):
+    """Test the server's handling of invalid requests."""
+    # Missing action
+    response = await send_request(req_socket, {})
+    assert response["success"] is False
+    assert "Missing required field: action" in response["error"]
+
+    # Unknown action
+    response = await send_request(req_socket, {"action": "unknown_action"})
+    assert response["success"] is False
+    assert "Unknown action" in response["error"]
+
+    # Invalid JSON - can't test directly with send_request as it uses json.dumps
+    # This would require a lower-level test with raw socket
+
+
+@pytest.mark.asyncio
+async def test_server_register_service(server, req_socket, sub_socket):
+    """Test registering a service."""
+
+    service_info = {
+        "name": "test-service",
+        "host": "localhost",
+        "port": 8080,
+        "type": "test",
+        "tags": ["test"],
+        "metadata": {"version": "1.0.0"}
+    }
+
+    response = await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": service_info
+        }
+        )
+
+    assert response["success"] is True
+    assert "service_id" in response
+
+    # Verify a registration event was published
+    event = await wait_for_event(sub_socket)
+    assert event is not None
+    assert event["type"] == "register"
+    assert "service_id" in event["data"]
+    assert event["data"]["service_info"]["name"] == "test-service"
+
+
+@pytest.mark.asyncio
+async def test_server_get_service(server, req_socket):
+    """Test getting a service by ID."""
+
+    service_info = {
+        "name": "test-service",
+        "host": "localhost",
+        "port": 8080
+    }
+
+    register_response = await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": service_info
+        }
+    )
+
+    service_id = register_response["service_id"]
+
+    # Now get the service
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+    )
+
+    assert response["success"] is True
+    assert response["service"]["id"] == service_id
+    assert response["service"]["name"] == "test-service"
+    assert response["service"]["host"] == "localhost"
+    assert response["service"]["port"] == 8080
+
+    # Try to get a non-existent service
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": "nonexistent"
+        }
+    )
+
+    assert response["success"] is False
+    assert "Service not found" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_list_services(server, req_socket):
+    """Test listing services."""
+
+    # Register a couple of services
+    await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "service-1",
+                "host": "localhost",
+                "port": 8081,
+                "type": "type-a"
+            }
+        }
+    )
+
+    await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "service-2",
+                "host": "localhost",
+                "port": 8082,
+                "type": "type-b"
+            }
+        }
+    )
+
+    # List all services
+    response = await send_request(
+        req_socket, {
+            "action": "list"
+        }
+    )
+
+    assert response["success"] is True
+    assert len(response["services"]) >= 2
+
+    # List services by type
+    response = await send_request(
+        req_socket, {
+            "action": "list",
+            "service_type": "type-a"
+        }
+    )
+
+    assert response["success"] is True
+    assert len(response["services"]) >= 1
+    assert any(s["name"] == "service-1" for s in response["services"])
+    assert not any(s["name"] == "service-2" for s in response["services"])
+
+
+@pytest.mark.asyncio
+async def test_server_discover_service(server, req_socket):
+    """Test discovering a service by type."""
+
+    await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "test-service",
+                "host": "localhost",
+                "port": 8080,
+                "type": "discovery-test"
+            }
+        }
+    )
+
+    # Discover a service
+    response = await send_request(
+        req_socket, {
+            "action": "discover",
+            "service_type": "discovery-test"
+        }
+    )
+
+    assert response["success"] is True
+    assert response["service"]["name"] == "test-service"
+    assert response["service"]["host"] == "localhost"
+    assert response["service"]["port"] == 8080
+
+    # Try to discover a non-existent service type
+    response = await send_request(
+        req_socket, {
+            "action": "discover",
+            "service_type": "nonexistent"
+        }
+    )
+
+    assert response["success"] is False
+    assert "No healthy service" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_server_deregister_service(server, req_socket, sub_socket):
+    """Test de-registering a service."""
+
+    register_response = await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "test-service",
+                "host": "localhost",
+                "port": 8080
+            }
+        }
+    )
+
+    service_id = register_response["service_id"]
+
+    # Now deregister the service
+    response = await send_request(
+        req_socket, {
+            "action": "deregister",
+            "service_id": service_id
+        }
+    )
+
+    assert response["success"] is True
+
+    # Verify a de-registration event was published, the first event is the
+    # registration which we will skip.
+    event = await wait_for_event(sub_socket)
+    assert event['type'] == 'register'
+    event = await wait_for_event(sub_socket)
+    assert event is not None
+    assert event["type"] == "deregister"
+    assert event["data"]["service_id"] == service_id
+
+    # Verify the service was deregistered
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+    )
+
+    assert response["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_server_renew_service(server, req_socket):
+    """Test renewing a service's TTL."""
+
+    register_response = await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "test-service",
+                "host": "localhost",
+                "port": 8080
+            },
+            "ttl": 5
+        }
+    )
+
+    service_id = register_response["service_id"]
+
+    # Get the initial service data
+    service_response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+    )
+
+    initial_heartbeat = service_response["service"]["last_heartbeat"]
+
+    # Wait a moment
+    await asyncio.sleep(1.0)
+
+    # Renew the service
+    response = await send_request(
+        req_socket, {
+            "action": "renew",
+            "service_id": service_id
+        }
+    )
+
+    assert response["success"] is True
+
+    # Verify the heartbeat was updated
+    service_response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+        )
+
+    assert service_response["service"]["last_heartbeat"] > initial_heartbeat
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+async def test_server_cleanup_expired_services(req_socket, sub_socket, server):
+    """Test cleanup of expired services."""
+
+    # Register a service with a short TTL
+    register_response = await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "short-lived-service",
+                "host": "localhost",
+                "port": 8080
+            },
+            "ttl": 2  # Very short TTL
+        }
+        )
+
+    service_id = register_response["service_id"]
+
+    # Wait for the service to expire and be cleaned up
+    # Should take about 2-3 seconds (TTL + cleanup interval)
+    expire_event = None
+    for _ in range(5):  # Try a few times
+        event = await wait_for_event(sub_socket, timeout=1.0)
+        if event and event["type"] == "expire" and event["data"]["service_id"] == service_id:
+            expire_event = event
+            break
+
+    assert expire_event is not None, "Service expiration event not received"
+
+    # Verify the service was removed
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+        )
+
+    assert response["success"] is False, "Service should have been removed"
+
+
+@pytest.mark.asyncio
+async def test_server_shutdown(server):
+    """Test server shutdown."""
+
+    assert server._running is True
+
+    # Stop the server
+    server.stop()
+
+    await asyncio.sleep(0.5)  # Allow the server some time to shut down
+
+    # Verify the server is no longer running
+    assert server._running is False
+
+
+# ######################################################################################################################
+# Tests for AsyncRegistryClient
+# ######################################################################################################################
+
+@pytest.mark.asyncio
+async def test_async_client_initialization(client):
+    """Test that the client initializes correctly."""
+    assert client.registry_req_endpoint == f"tcp://localhost:{TEST_REQ_PORT}"
+    assert client.registry_sub_endpoint == f"tcp://localhost:{TEST_PUB_PORT}"
+
+
+@pytest.mark.asyncio
+async def test_async_client_register(client, server):
+    """Test service registration."""
+
+    service_id = await client.register(
+        "test-client-service",
+        "localhost",
+        8080,
+        service_type="test-client",
+        metadata={"version": "1.0.0"}
+    )
+
+    assert service_id is not None
+    assert client._service_id == service_id
+    assert client._service_info is not None
+    assert client._service_info["name"] == "test-client-service"
+    assert client._service_info["type"] == "test-client"
+
+
+@pytest.mark.asyncio
+async def test_client_deregister(client, server):
+    """Test service de-registration."""
+
+    # First register
+    service_id = await client.register(
+        "test-client-service",
+        "localhost",
+        8080
+    )
+
+    assert service_id is not None
+
+    # Then deregister
+    success = await client.deregister()
+
+    assert success is True
+    assert client._service_id is None
+
+
+@pytest.mark.asyncio
+async def test_client_heartbeat(client, server, req_socket):
+    """Test service heartbeat."""
+
+    # Register the service
+    service_id = await client.register(
+        "heartbeat-test-service",
+        "localhost",
+        8080,
+        ttl=5
+    )
+
+    # Get initial heartbeat time
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+    )
+
+    initial_heartbeat = response["service"]["last_heartbeat"]
+
+    # Start heartbeat with a short interval
+    await client.start_heartbeat(interval=1)
+
+    # Wait for heartbeat to happen
+    await asyncio.sleep(1.5)
+
+    # Check if heartbeat was updated
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+        )
+
+    assert response["service"]["last_heartbeat"] > initial_heartbeat
+
+    # Stop heartbeat
+    await client.stop_heartbeat()
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+async def test_client_event_listener(client, server, req_socket):
+    """Test the client's event listener."""
+
+    # Create a mocked event handler
+    event_received = asyncio.Event()
+    event_data = {}
+
+    async def event_handler(data):
+        event_data.update(data)
+        event_received.set()
+
+    # Register the event handler and start the listener
+    client.on_event("register", event_handler)
+    await client.start_event_listener()
+
+    # Register a service to trigger an event
+    await send_request(
+        req_socket, {
+            "action": "register",
+            "service_info": {
+                "name": "event-test-service",
+                "host": "localhost",
+                "port": 8080
+            }
+        }
+    )
+
+    # Wait for the event to be processed
+    await asyncio.wait_for(event_received.wait(), timeout=5.0)
+
+    # Verify the event was received
+    assert "service_id" in event_data
+    assert "service_info" in event_data
+    assert event_data["service_info"]["name"] == "event-test-service"
+
+    # Stop the event listener
+    await client.stop_event_listener()
+
+
+@pytest.mark.asyncio
+async def test_client_discover_service(client, server):
+    """Test service discovery."""
+
+    # Register a service through the server
+    service_id = await client.register(
+        "discovery-test-service",
+        "localhost",
+        8080,
+        service_type="discovery-test"
+    )
+
+    # Discover a service
+    service = await client.discover_service("discovery-test")
+
+    assert service is not None
+    assert service["id"] == service_id
+    assert service["name"] == "discovery-test-service"
+    assert service["host"] == "localhost"
+    assert service["port"] == 8080
+
+    # Try to discover a non-existent service type
+    service = await client.discover_service("nonexistent")
+    assert service is None
+
+
+@pytest.mark.asyncio
+async def test_client_get_service(client, server):
+    """Test getting a service by ID."""
+
+    service_id = await client.register(
+        "get-test-service",
+        "localhost",
+        8080
+    )
+
+    # Get the service
+    service = await client.get_service(service_id)
+
+    assert service is not None
+    assert service["id"] == service_id
+    assert service["name"] == "get-test-service"
+
+    # Try to get a non-existent service
+    service = await client.get_service("nonexistent")
+    assert service is None
+
+
+@pytest.mark.asyncio
+async def test_client_list_services(client, server):
+    """Test listing services."""
+
+    # Register some services
+    await client.register(
+        "list-test-service-1",
+        "localhost",
+        8081,
+        service_type="type-a"
+    )
+
+    await client.register(
+        "list-test-service-2",
+        "localhost",
+        8082,
+        service_type="type-b"
+    )
+
+    # List all services
+    services = await client.list_services()
+
+    assert len(services) >= 2
+    assert any(s["name"] == "list-test-service-1" for s in services)
+    assert any(s["name"] == "list-test-service-2" for s in services)
+
+    # List services by type
+    services = await client.list_services("type-a")
+
+    assert len(services) >= 1
+    assert any(s["name"] == "list-test-service-1" for s in services)
+    assert not any(s["name"] == "list-test-service-2" for s in services)
+
+
+@pytest.mark.asyncio
+async def test_client_health_check(client, server):
+    """Test health check."""
+    health = await client.health_check()
+    assert health is True
+
+
+@pytest.mark.asyncio
+async def test_client_caching(client, server):
+    """Test client's service caching."""
+
+    service_id = await client.register(
+        "cache-test-service",
+        "localhost",
+        8080,
+        service_type="cache-test"
+    )
+
+    # Look up the service (should populate cache)
+    service = await client.get_service(service_id)
+    assert service is not None
+
+    # Check if it's in the cache
+    async with client._service_cache_lock:
+        assert service_id in client._service_cache
+
+    # Look up by type (should use cache when use_cache=True)
+    with patch.object(client, '_send_request', new_callable=AsyncMock) as mock_send:
+        # First call with use_cache=True should check cache
+        service = await client.discover_service("cache-test", use_cache=True)
+        assert service is not None
+        assert service["id"] == service_id
+
+        # Configure the mock to return a dictionary that matches what _send_request would return
+        mock_send.return_value = {
+            'success': True,
+            'service': {
+                'id': service_id,
+                'name': 'cache-test-service',
+                'host': 'localhost',
+                'port': 8080,
+                'type': 'cache-test'
+            }
+        }
+
+        # Second call with use_cache=False should make a request
+        service = await client.discover_service("cache-test", use_cache=False)
+        assert service is not None
+        assert mock_send.called
+
+
+@pytest.mark.asyncio
+async def test_client_register_context(client, server, req_socket):
+    """Test the register_context context manager."""
+
+    # Use the context manager
+    async with client.register_context(
+            "context-test-service",
+            "localhost",
+            8080,
+            service_type="context-test"
+    ) as service_id:
+        # Verify the service was registered
+        response = await send_request(
+            req_socket, {
+                "action": "get",
+                "service_id": service_id
+            }
+        )
+
+        assert response["success"] is True
+        assert response["service"]["name"] == "context-test-service"
+
+    # After exiting the context, the service should be deregistered
+    response = await send_request(
+        req_socket, {
+            "action": "get",
+            "service_id": service_id
+        }
+    )
+
+    assert response["success"] is False

--- a/libs/cgse-core/tests/test_server_running.py
+++ b/libs/cgse-core/tests/test_server_running.py
@@ -1,0 +1,150 @@
+"""
+Test to verify the server is running in the background.
+
+Start the test as follows (with pytest):
+
+    $ uv run pytest -v --setup-show tests/test_server_running.py
+
+Start the test wihout pytest:
+
+    $ uv run py tests/test_server_running.py
+"""
+
+import asyncio
+import json
+import logging
+import time
+
+import pytest
+import zmq
+import zmq.asyncio
+
+from egse.registry.backend import AsyncInMemoryBackend
+from egse.registry.server import AsyncRegistryServer
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+           "%(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+)
+
+logger = logging.getLogger("test_registry_service")
+
+TEST_REQ_PORT = 15556
+TEST_PUB_PORT = 15557
+
+SERVER_STARTUP_TIMEOUT = 5
+
+
+async def server_health_check(zmq_context):
+
+    # Verify server is ready by testing the health endpoint
+    start_time = time.time()
+    test_socket = zmq_context.socket(zmq.REQ)
+    test_socket.connect(f"tcp://localhost:{TEST_REQ_PORT}")
+
+    server_ready = False
+    health_request = {"action": "health"}
+
+    # Try several times to connect to the server
+    for attempt in range(1, 11):  # 10 attempts
+        logger.info(f"Attempt to connect to the server: {attempt}")
+        try:
+            if time.time() - start_time > SERVER_STARTUP_TIMEOUT:
+                break
+
+            # Send health check request
+            await test_socket.send_string(json.dumps(health_request))
+
+            # Wait for response
+            if await test_socket.poll(timeout=1000):
+                response_json = await test_socket.recv_string()
+                response = json.loads(response_json)
+
+                if response.get("success"):
+                    server_ready = True
+                    logger.info(f"Server ready after {attempt} attempts")
+                    break
+
+        except Exception as e:
+            logger.error(f"ERROR: Attempt {attempt} failed: {e}")
+
+        # Wait before trying again
+        await asyncio.sleep(0.5)
+
+    # Clean up test socket
+    test_socket.close()
+
+    return server_ready
+
+
+async def start_server():
+    """
+    Session-scoped fixture for AsyncRegistryServer that verifies the server
+    is ready before proceeding.
+    """
+    zmq_context = zmq.asyncio.Context()
+
+    backend = AsyncInMemoryBackend()
+    await backend.initialize()
+
+    # Create server with specified ports
+    server = AsyncRegistryServer(
+        req_port=TEST_REQ_PORT,
+        pub_port=TEST_PUB_PORT,
+        backend=backend,
+        cleanup_interval=1  # Fast cleanup for testing
+    )
+
+    # Start the server in a task
+    server_task = asyncio.create_task(server.start())
+
+    server_ready = await server_health_check(zmq_context)
+
+    if not server_ready:
+        # Stop the server if it failed to start properly
+        await server.stop()
+        try:
+            await asyncio.wait_for(server_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+
+        raise RuntimeError(f"Server failed to start after {SERVER_STARTUP_TIMEOUT} seconds")
+
+    logger.info("Server is ready...")
+
+    # Yield the server for tests to use
+    return server, server_task
+
+
+async def stop_server(server, server_task):
+    # Clean shutdown
+    logger.info("Stopping server...")
+
+    server.stop()
+
+    try:
+        await asyncio.wait_for(server_task, timeout=2.0)
+    except asyncio.TimeoutError:
+        logger.warning("WARNING: Server task didn't complete in time during shutdown")
+
+
+@pytest.mark.asyncio
+async def test_server_running():
+
+    await main()
+
+
+async def main():
+
+    server, server_task = await start_server()
+
+    await asyncio.sleep(10.0)
+
+    await stop_server(server, server_task)
+
+
+# This allows you to run the test without using pytest
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/libs/cgse-core/tests/test_server_running_with_fixture.py
+++ b/libs/cgse-core/tests/test_server_running_with_fixture.py
@@ -1,0 +1,148 @@
+"""
+Test to verify the server is running in the background.
+
+Start the test as follows:
+
+    $ uv run pytest -v --setup-show tests/test_server_running_with_fixture.py
+
+"""
+
+import asyncio
+import json
+import logging
+import time
+
+import pytest
+import pytest_asyncio
+import zmq
+import zmq.asyncio
+
+from egse.registry.backend import AsyncInMemoryBackend
+from egse.registry.server import AsyncRegistryServer
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="[%(asctime)s] %(threadName)-12s %(levelname)-8s "
+           "%(name)-12s %(lineno)5d:%(module)-20s %(message)s",
+)
+
+logger = logging.getLogger("test_registry_service")
+
+TEST_REQ_PORT = 15556
+TEST_PUB_PORT = 15557
+
+SERVER_STARTUP_TIMEOUT = 5
+
+
+async def server_health_check(zmq_context):
+
+    # Verify server is ready by testing the health endpoint
+    start_time = time.time()
+    test_socket = zmq_context.socket(zmq.REQ)
+    test_socket.connect(f"tcp://localhost:{TEST_REQ_PORT}")
+
+    server_ready = False
+    health_request = {"action": "health"}
+
+    # Try several times to connect to the server
+    for attempt in range(1, 11):  # 10 attempts
+        logger.info(f"Attempt to connect to the server: {attempt}")
+        try:
+            if time.time() - start_time > SERVER_STARTUP_TIMEOUT:
+                break
+
+            # Send health check request
+            await test_socket.send_string(json.dumps(health_request))
+
+            # Wait for response
+            if await test_socket.poll(timeout=1000):
+                response_json = await test_socket.recv_string()
+                response = json.loads(response_json)
+
+                if response.get("success"):
+                    server_ready = True
+                    logger.info(f"Server ready after {attempt} attempts")
+                    break
+
+        except Exception as e:
+            logger.error(f"ERROR: Attempt {attempt} failed: {e}")
+
+        # Wait before trying again
+        await asyncio.sleep(0.5)
+
+    # Clean up test socket
+    test_socket.close()
+
+    return server_ready
+
+
+@pytest_asyncio.fixture(scope="session")
+async def zmq_context():
+    """Session-scoped fixture for ZeroMQ context."""
+    context = zmq.asyncio.Context()
+    logger.info("Yielding zmq context...")
+    yield context
+    logger.info("Terminating zmq context...")
+    context.term()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def in_memory_backend():
+    """Fixture for an in-memory backend."""
+    backend = AsyncInMemoryBackend()
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def server(zmq_context, in_memory_backend):
+    """
+    Session-scoped fixture for AsyncRegistryServer that verifies the server
+    is ready before proceeding.
+    """
+
+    # Create server with specified ports
+    server = AsyncRegistryServer(
+        req_port=TEST_REQ_PORT,
+        pub_port=TEST_PUB_PORT,
+        backend=in_memory_backend,
+        cleanup_interval=1  # Fast cleanup for testing
+    )
+
+    # Start the server in a task
+    server_task = asyncio.create_task(server.start())
+
+    server_ready = await server_health_check(zmq_context)
+
+    if not server_ready:
+        # Stop the server if it failed to start properly
+        await server.stop()
+        try:
+            await asyncio.wait_for(server_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+
+        raise RuntimeError(f"Server failed to start after {SERVER_STARTUP_TIMEOUT} seconds")
+
+    logger.info("Server is ready...")
+
+    yield server
+
+    # Clean shutdown
+    logger.info("Stopping server...")
+
+    server.stop()
+
+    try:
+        await asyncio.wait_for(server_task, timeout=2.0)
+    except asyncio.TimeoutError:
+        logger.warning("WARNING: Server task didn't complete in time during shutdown")
+
+
+@pytest.mark.asyncio
+async def test_server_running_with_fixture(server):
+
+    # Wait to see log messages from the server appearing
+
+    await asyncio.sleep(10.0)

--- a/libs/cgse-core/tests/test_zmq_microservice.py
+++ b/libs/cgse-core/tests/test_zmq_microservice.py
@@ -1,0 +1,36 @@
+import pytest
+
+from egse.registry.service import ZMQMicroservice
+from egse.system import get_host_ip
+
+
+@pytest.mark.asyncio
+async def test_zmq_microservice_initialization():
+
+    print()
+
+    service = ZMQMicroservice("vanilla", "plain")
+
+    assert service.service_name == "vanilla"
+    assert service.service_type == "plain"
+    assert service.host_ip == get_host_ip()
+
+    print(f"{service.rep_port = }")
+
+    assert service.rep_port != 0
+
+    await service._cleanup()
+
+
+# Registration to the service registry will time out in 5s
+@pytest.mark.timeout(10)
+@pytest.mark.asyncio
+async def test_zmq_microservices_registration(caplog):
+
+    print()
+
+    service = ZMQMicroservice("vanilla", "plain")
+
+    caplog.clear()
+    await service.start()
+    assert "Failed to register with the service registry" in caplog.text


### PR DESCRIPTION
The main functionality added is the registry service which is part of the core services. The idea is that this registry serves as a service point for all core services and device servers. Any of these processes registers to the service registry with information about their status, hostname, port numbers, and metadata. The service registry will keep track of the health of the registered services by monitoring their heartbeat. When a process or script needs a service, it will request the information it needs to contact the service from the service registry. 

Two backend options have been implemented, an *AsyncInMemoryBackend* and a *AsyncSQLiteBackend*, both implement the *AsyncRegistryBackend* protocol. The former is mainly for test purposes, the latter will be used in production.

Summary of the changes:

*decorators.py*
- added `implements_protocol` decorator to verify protocol compliance at runtime
*system.py*
- added `TyperAsyncCommand` to define commands that need to run in an event loop. 
*zmq_ser.py*
- added a function to extract the port number from the ZeroMQ endpoint

*cgse_core*
- added a service registry (`egse.registry`). 
- The *cgse core* command is updated to start, stop and request status of the service registry
- The *cgse show* command is updated to show also the registry server process
- The *log_cs* has some added information in the status report

*unit tests*
- individual tests for the backends, the registry service client and the server
- a few scripts to test a microservices implementation
