### PR TITLE
maintenance service registry

### DIFF
--- a/libs/cgse-common/noxfile.py
+++ b/libs/cgse-common/noxfile.py
@@ -29,7 +29,7 @@ def uv_tests(session: nox.Session):
     session.run(*uv_run_cmd, "pytest", "-v", *session.posargs)
 
 
-@nox.session(python=python_versions)
+@nox.session(python=python_versions, default=False)
 def py_tests(session: nox.Session):
     """
     Run the unit and regular tests using plain Python.

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.7.0"
+version = "0.7.1"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -95,6 +95,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.14.0",
     "ruff>=0.9.0",

--- a/libs/cgse-common/src/egse/exceptions.py
+++ b/libs/cgse-common/src/egse/exceptions.py
@@ -57,3 +57,7 @@ class InternalError(Error):
 
 class Abort(RuntimeError):
     """Internal Exception to signal a process to abort."""
+
+
+class InitialisationError(Error):
+    """Raised when an initialisation failed."""

--- a/libs/cgse-common/src/egse/zmq_ser.py
+++ b/libs/cgse-common/src/egse/zmq_ser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import pickle
 import zlib
 from enum import IntEnum
@@ -56,6 +57,41 @@ def get_port_number(socket: zmq.Socket) -> int | None:
         return int(port)
     else:
         return None
+
+
+def zmq_string_request(request: str) -> list:
+    return [
+        b"MESSAGE_TYPE:STRING",
+        request.encode('utf-8'),
+    ]
+
+
+def zmq_string_response(message: str) -> list:
+    return [
+        b"MESSAGE_TYPE:STRING",
+        message.encode('utf-8'),
+    ]
+
+
+def zmq_json_request(request: dict) -> list:
+    return [
+        b"MESSAGE_TYPE:JSON",
+        json.dumps(request).encode(),
+    ]
+
+
+def zmq_json_response(message: dict) -> list:
+    return [
+        b"MESSAGE_TYPE:JSON",
+        json.dumps(message).encode(),
+    ]
+
+
+def zmq_error_response(message: dict) -> list:
+    return [
+        b"MESSAGE_TYPE:ERROR",
+        pickle.dumps(message),
+    ]
 
 
 class MessageIdentifier(IntEnum):

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.7.0"
+version = "0.7.1"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -51,7 +51,7 @@ filterwarnings = [
     "ignore::DeprecationWarning"
 ]
 log_cli = true
-log_cli_level = "WARNING"
+log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.7.0"
+version = "0.7.1"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/cgse_core/_status.py
+++ b/libs/cgse-core/src/cgse_core/_status.py
@@ -10,28 +10,31 @@ from egse.registry.client import AsyncRegistryClient
 
 async def run_all_status(full: bool = False):
     tasks = [
-        status_rs_cs(),
-        status_log_cs(),
-        status_sm_cs(full),
-        status_cm_cs(),
+        asyncio.create_task(status_rs_cs()),
+        asyncio.create_task(status_log_cs()),
+        asyncio.create_task(status_sm_cs(full)),
+        asyncio.create_task(status_cm_cs()),
     ]
 
     await asyncio.gather(*tasks)
 
 
 async def status_rs_cs():
-    client = AsyncRegistryClient()
-    response = await client.server_status()
+    with AsyncRegistryClient() as client:
+        response = await client.server_status()
 
-    status_report = textwrap.dedent(
-        f"""\
-        Registry Service:
-            Status: {response['status']}
-            Requests port: {response['req_port']}
-            Notifications port: {response['pub_port']}
-            Registrations: {", ".join([f"({x['name']}, {x['health']})" for x in response['services']])}\
-        """
-    )
+    if response['success']:
+        status_report = textwrap.dedent(
+            f"""\
+            Registry Service:
+                Status: {response['status']}
+                Requests port: {response['req_port']}
+                Notifications port: {response['pub_port']}
+                Registrations: {", ".join([f"({x['name']}, {x['health']})" for x in response['services']])}\
+            """
+        )
+    else:
+        status_report = "Registry Service: not active"
 
     rich.print(status_report)
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import rich
 import typer
@@ -42,6 +43,11 @@ def stop_core_services():
 def status_core_services(full: bool = False):
     """Print the status of the core services."""
     # from scripts._status import status_log_cs, status_sm_cs, status_cm_cs
+
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="[%(asctime)s] %(threadName)-12s %(levelname)-8s %(name)-20s %(lineno)5d:%(module)-20s %(message)s",
+    )
 
     rich.print("[green]Status of the core services...[/]")
 

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.7.0"
+version = "0.7.1"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.7.0"
+version = "0.7.1"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.7.0"
+version = "0.7.1"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}
@@ -30,7 +30,7 @@ dependencies = [
 test = ["pytest", "pytest-mock", "pytest-cov"]
 
 [project.scripts]
-daq6510_cs = 'egse.tempcontrol.keithley.daq6510_cs:cli'
+daq6510_cs = 'egse.tempcontrol.keithley.daq6510_cs:app'
 daq6510_sim = 'egse.tempcontrol.keithley.daq6510_sim:app'
 
 [project.gui-scripts]
@@ -44,6 +44,12 @@ keithley-tempcontrol = "keithley_tempcontrol:settings.yaml"
 
 [project.entry-points."cgse.service"]
 daq6510 = 'keithley_tempcontrol.cgse_services:daq6510'
+
+[project.entry-points."cgse.explore"]
+explore = "keithley_tempcontrol.cgse_explore"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.hatch.build.targets.sdist]
 exclude = [

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.7.0"
+version = "0.7.1"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.7.0"
+version = "0.7.1"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.7.0"
+version = "0.7.1"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.7.0"
+version = "0.7.1"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.7.0"
+version = "0.7.1"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
- added InitialisationError
- editorial changes and added two functions: `get_current_location` and `log_rich_output`
- added some convenience functions to create requests and responses.
- disable py_tests, use uv_tests by default
- added pytest-asyncio
- added connect/disconnect and context manager functions, optional timeout for _send_request
- added logging
- fixed status report for service registry
- bump 0.7.0 -> 0.7.1