### PR TITLE
Metrics populated (generically) from `ControlServer` instead of device protocols

### DIFF
--- a/libs/cgse-common/src/egse/dummy.py
+++ b/libs/cgse-common/src/egse/dummy.py
@@ -275,9 +275,6 @@ class DummyProtocol(CommandProtocol):
     def quit(self):
         _LOGGER.info("Executing 'quit()' on DummyProtocol.")
 
-        if self.client:
-            self.client.close()
-
 
 class DummyControlServer(ControlServer):
     """

--- a/libs/cgse-common/src/egse/protocol.py
+++ b/libs/cgse-common/src/egse/protocol.py
@@ -9,11 +9,6 @@ command definitions.
 """
 from __future__ import annotations
 
-import os
-
-from influxdb_client_3 import InfluxDBClient3
-from influxdb_client_3.write_client.domain.write_precision import WritePrecision
-
 __all__ = [
     "get_method",
     "get_function",
@@ -367,18 +362,6 @@ class CommandProtocol(BaseCommandProtocol, metaclass=abc.ABCMeta):
         super().__init__(control_server)
         self._commands = {}  # variable is used by subclasses
         self._method_lookup = {}  # lookup table for device methods
-
-        token = os.getenv("INFLUXDB3_AUTH_TOKEN")
-        project = os.getenv("PROJECT")
-        self.metrics_time_precision = WritePrecision.MS
-
-        if project and token:
-            self.client = InfluxDBClient3(database=project, host="http://localhost:8181", token=token)
-        else:
-            self.client = None
-            logger.warning("INFLUXDB3_AUTH_TOKEN and/or PROJECT environment variable is not set.  Metrics cannot not be "
-                           "propagated to InfluxDB.")
-
 
     def send_commands(self):
         """

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1089,9 +1089,6 @@ class ConfigurationManagerProtocol(CommandProtocol):
     def quit(self):
         self.controller.quit()
 
-        if self.client:
-            self.client.close()
-
 
 # The following functions are defined here to allow them to be used in the list_setups() method
 # and be pickled and passed over ZeroMQ.

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -1062,28 +1062,6 @@ class ConfigurationManagerProtocol(CommandProtocol):
             "CM_GIT_VERSION": self.git_version,
         }
 
-        # Update the metrics
-
-        # Update the metrics
-
-        origin = self.control_server.get_storage_mnemonic()
-
-        try:
-            if self.client:
-                metrics_dictionary = {
-                    "measurement": origin.lower(),  # Table name
-                    "tags": {"site_id": site_id, "origin": origin},  # Site ID, Origin
-                    "fields": dict((hk_name.lower(), hk[hk_name]) for hk_name in hk if hk_name != "timestamp"),
-                    "time": hk["timestamp"]
-                }
-                point = Point.from_dict(metrics_dictionary, write_precision=self.metrics_time_precision)
-                self.client.write(point)
-            else:
-                LOGGER.warning(f"Could not write {origin} metrics to InfluxDB (self.client is None).")
-        except NewConnectionError:
-            LOGGER.warning(f"No connection to InfluxDB could be established to propagate {origin} metrics.  Check "
-                           f"whether this service is (still) running.")
-
         return hk
 
     def quit(self):

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -191,10 +191,6 @@ class ProcessManagerProtocol(CommandProtocol):
     def quit(self):
         self.controller.quit()
 
-        if self.client:
-            self.client.close()
-
-
 class ProcessManagerCommand(ClientServerCommand):
 
     """


### PR DESCRIPTION
# Summary of the changes

In the `serve` method of the `ControlServer` class, in the section where we store the HK information to a dedicated CSV file, we call a new method, `propagate_metrics`, which propagates the HK to InfluxDB.  That way, everything metrics-related has been moved out of the device protocols, which is cleaner and avoids double work.

# Related issues

#108 

# Impact on commanding

None

# Test results

Tested in a similar fashion as in #109, #111, and #113.