### PR TITLE
Handle potential problems with the connection to InfluxDB 

### DIFF
--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -274,7 +274,9 @@ class DummyProtocol(CommandProtocol):
 
     def quit(self):
         _LOGGER.info("Executing 'quit()' on DummyProtocol.")
-        self.client.close()
+
+        if self.client:
+            self.client.close()
 
 
 class DummyControlServer(ControlServer):

--- a/libs/cgse-common/src/egse/protocol.py
+++ b/libs/cgse-common/src/egse/protocol.py
@@ -368,10 +368,17 @@ class CommandProtocol(BaseCommandProtocol, metaclass=abc.ABCMeta):
         self._commands = {}  # variable is used by subclasses
         self._method_lookup = {}  # lookup table for device methods
 
-        token = os.environ["INFLUXDB3_AUTH_TOKEN"]
-        project = os.environ["PROJECT"]
-        self.client = InfluxDBClient3(database=project, host="http://localhost:8181", token=token)
+        token = os.getenv("INFLUXDB3_AUTH_TOKEN")
+        project = os.getenv("PROJECT")
         self.metrics_time_precision = WritePrecision.MS
+
+        if project and token:
+            self.client = InfluxDBClient3(database=project, host="http://localhost:8181", token=token)
+        else:
+            self.client = None
+            logger.warning("INFLUXDB3_AUTH_TOKEN and/or PROJECT environment variable is not set.  Metrics cannot not be "
+                           "propagated to InfluxDB.")
+
 
     def send_commands(self):
         """

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1086,7 +1086,9 @@ class ConfigurationManagerProtocol(CommandProtocol):
 
     def quit(self):
         self.controller.quit()
-        self.client.close()
+
+        if self.client:
+            self.client.close()
 
 
 # The following functions are defined here to allow them to be used in the list_setups() method

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1066,8 +1066,9 @@ class ConfigurationManagerProtocol(CommandProtocol):
 
         # Update the metrics
 
+        origin = self.control_server.get_storage_mnemonic()
+
         try:
-            origin = self.control_server.get_storage_mnemonic()
             metrics_dictionary = {
                 "measurement": origin.lower(),  # Table name
                 "tags": {"site_id": site_id, "origin": origin},  # Site ID, Origin
@@ -1077,7 +1078,9 @@ class ConfigurationManagerProtocol(CommandProtocol):
             point = Point.from_dict(metrics_dictionary, write_precision=self.metrics_time_precision)
             self.client.write(point)
         except NewConnectionError:
-            pass
+            LOGGER.warning(f"No connection to InfluxDB could be established to propagate {origin} metrics")
+        except AttributeError as exc:
+            LOGGER.warning(f"Could not write {origin} metrics to InfluxDB ({exc})")
 
         return hk
 

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -190,7 +190,9 @@ class ProcessManagerProtocol(CommandProtocol):
 
     def quit(self):
         self.controller.quit()
-        self.client.close()
+
+        if self.client:
+            self.client.close()
 
 
 class ProcessManagerCommand(ClientServerCommand):

--- a/projects/generic/keithley-tempcontrol/src/egse/tempcontrol/keithley/daq6510_protocol.py
+++ b/projects/generic/keithley-tempcontrol/src/egse/tempcontrol/keithley/daq6510_protocol.py
@@ -100,4 +100,6 @@ class DAQ6510Protocol(CommandProtocol):
 
         # TODO
         # self.synoptics.disconnect_cs()
-        pass
+
+        if self.client:
+            self.client.close()


### PR DESCRIPTION
# Summary of the changes

- Missing environment variables `PROJECT` and/or `INFLUXDB3_AUTH_TOKEN`:
     - Log warning message;
     - `self.client` will be `None`;
     - Check for this when writing metrics to InfluxDB (in the `get_housekeeping` method in the device protocols);
     - Check for this when calling the `quit` method of the device protocol (when the CS is stopped);
- InfluxDB not running:
     - Log warning message;
     - Device protocol automatically picks up on a (re-)start of InfluxDB.

# Related issues

#108 

# Impact on commanding

None

# Test results

See #109 and #111.