### PR TITLE
improve synchronous  RegistryClient

### DIFF
--- a/libs/cgse-core/src/egse/registry/service.py
+++ b/libs/cgse-core/src/egse/registry/service.py
@@ -95,6 +95,7 @@ class ZMQMicroservice:
             registry_req_endpoint=self.registry_req_endpoint,
             registry_sub_endpoint=self.registry_sub_endpoint
         )
+        self.registry_client.connect()
 
         self.command_handlers = {}
 

--- a/libs/cgse-core/tests/script_test_async_registry_client.py
+++ b/libs/cgse-core/tests/script_test_async_registry_client.py
@@ -42,6 +42,7 @@ async def run_async_client():
         Sends a command to a microservice.
         """
         registry_client = AsyncRegistryClient()
+        registry_client.connect()
 
         try:
             service = await registry_client.discover_service(service_type)
@@ -75,6 +76,7 @@ async def run_async_client():
                 socket.close()
         finally:
             await registry_client.close()
+            registry_client.disconnect()
 
     # Function to subscribe to service events
     async def subscribe_to_events(service_type, event_types):

--- a/libs/cgse-core/tests/script_test_sync_registry_client.py
+++ b/libs/cgse-core/tests/script_test_sync_registry_client.py
@@ -36,6 +36,7 @@ def run_client():
         Sends a command to a microservice.
         """
         registry_client = RegistryClient()
+        registry_client.connect()
 
         try:
             service = registry_client.discover_service(service_type)
@@ -69,6 +70,7 @@ def run_client():
                 socket.close()
         finally:
             registry_client.close()
+            registry_client.disconnect()
 
     def subscribe_to_events(service_type, event_types):
         # Create a registry client


### PR DESCRIPTION
Improved the synchronous RegistryClient:

- added connect() and disconnect() methods
- can now be used as a context manager

Also unit tests are fixed. 