### PR TITLE
Started migration to InfluxDB3

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pyzmq>=25.1.0; python_version >= '3.10'",
     # Python 3.10+ entrypoints interface changed
     "importlib_metadata>=4.6.0; python_version == '3.9'",
+    "influxdb3-python",
 ]
 
 [project.scripts]

--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -274,6 +274,7 @@ class DummyProtocol(CommandProtocol):
 
     def quit(self):
         _LOGGER.info("Executing 'quit()' on DummyProtocol.")
+        self.client.close()
 
 
 class DummyControlServer(ControlServer):

--- a/libs/cgse-common/src/egse/protocol.py
+++ b/libs/cgse-common/src/egse/protocol.py
@@ -9,6 +9,11 @@ command definitions.
 """
 from __future__ import annotations
 
+import os
+
+from influxdb_client_3 import InfluxDBClient3
+from influxdb_client_3.write_client.domain.write_precision import WritePrecision
+
 __all__ = [
     "get_method",
     "get_function",
@@ -362,6 +367,11 @@ class CommandProtocol(BaseCommandProtocol, metaclass=abc.ABCMeta):
         super().__init__(control_server)
         self._commands = {}  # variable is used by subclasses
         self._method_lookup = {}  # lookup table for device methods
+
+        token = os.environ["INFLUXDB3_AUTH_TOKEN"]
+        project = os.environ["PROJECT"]
+        self.client = InfluxDBClient3(database=project, host="http://localhost:8181", token=token)
+        self.metrics_time_precision = WritePrecision.MS
 
     def send_commands(self):
         """

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -124,7 +124,6 @@ from typing import Union
 import git
 import rich
 from git import GitCommandError
-from prometheus_client import Gauge
 
 from egse.command import ClientServerCommand
 from egse.command import stringify_function_call
@@ -169,8 +168,8 @@ CTRL_SETTINGS = Settings.load("Configuration Manager Control Server")
 SITE_ID = get_site_id()
 COMMAND_SETTINGS = Settings.load(location=HERE, filename="confman.yaml")
 
-CM_SETUP_ID = Gauge("CM_SETUP_ID", 'Setup ID')
-CM_TEST_ID = Gauge("CM_TEST_ID", 'Test ID')
+# CM_SETUP_ID = Gauge("CM_SETUP_ID", 'Setup ID')
+# CM_TEST_ID = Gauge("CM_TEST_ID", 'Test ID')
 
 PROXY_TIMEOUT = 10_000  # don't wait longer than 10s by default
 

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -111,11 +111,9 @@ from __future__ import annotations
 
 import logging
 import operator
-import os
 import subprocess
 import textwrap
 import threading
-import time
 from pathlib import Path
 from typing import NamedTuple
 from typing import Optional
@@ -123,7 +121,9 @@ from typing import Union
 
 import git
 import rich
+import time
 from git import GitCommandError
+from influxdb_client_3 import Point
 
 from egse.command import ClientServerCommand
 from egse.command import stringify_function_call
@@ -1063,8 +1063,16 @@ class ConfigurationManagerProtocol(CommandProtocol):
 
         # Update the metrics
 
-        CM_SETUP_ID.set(float(setup_id))
-        CM_TEST_ID.set(float(test_id))
+        origin = self.control_server.get_storage_mnemonic()
+
+        metrics_dictionary = {
+            "measurement": origin.lower(),  # Table name
+            "tags": {"site_id": site_id, "origin": origin},  # Site ID, Origin
+            "fields": dict((hk_name.lower(), hk[hk_name]) for hk_name in hk if hk_name != "timestamp"),
+            "time": hk["timestamp"]
+        }
+        point = Point.from_dict(metrics_dictionary, write_precision=self.metrics_time_precision)
+        self.client.write(point)
 
         return hk
 

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1071,6 +1071,7 @@ class ConfigurationManagerProtocol(CommandProtocol):
 
     def quit(self):
         self.controller.quit()
+        self.client.close()
 
 
 # The following functions are defined here to allow them to be used in the list_setups() method

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -190,6 +190,7 @@ class ProcessManagerProtocol(CommandProtocol):
 
     def quit(self):
         self.controller.quit()
+        self.client.close()
 
 
 class ProcessManagerCommand(ClientServerCommand):


### PR DESCRIPTION
# Summary of the changes

- Added the dependency `influxdb3-python` to the `pyproject.toml` file for `cgse-common`.  For now, I have not removed the `prometheus-client` dependency, as not all processes have their metrics migrated to InfluxDB3.  This will be done at a later stage.
- Upon initialisation of a `CommandProtocol`, I now create an `InfluxDB3Client`, which is used in the device protocol to add metrics to the InfluxDB database.
- For the Configuration Manager, the metrics are now added to InfluxDB rather than Prometheus.

# Related issues

#108 

# Test results

## Setup
Tested on my own laptop with the following configuration:

- InfluxDB3 Core installed and running locally;
- Grafana installed and running locally;
- CGSE core services running;
- Created a Grafana dashboard, showing, e.g., `CM_SETUP_ID`.

## Results

- Table `CM_CS` created in the project database;
- Metrics of the Configuration Manager is being added to this table, as can be seen from:
     - Query on the database (via command line);
     - Plot on the Grafana dashboard I created.

## Screenshots

Note that in the screenshots below, the name of my database was still "TEST2".

### Grafana dashboard

<img width="1088" alt="Screenshot 2025-05-02 at 15 15 50" src="https://github.com/user-attachments/assets/83cd390e-559a-44c4-ba6c-b2f4f5a9797e" />

### Command line query

<img width="1270" alt="Screenshot 2025-05-02 at 15 17 17" src="https://github.com/user-attachments/assets/d37b4682-bc64-4b1c-964b-9d710c016e9e" />
