### PR TITLE
Migrating LakeShore336 from plato-common-egse

### DIFF
--- a/libs/cgse-common/src/egse/control.py
+++ b/libs/cgse-common/src/egse/control.py
@@ -103,12 +103,13 @@ class ControlServer(metaclass=abc.ABCMeta):
 
     """
 
-    def __init__(self):
+    def __init__(self, device_id: str = None):
         """Initialisation of a new Control Server."""
 
         from egse.monitoring import MonitoringProtocol
         from egse.services import ServiceProtocol
 
+        self.device_id = device_id
         self._process_status = ProcessStatus()
 
         self._timer_thread = threading.Thread(

--- a/projects/generic/keithley-tempcontrol/src/egse/tempcontrol/keithley/daq6510_protocol.py
+++ b/projects/generic/keithley-tempcontrol/src/egse/tempcontrol/keithley/daq6510_protocol.py
@@ -101,5 +101,4 @@ class DAQ6510Protocol(CommandProtocol):
         # TODO
         # self.synoptics.disconnect_cs()
 
-        if self.client:
-            self.client.close()
+        pass

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,0 +1,69 @@
+[project]
+name = "lakeshore-tempcontrol"
+version = "2025.0.1"
+description = "Lakeshore Temperature Control for CGSE"
+authors = [
+    {name = "IVS KU Leuven"}
+]
+maintainers = [
+    {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},
+    {name = "Sara Regibo", email = "sara.regibo@kuleuven.be"}
+]
+readme = {"file" = "README.md", "content-type" = "text/markdown"}
+requires-python = ">=3.9"
+license = "MIT"
+keywords = [
+    "CGSE",
+    "Common-EGSE",
+    "hardware testing",
+    "software framework",
+    "temperature control",
+]
+dependencies = [
+    "cgse-common",
+    "cgse-core",
+    "cgse-gui",
+    "PyQt5>=5.15.11",
+    "rich",
+]
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-mock", "pytest-cov"]
+
+[project.scripts]
+lakeshore336_cs = 'egse.tempcontrol.lakeshore.lakeshore336_cs:cli'
+
+[project.gui-scripts]
+lakeshore336_ui = "egse.tempcontrol.lakeshore.lakeshore336_ui:main"
+
+[project.entry-points."cgse.version"]
+lakeshore-tempcontrol = 'egse.version:get_version_installed'
+
+[project.entry-points."cgse.settings"]
+lakeshore-tempcontrol = "lakeshore_tempcontrol:settings.yaml"
+
+[project.entry-points."cgse.service"]
+lakeshore336 = 'lakeshore_tempcontrol.cgse_services:lakeshore336'
+
+[project.entry-points."cgse.explore"]
+explore = "lakeshore_tempcontrol.cgse_explore"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/tests",
+    "/pytest.ini",
+    "/.gitignore",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/egse", "src/lakeshore_tempcontrol"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+extend-select = ["E501"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
@@ -1,5 +1,130 @@
-class LakeShore336Proxy(Proxy, Lakeshore336Interface):
+from enum import IntEnum
+
+from egse.device import DeviceInterface
+from egse.mixin import dynamic_command, CommandType, add_lf
+from egse.proxy import Proxy
+from egse.randomwalk import RandomWalk
+from egse.settings import Settings
+from egse.tempcontrol.lakeshore.lakeshore336_devif import LakeShore336EthernetInterface
+from egse.zmq_ser import connect_address
+CTRL_SETTINGS = Settings.load("LakeShore336 Control Server")
+
+def split_response (response) -> list[float]:
+    return response.split(",")
+
+
+class SelfTestResult(IntEnum):
+    """ Possible results of the selftest."""
+
+    NO_ERRORS_FOUND = 0
+    ERRORS_FOUND = 1
+
+
+class AutotuneMode(IntEnum):
+    """ Possible autotune modes."""
+
+    PROPORTIONAL = P = 0                            # P only
+    PROPORTIONAL_INTEGRAL = PI = 1                  # P and I
+    PROPORTIONAL_INTEGRAL_DERIVATIVE = PID = 2      # P, I, and D
+
+
+class HeaterQuantity(IntEnum):
+    """ Possible heater quantities."""
+
+    CURRENT = 1
+    POWER = 2
+
+
+class HeaterRange(IntEnum):
+    """ Possible heater ranges."""
+
+    OFF = 0         # Output 1 - 4
+    LOW = 1         # Output 1 & 2
+    MEDIUM = 2      # Output 1 & 2
+    HIGH = 3        # Output 1 & 2
+
+    ON = 1          # Output 3 & 4
+
+
+class Mode(IntEnum):
+    """ Possible operating modes."""
+
+    LOCAL = 0
+    REMOTE = 1
+    REMOTE_WITH_LOCAL_LOCKOUT =2
+
+
+class DisplayMode(IntEnum):
+    """ Possible display modes."""
+
+    INPUT_A = 0
+    INPUT_B = 1
+    INPUT_C = 2
+    INPUT_D = 3
+    CUSTOM = 4
+    FOUR_LOOP = 5
+    ALL_INPUTS = 6
+
+
+class SensorType(IntEnum):
+    """ Possible sensor types."""
+
+    DISABLED = 0
+    DIODE = 1           # 3062 option only
+    PTC_RTD = 2
+    NTC_RTD = 3
+    THERMOCOUPLE = 4    # 3060 option only
+    CAPACITANCE = 5     # 3060 option only
+
+
+class InputSimulator:
+
+    def __init__(self, input: str) -> None:
+
+        self.input = input
+        self.name = None
+        self.type = None
+        self.temperature_limit = None
+        self.min_temperature = None
+        self.max_temperature = None
+
+        self.randomwalk = RandomWalk(start=15, boundary=(-100, 25), scale=0.01, count=0)
+
+    def get_temperature(self):
+
+        return next(self.randomwalk)
+
+
+class OutputSimulator:
+
+    def __init__(self, output: int) -> None:
+
+        self.output = output
+        self.resistance_setting = None
+        self.max_current_setting = None
+        self.max_user_current = None
+        self.heater_quantity = None
+
+        self.proportional = self.p = None
+        self.integral = self.i = None
+        self.derivative = self.d = None
+
+        self.temperature_setpoint = None
+        self.heater_range = None
+
+    def set_pid_parameters(self, p, i, d):
+
+        self.p = p
+        self.i = i
+        self.d = d
+
+    def get_pid_parameters(self):
+
+        return self.p, self.i, self.d
+
+
 class LakeShore336Interface(DeviceInterface):
+    """ Interface for the LakeShore336 Controller, Simulator, and Proxy."""
 
     def __init__(self, device_id: str):
         """ Initialisation of a LakeShore336 interface.
@@ -11,6 +136,373 @@ class LakeShore336Interface(DeviceInterface):
         super().__init__()
 
         self.device_id = device_id
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="*IDN?", process_cmd_string=add_lf)
+    def info(self) -> (str, str, str, float):
+        """ Identification query.
+
+        Returns basic information about the device.
+
+        Returns: Tuple with the following information:
+            - Manufacturer identifier (e.g. "LSCI");
+            - Instrument model number (e.g. "MODEL336");
+            - Instrument serial number / Option card serial number (e.g. "1234567/1234567");
+            - Instrument firmware version (e.g. 1.0)
+        """
+
+        raise NotImplementedError
+
+    @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="*CLS", process_cmd_string=add_lf)
+    def clear_interface(self):
+        """ Clear interface command.
+
+        Clears the bits in the status byte register, standard event status register, and operation event register, and
+        terminates all pending operations.  Clears the interface but not the controller.  The related controller
+        command is `reset_instrument`."""
+
+        raise NotImplementedError
+
+
+    @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="*RST", process_cmd_string=add_lf)
+    def reset_instrument(self):
+        """ Reset instrument command.
+
+        Sets the controller parameters to power-up settings.
+        """
+
+        raise NotImplementedError
+
+
+
+    # # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="*ESE", process_cmd_string=add_lf)
+    #
+    # # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="*ESE?", process_cmd_string=add_lf)
+    #
+    # # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="*ESR?", process_cmd_string=add_lf)
+
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="TST?", process_cmd_string=add_lf)
+    def get_selftest_result(self) -> int:
+        """ Selftest query.
+
+        Reports status based on test done at power-up.
+        """
+
+        raise NotImplementedError
+
+
+    @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="ATUNE ${output_channel}, ${mode}")
+    def autotune(self, output_channel: int, mode: AutotuneMode):
+        """ Autotune command.
+
+        Configures autotune parameters.
+
+        Args:
+            output_channel (int): Output associated with the loop to be autotuned (1 - 4)
+            mode (int): Autotune mode to start using:
+                - 0 (AutotuneMode.PROPORTIONAL / AutotuneMode.P): Autotune in proportional mode;
+                - 1 (AutotuneMode.PROPORTIONAL_INTEGRAL / AutotuneMode.PI): Autotune in proportional and integral mode;
+                - 2 (AutotuneMode.PROPORTIONAL_INTEGRAL_DERIVATIVE / AutotuneMode.PID): Autotune in proportional,
+                  integral, and derivative mode.
+        """
+
+        raise NotImplementedError
+
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="TUNEST?", process_cmd_string=add_lf)
+    def get_tuning_status(self):
+        """ Control tuning status query.
+
+        Returns:
+            Tuning status (int):
+                - 0: No active tuning
+                - 1: Active tuning
+            Heater output (int) of the control loop being tuned (when tuning)
+                - 1: Heater output 1
+                - 2: Heater output 2
+            Error status (int):
+                - 0: No tuning error
+                - 1: Tuning error
+            Current stage in the autotuning process that failed, if any (when tuning)
+
+        """
+
+        raise NotImplementedError
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="CRDG? {input_channel}", process_cmd_string=add_lf)
+    def get_temperature(self, input_channel: str):
+        """ Celsius reading query.
+
+        Args:
+            input_channel (str): Input channel for which to return the current temperature
+
+        Returns the current temperature reading for the specified input channel.
+        """
+
+        raise NotImplementedError
+
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="HTR? ${output_channel}", process_cmd_string=add_lf)
+    def get_heater_output(self, output_channel: int):
+        """ Heater output query.
+
+        Returns the heater output.
+
+        Args:
+            output_channel (int): Heater output to query (1 or 2)
+
+        Returns: Heater output in percentage.
+        """
+
+        raise NotImplementedError
+
+    #
+    # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="HTRSET?", process_cmd_string=add_lf)
+    # # def get_heater_setup(self, output: int) -> (int, int, float, int):
+    # #     """ Returns the heater setup.
+    # #
+    # #     Args:
+    # #         output (int): Specifies heater output to query (1 or 2)
+    # #
+    # #     Returns: Heater setup:
+    # #         - Heater resistance setting (int):
+    # #             - 1: 25 Ohm;
+    # #             - 2: 50 Ohm.
+    # #         - Maximum heater output setting (int):
+    # #             - 0: user-specified;
+    # #             - 1: 0.707A;
+    # #             - 2: 1A;
+    # #             - 3: 1.141A;
+    # #             - 4: 2A.
+    # #         - Maximum user current (float)
+    # #         - Heater quantity, specifying whether the heater output should be displayed in current
+    # #           (HeaterQuantity.CURRENT / 1) or in power (HeaterQuantity.POWER / 2)
+    # #
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="HTRST?", process_cmd_string=add_lf)
+    # # def get_heater_status(self, output: int) -> int:
+    # #     """ Returns the heater status for the given output.
+    # #
+    # #     The error condition is cleared upon querying the heater status, which will also clear the error message on the
+    # #     front panel.
+    # #
+    # #     Args:
+    # #         output (int): Specifies heater output to query (1 or 2)
+    # #
+    # #     Returns: Heater status for the given output:
+    # #         - 0: No error;
+    # #         - 1: Heater open load;
+    # #         - 2: Heater short.
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # # # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="*SRE", process_cmd_string=add_lf())
+    # #
+    # # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="*SRE?", process_cmd_string=add_lf())
+    # #
+    # # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="MODE ${mode}", process_cmd_string=add_lf)
+    # # def set_mode(self, mode: Mode):
+    # #     """ Places the controller in the given mode.
+    # #
+    # #     Args:
+    # #         mode (Mode): Interface mode:
+    # #             - 0 (Mode.LOCAL): Local mode;
+    # #             - 1 (Mode.REMOTE): Remote mode;
+    # #             - 2 (Mode.REMOTE_WITH_LOCAL_LOCKOUT): Remote mode with local lockout.
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="MODE?", process_cmd_string=add_lf)
+    # # def get_mode(self) -> int:
+    # #     """ Returns the mode of the controller.
+    # #
+    # #     Returns: Mode of the controller:
+    # #         - 0 (Mode.LOCAL): Local mode;
+    # #         - 1 (Mode.REMOTE): Remote mode;
+    # #         - 2 (Mode.REMOTE_WITH_LOCAL_LOCKOUT): Remote mode with local lockout.
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="MOUT ${output}, ${value}", process_cmd_string=add_lf)
+    # # def set_manual_output(self, output: int, value: float):
+    # #     """ Sets the output value for the given output.
+    # #
+    # #     Args:
+    # #         output (int): Specifies heater output
+    # #         value (float): New value for the given heater output.
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="MOUT?", process_cmd_string=add_lf)
+    # # def get_manual_output(self, output: int):
+    # #     """ Returns the output value for the given output.
+    # #
+    # #     Args:
+    # #         output (int): Specifies heater output
+    # #
+    # #     Returns: Output value for the given output.
+    # #    """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="DISPLAY ${mode}, ${num_fields}, ${output_source}", process_cmd_string=add_lf)
+    # # def set_display_setup(self, mode: DisplayMode, num_fields: int, output_source: int):
+    # #     """ Specifies the display mode.
+    # #
+    # #     Args:
+    # #         mode (DisplayMode): Display mode:
+    # #             - 0 (DisplayMode.INPUT_A);
+    # #             - 1 (DisplayMode.INPUT_B);
+    # #             - 2 (DisplayMode.INPUT_C);
+    # #             - 3 (DisplayMode.INPUT_D);
+    # #             - 4 (DisplayMode.CUSTOM);
+    # #             - 5 (DisplayMode.FOUR_LOOP);
+    # #             - 6 (DisplayMode.ALL_INPUTS)
+    # #         num_fields (int): When `mode` is set to DisplayMode.CUSTOM, specifies the number of fields (display
+    # #                           locations) to display:
+    # #                                 - 0: 2 large;
+    # #                                 - 1: 4 large;
+    # #                                 - 2: 8 small.
+    # #                           When `mode` is set to DisplayMode.All_INPUTS, specifies the size of hte readings:
+    # #                                 - 0: Small with input names;
+    # #                                 - 1: Large without input names.
+    # #                           Ignored in all display modes (`mode`) except DisplayMode.CUSTOM.
+    # #
+    # #         output_source (int): Specifies which output and associated loop information to display in the bottom half
+    # #                              of the custom display screen:
+    # #                                 - 1: Output 1;
+    # #                                 - 2: Output 2;
+    # #                                 - 3: Output 3;
+    # #                                 - 4: Output 4.
+    # #                              Ignored in all display modes (`mode`) except DisplayMode.CUSTOM.
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    # #
+    # # @dynamic_command(cmd_type=CommandType.READ, cmd_string="DISPLAY?", process_cmd_string=add_lf)
+    # # def get_display_setup(self):
+    # #     """ Returns the display setup.
+    # #
+    # #
+    # #     """
+    # #
+    # #     raise NotImplementedError
+    #
+    # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="TLIMIT ${input}, ${limit}", process_cmd_string=add_lf)
+    # def set_temperature_limit(self, input: str, limit: float):
+    #     """ Sets temperature limit for the given input.
+    #
+    #     Args:
+    #         input (str): Specifies which input to configure
+    #         limit (float): Temperature limit [K] for which to shut down all control units when exceeded.  A temperature
+    #                        limit of zero turns the temperature limit feature off for the given sensor input.
+    #
+    #     """
+    #
+    #     raise NotImplementedError
+    #
+    # @dynamic_command(cmd_type=CommandType.READ, cmd_string="TLIMIT? ${input}", process_cmd_string=add_lf)
+    # def get_temperature_limit(self, input: str):
+    #     """ Returns the temperature limit for the given input.
+    #
+    #     Args:
+    #         input (str): Specifies for which input to return the temperature
+    #
+    #     Returns: Temperature limit for the given input [K]
+    #     """
+    #
+    #     raise NotImplementedError
+    #
+    #
+    # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="INNAME ${input}, ${name}", process_cmd_string=add_lf)
+    # def set_input_name(self, input: str, name: str):
+    #
+    #     raise NotImplementedError
+    #
+    # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="INNAME? ${input}", process_cmd_string=add_lf)
+    # def get_input_name(self, input: str):
+    #
+    #     raise NotImplementedError
+    #
+    #
+    # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="HTRSET ${output}, ${resistance_setting}, ${max_current_setting}, ${max_user_current}, ${heater_quantity}", process_cmd_string=add_lf)
+    # def set_heater_setup(self, output: int, resistance_setting: int, max_current_setting: float, max_user_current: float, heater_quantity: HeaterQuantity):
+    #     """ Sets the heater setpoint.
+    #
+    #     Args:
+    #         output (int): Heater output to configure (1 or 2)
+    #         resistance_setting (int): Heater resistance setting
+    #             - 1: 25 Ohm;
+    #             - 2: 50 Ohm.
+    #         max_current_setting (int): Specifies the maximum heater output current:
+    #             - 0: user-specified;
+    #             - 1: 0.707A;
+    #             - 2: 1A;
+    #             - 3: 1.141A;
+    #             - 4: 2A.
+    #         max_user_current (float): Maximum heater output if `max_current_setting` is set to 0 (user-specified)
+    #         heater_quantity (HeaterQuantity): Specifies whether the heater output should be displayed in current
+    #                                           (HeaterQuantity.CURRENT / 1) or in power (HeaterQuantity.POWER / 2)
+    #     """
+    #
+    #     raise NotImplementedError
+
+    # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="PID ${output}, ${proportional}, ${integral}, ${derivative}", process_cmd_string=add_lf)
+    # def set_pid_parameters(self, output: int, proportional: float, integral: float, derivative: float):
+    #     """ Control loop PID values query.
+    #
+    #
+    #     """
+    #
+    #     raise NotImplementedError
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="PID? ${output_channel}", process_cmd_string=add_lf, post_cmd=split_response)
+    def get_pid_parameters(self, output_channel: int):
+        """ Control loop PID values query.
+
+        Args:
+            output_channel (int): Output channel for which to return the control loop PID parameters
+
+        Returns: Control loop PID values for the given output channel.
+        """
+
+        raise NotImplementedError
+
+    @dynamic_command(cmd_type=CommandType.READ, cmd_string="SETP? {output_channel}", process_cmd_string=add_lf, post_cmd=split_response)
+    def get_temperature_setpoint(self, output_channel: int):
+        """ Control setpoint query.
+
+        Args:
+            output_channel (int): Output channel for which to return the control setpoint (1 - 4)
+
+        Returns: Temperature setpoint for the given output channel [°C]
+        """
+
+    def quit(self):
+        """ Cleans up and stops threads that were started by the process."""
+
+        pass
+
+    # @dynamic_command(cmd_type=CommandType.TRANSACTION, cmd_string="SETP ${output}, ${temperature}")
+    # def set_temperature_setpoint(self, output: int, temperature: float):
+    #
+    #     raise NotImplementedError
+    #
+    # @dynamic_command(cmd_type=CommandType.WRITE, cmd_string="RANGE ${output}, ${range}", process_cmd_string=add_lf)
+    # def set_heater_range(self, output: int, range: int):
+    #
+    #     raise NotImplementedError
+    #
+    # @dynamic_command(cmd_type=CommandType.READ, cmd_string="RANGE? ${output}", process_cmd_string=add_lf)
+    # def get_heater_range(self, output: int):
+    #
+    #     raise NotImplementedError
 
 class LakeShore336Controller(LakeShore336Interface):
 
@@ -38,6 +530,148 @@ class LakeShore336Controller(LakeShore336Interface):
     def reconnect(self):
 
         self.lakeshore.reconnect()
+
+    def quit(self):
+
+        # self.synoptics.disconnect_cs()
+
+        pass
+
+
+class LakeShore336Simulator(LakeShore336Interface):
+
+    def __init__(self, device_id: str):
+
+        super().__init__(device_id)
+
+        self._is_connected = True
+
+        self.manufacturer = "LakeShore"
+        self.model = "LSCI336"
+        self.instrument_serial_number = 1234567
+        self.option_card_serial_number = 1234567
+        self.firmware_version = 1.0
+
+        self.input = {}
+        for i in range(ord("A"), ord("D") + 1):
+            self.input[chr(i)] = InputSimulator(chr(i))
+
+        # self.output = [
+        #     None,
+        #     OutputSimulator(1), OutputSimulator(2)
+        # ]
+
+    def is_simulator(self) -> bool:
+
+        return True
+
+    def is_connected(self) -> bool:
+
+        return self._is_connected
+
+    def connect(self):
+
+        self._is_connected = True
+
+    def disconnect(self):
+
+        self._is_connected = False
+
+    def reconnect(self):
+
+        self._is_connected = True
+
+    def info(self) -> (str, str, str, float):
+
+        return self.manufacturer, self.model, f"{self.instrument_serial_number}/{self.option_card_serial_number}", self.firmware_version
+
+    def clear_interface(self):
+
+        pass
+
+    def reset_instrument(self):
+
+        pass
+
+    def get_selftest_result(self):
+
+        # No errors found
+
+        return 0
+
+    def autotune(self, output_channel: int, mode: AutotuneMode):
+
+        pass
+
+    def get_tuning_status(self):
+
+        # TODO
+        pass
+
+
+
+    # def get_selftest_result(self):
+    #
+    #     return SelfTestResult.NO_ERRORS_FOUND
+    #
+    #
+    # def set_input_name(self, input: str, name: str):
+    #
+    #     self.input[input].name = name
+    #
+    # def get_input_name(self, input: str):
+    #
+    #     return self.input[input].name
+    #
+    # def set_temperature_limit(self, input: str, limit: float):
+    #
+    #     self.input[input].temperature_limit = limit
+    #
+    # def get_temperature_limit(self, input: str):
+    #
+    #     return self.input[input].temperature_limit
+    #
+    # def set_heater_setup(self, output: int, resistance_setting: int, max_current_setting: float, max_user_current: float, heater_quantity: HeaterQuantity):
+    #
+    #     self.output[output].resistance_setting = resistance_setting
+    #     self.output[output].max_current_setting = max_current_setting
+    #     self.output[output].max_user_current = max_user_current
+    #     self.output[output].heater_quantity = heater_quantity
+    #
+    # def set_pid_parameters(self, output: int, proportional: float, integral: float, derivative: float):
+    #
+    #     self.output[output].set_pid_parameters(proportional, integral, derivative)
+
+    def get_pid_parameters(self, output: int):
+
+        return self.output[output].get_pid_parameters()
+
+    # def set_temperature_setpoint(self, output: int, temperature: float):
+    #
+    #     self.output[output].temperature_setpoint = temperature
+
+    def get_temperature_setpoint(self, output_channel: str):
+
+        return self.output[output_channel].temperature_setpoint
+    #
+    # def set_heater_range(self, output: int, range: int):
+    #
+    #     self.output[output].heater_range = range
+    #
+    # def get_heater_range(self, output: int):
+    #
+    #     return self.output[output].heater_range
+
+    def get_heater_output(self, output_channel: int):
+
+        return self.output[output_channel].heater_quantity
+
+    def get_temperature(self, input_channel: str):
+
+        return self.input[input_channel].get_temperature()
+
+
+class LakeShore336Proxy(Proxy, LakeShore336Interface):
     """ Proxy to connect to a LakeShore 336 Control Server """
 
     def __init__(self, device_id: str):

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
@@ -1,4 +1,43 @@
 class LakeShore336Proxy(Proxy, Lakeshore336Interface):
+class LakeShore336Interface(DeviceInterface):
+
+    def __init__(self, device_id: str):
+        """ Initialisation of a LakeShore336 interface.
+
+        Args:
+            device_id (str): Device identifier
+        """
+
+        super().__init__()
+
+        self.device_id = device_id
+
+class LakeShore336Controller(LakeShore336Interface):
+
+    def __init__(self, device_id: str):
+        super().__init__(device_id)
+
+        self.lakeshore = self.transport = LakeShore336EthernetInterface(device_id)
+
+    def is_simulator(self) -> bool:
+
+        return False
+
+    def is_connected(self) -> bool:
+
+        return self.lakeshore.is_connected()
+
+    def connect(self):
+
+        self.lakeshore.connect()
+
+    def disconnect(self):
+
+        self.lakeshore.disconnect()
+
+    def reconnect(self):
+
+        self.lakeshore.reconnect()
     """ Proxy to connect to a LakeShore 336 Control Server """
 
     def __init__(self, device_id: str):

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
@@ -1,0 +1,15 @@
+class LakeShore336Proxy(Proxy, Lakeshore336Interface):
+    """ Proxy to connect to a LakeShore 336 Control Server """
+
+    def __init__(self, device_id: str):
+        """ Proxy to connect to the LakeShore 336 with the given device identifier
+
+        Args:
+            device_id (str): Device identifier
+        """
+
+        protocol = CTRL_SETTINGS.PROTOCOL
+        hostname = CTRL_SETTINGS.HOSTNAME
+        port = CTRL_SETTINGS[device_id]["COMMANDING_PORT"]      # TODO: Use port number from registry service
+
+        super().__init__(endpoint=connect_address(protocol, hostname, port))

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.py
@@ -556,10 +556,10 @@ class LakeShore336Simulator(LakeShore336Interface):
         for i in range(ord("A"), ord("D") + 1):
             self.input[chr(i)] = InputSimulator(chr(i))
 
-        # self.output = [
-        #     None,
-        #     OutputSimulator(1), OutputSimulator(2)
-        # ]
+        self.output = [
+            None,
+            OutputSimulator(1), OutputSimulator(2)
+        ]
 
     def is_simulator(self) -> bool:
 
@@ -597,7 +597,7 @@ class LakeShore336Simulator(LakeShore336Interface):
 
         # No errors found
 
-        return 0
+        return SelfTestResult.NO_ERRORS_FOUND.value
 
     def autotune(self, output_channel: int, mode: AutotuneMode):
 
@@ -642,6 +642,10 @@ class LakeShore336Simulator(LakeShore336Interface):
     #
     #     self.output[output].set_pid_parameters(proportional, integral, derivative)
 
+    def set_pid_parameters(self, output: int, p: float, i: float, d: float):
+
+        self.output[output].set_pid_parameters(p, i, d)
+
     def get_pid_parameters(self, output: int):
 
         return self.output[output].get_pid_parameters()
@@ -650,7 +654,7 @@ class LakeShore336Simulator(LakeShore336Interface):
     #
     #     self.output[output].temperature_setpoint = temperature
 
-    def get_temperature_setpoint(self, output_channel: str):
+    def get_temperature_setpoint(self, output_channel: int):
 
         return self.output[output_channel].temperature_setpoint
     #
@@ -662,9 +666,13 @@ class LakeShore336Simulator(LakeShore336Interface):
     #
     #     return self.output[output].heater_range
 
+    def set_heater_output(self, output_channel: int, heater_output: float):
+
+        self.output[output_channel].output = heater_output
+
     def get_heater_output(self, output_channel: int):
 
-        return self.output[output_channel].heater_quantity
+        return self.output[output_channel].output
 
     def get_temperature(self, input_channel: str):
 

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.yaml
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336.yaml
@@ -1,0 +1,94 @@
+BaseClass:
+    egse.tempcontrol.lakeshore.lakeshore336.LakeShoreInterface
+
+ProxyClass:
+    egse.tempcontrol.lakeshore.lakeshore336.LakeShoreProxy
+
+ControlServerClass:
+    egse.tempcontrol.lakeshore.lakeshore336_cs.LakeShoreControlServer
+
+ControlServer:
+    egse.tempcontrol.lakeshore.lakeshore336_cs
+
+Commands:
+
+    # Each of these groups is parsed and used on both the server and the client side.
+    # The group name (e.g. is_simulator) will be monkey-patched in the Proxy class for the device or service.
+    # The other fields are:
+    #   description:   Used by the doc_string method to generate a help string
+    #   cmd:           Command string that will eventually be sent to the hardware controller for the
+    #                  device after the arguments have been filled.
+    #   device_method: The name of the method to be called on the device class.
+    #                  These should all be defined by the base class for the device, i.e. KeithleyBase.
+    #   response:      The name of the method to be called from the device protocol.
+    #                  This method should exist in the sub-class of the CommandProtocol base class, i.e.
+    #                  in this case it will be the KeithleyProtocol class.
+
+    # Definition of the DeviceInterface
+
+    disconnect:
+        description  : Disconnects from the LakeShore336 controller. This command will be sent to the
+                       LakeShore336 Control Server which will then disconnect from the hardware controller.
+                       This command doesn't affect the ZeroMQ connection of this Proxy to the
+                       Control Server. Use the service command `disconnect_cs()` to disconnect
+                       from the Control Server.
+
+    connect:
+        description:    Connects the LakeShore336 hardware controller
+
+    reconnect:
+        description:    Reconnects the LakeShore336 hardware controller.
+                        This command will force a disconnect and then try to re-connect to the controller.
+
+    is_simulator:
+        description:   Asks if the Control Server is a simulator instead of the real LakeShore336Controller class.
+
+    is_connected:
+        description:   Checks if the LakeShore336 hardware controller is connected.
+
+    # Definition of the device commands
+
+    info:
+        description:    Identification query
+                        Returns basic information about the device (manufacturer, model, serial number, firmware version).
+
+    clear_interface:
+        description:    Clear interface command
+                        Clears the bits in the status byte register, standard event status register, and operation 
+                        event register, and terminates all pending operations.  Clears the interface but not the 
+                        controller.  The related controller command is `reset_instrument`.
+
+    reset_instrument:
+        description:    Reset instrument command
+                        Sets the controller parameters to power-up settings.
+
+    get_selftest_result:
+        description:    Selftest query
+                        Reports status based on test done at power-up.
+
+    autotune:
+        description:    Autotune command
+                        Configures autotune parameters.
+        cmd:            '{output_channel}, {mode}'
+
+    get_tuning_status:
+        description:    Returns Tuning Status
+
+    get_temperature:
+        description:    Celsius Temperature Query
+        cmd:            '{input_channel}'
+
+    get_heater_output:
+        description:    Heater Output Query
+        cmd:            '{output_channel}'
+
+    get_pid_parameters:
+        description:    Control Loop PID Values Query
+        cmd:           '{output_channel}'
+
+    get_temperature_setpoint:
+        description:    Control Setpoint Query
+        cmd:            '{output_channel}'
+
+    quit:
+        description:    Cleans up and stops threads that were started by the process

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
@@ -10,6 +10,7 @@ import zmq
 from egse.control import is_control_server_active, ControlServer
 from egse.services import ServiceProxy
 from egse.settings import Settings
+from egse.storage import store_housekeeping_information
 from egse.tempcontrol.lakeshore.lakeshore336 import LakeShore336Proxy
 from egse.tempcontrol.lakeshore.lakeshore336_protocol import LakeShore336Protocol
 from egse.zmq_ser import connect_address
@@ -219,5 +220,5 @@ def status(device_id: str):
             rich.print(f"mode: {'simulator' if sim else 'device'}{' not' if not connected else ''} connected")
             rich.print(f"hostname: {ip}")
     else:
-        print("Control Server is inactive")
+        rich.print(f"{device_id} CS: [red]inactive")
 

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
@@ -107,8 +107,46 @@ class LakeShore336ControlServer(ControlServer):
         except AttributeError:
             return self.device_id
 
-    # def after_serve(self) -> None:
-    #     self.device_protocol.synoptics.disconnect_cs()
+    def is_storage_manager_active(self):
+        """ Checks whether the Storage Manager is active.
+
+        Returns: True if the Storage Manager is active; False otherwise.
+        """
+
+        from egse.storage import is_storage_manager_active
+        return is_storage_manager_active()
+
+    def store_housekeeping_information(self, data):
+        """ Stores the given housekeeping information in a dedicated file.
+
+        Args:
+            data (dict): Dictionary containing parameter name and value of all device housekeeping.
+        """
+
+        origin = self.get_storage_mnemonic()
+        store_housekeeping_information(origin, data)
+
+    def register_to_storage_manager(self):
+        """ Registers the Control Server to the Storage Manager."""
+
+        from egse.storage import register_to_storage_manager
+        from egse.storage.persistence import TYPES
+
+        register_to_storage_manager(
+            origin=self.get_storage_mnemonic(),
+            persistence_class=TYPES["CSV"],
+            prep={
+                "column_names": list(self.device_protocol.get_housekeeping().keys()),
+                "mode": "a",
+            }
+        )
+
+    def unregister_from_storage_manager(self):
+        """ Unregisters the Control Server from the Storage Manager."""
+
+        from egse.storage import unregister_from_storage_manager
+
+        unregister_from_storage_manager(origin=self.get_storage_mnemonic())
 
 
 app = typer.Typer()

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_cs.py
@@ -47,9 +47,7 @@ class LakeShore336ControlServer(ControlServer):
             simulator (bool): Indicates whether the LakeShore336 Control Server should be started in simulator mode
         """
 
-        super().__init__()
-
-        self.device_id = device_id  # TODO Shouldn't every CS have a device ID?
+        super().__init__(device_id=device_id)
 
         self.device_protocol = LakeShore336Protocol(self, device_id, simulator=simulator)
 

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
@@ -19,3 +19,9 @@ class LakeShore336Command(ClientServerCommand):
 
         out = super().get_cmd_string(*args, **kwargs)
         return out + "\n"
+
+class LakeShore336Error(Exception):
+
+    """ Base exception for all LakeShore336 errors."""
+
+    pass

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
@@ -1,5 +1,16 @@
-from egse.command import ClientServerCommand
+import logging
+import socket
+from typing import Optional
 
+import time
+
+from egse.command import ClientServerCommand
+from egse.device import DeviceConnectionInterface, DeviceTransport
+from egse.settings import Settings
+
+DEVICE_SETTINGS = Settings.load("LakeShore336")
+
+logger = logging.getLogger(__name__)
 
 class LakeShore336Command(ClientServerCommand):
     """ Commands for the Lakeshore336 temperature controller.
@@ -25,3 +36,212 @@ class LakeShore336Error(Exception):
     """ Base exception for all LakeShore336 errors."""
 
     pass
+
+class LakeShore336EthernetInterface(DeviceConnectionInterface, DeviceTransport):
+    """ Defines the low-level interface to the LakeShore336 temperature controller."""
+
+    def __init__(self, device_id: str, hostname: str = None, port: int = None):
+        """ Initialisation of an Ethernet interface for the Lakeshore336.
+
+        Args:
+            device_id (str): Device identifier
+            hostname (str): Hostname to which to open a socket
+            port (int): Port to which to open a socket
+        """
+
+        super().__init__()
+
+        self.device_id = device_id
+
+        self.hostname = DEVICE_SETTINGS[device_id]["HOSTNAME"] if hostname is None else hostname
+        self.port = DEVICE_SETTINGS[device_id]["COMMANDING_PORT"] if port is None else port
+
+        self._socket = None
+        self._is_connection_open = False
+
+    def connect(self):
+        """ Connects to the Ethernet connection.
+
+        Raises:
+            LakeShore336Error when no connection could be established
+        """
+
+        # Sanity checks
+
+        if self._is_connection_open:
+            logger.warning(f"{self.device_id}: trying to connect to an already connected socket.")
+            return
+
+        if self.hostname in (None, ""):
+            raise LakeShore336Error(f"{self.device_id}: hostname is not initialised.")
+
+        if self.port in (None, 0):
+            raise LakeShore336Error(f"{self.device_id}: port number is not initialised.")
+
+        # Create a new socket instance
+
+        try:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            # self._socket.setblocking(1)
+            # self._socket.settimeout(3)
+        except socket.error as e_socket:
+            raise LakeShore336Error(self.device_id, "Failed to create socket.") from e_socket
+
+        # Attempt to establish a connection to the remote host
+
+        # FIXME: Socket shall be closed on exception?
+
+        # We set a timeout of 3s before connecting and reset to None (=blocking) after the `connect` method has been
+        # called. This is because when no device is available, e.g. during testing, the timeout will take about
+        # two minutes, which is way too long. It needs to be evaluated if this approach is acceptable and not causing
+        # problems during production.
+
+        try:
+            logger.debug(f'Connecting a socket to host "{self.hostname}" using port {self.port}')
+            self._socket.settimeout(3)
+            self._socket.connect((self.hostname, self.port))
+            self._socket.settimeout(None)
+        except ConnectionRefusedError as exc:
+            raise LakeShore336Error(self.device_id, f"Connection refused to {self.hostname}:{self.port}.") from exc
+        except TimeoutError as exc:
+            raise LakeShore336Error(self.device_id, f"Connection to {self.hostname}:{self.port} timed out.") from exc
+        except socket.gaierror as exc:
+            raise LakeShore336Error(self.device_id, f"Socket address info error for {self.hostname}") from exc
+        except socket.herror as exc:
+            raise LakeShore336Error(self.device_id, f"Socket host address error for {self.hostname}") from exc
+        except socket.timeout as exc:
+            raise LakeShore336Error(self.device_id, f"Socket timeout error for {self.hostname}:{self.port}") from exc
+        except OSError as exc:
+            raise LakeShore336Error(self.device_id, f"OSError caught ({exc}).") from exc
+
+        self._is_connection_open = True
+
+        # Check that we are connected to the controller by issuing the "*IDN?" or  query. If we don't get the right
+        # response, then disconnect automatically.
+
+        if not self.is_connected():
+            raise LakeShore336Error(self.device_id, "Device is not connected, check logging messages for the cause.")
+
+    def disconnect(self):
+        """ Disconnects from the Ethernet connection.
+
+        Raises:
+            LakeShore336Error when the socket could not be closed
+        """
+
+        try:
+            if self._is_connection_open:
+                logger.debug(f"Disconnecting from {self.hostname}")
+                self._socket.close()
+                self._is_connection_open = False
+        except Exception as e_exc:
+            raise LakeShore336Error(self.device_id, f"Could not close socket to {self.hostname}") from e_exc
+
+    def reconnect(self):
+        """ Reconnects to the Ethernet connection."""
+
+        if self._is_connection_open:
+            self.disconnect()
+        self.connect()
+
+    def is_connected(self) -> bool:
+        """ Checks if the client is connected to the device.
+
+        Returns: True if the client is connected to the device; False otherwise.
+        """
+
+        if not self._is_connection_open:
+            return False
+
+        try:
+            version = self.query("*IDN?\n")
+        except LakeShore336Error as exc:
+            logger.exception(exc)
+            logger.error("Most probably the client connection was closed. Disconnecting...")
+            self.disconnect()
+            return False
+
+        if "LSCI" not in version:
+            logger.error(
+                f'Device did not respond correctly to a "*IDN?" command, response={version}. Disconnecting...'
+            )
+            return False
+
+        return True
+
+    def write(self, command: str):
+        """ Sends a single command to the device controller without waiting for a response.
+
+        Args
+            command (str): Command to send to the controller
+        """
+
+        try:
+            self._socket.sendall(command.encode())
+        except socket.timeout as e_timeout:
+            raise LakeShore336Error("Socket timeout error") from e_timeout
+        except socket.error as e_socket:
+            # Interpret any socket-related error as a connection error
+            raise LakeShore336Error("Socket communication error.") from e_socket
+        except AttributeError:
+            if not self.is_connected:
+                msg = "The LakeShore336 is not connected, use the connect() method."
+                raise LakeShore336Error(msg)
+
+    def trans(self, command: str) -> Optional[str]:
+        """ Sends a single command to the device and blocks until a response is received.
+
+        This operation is seen as a transaction or query.
+
+        Args:
+            command (str): Command to send to the controller
+
+        Returns: Either a string returned by the controller (on success) or an error message (on failure).
+
+        Raises:
+            LakeShore336Error when there was an I/O problem during communication with the controller, or when there
+            was a timeout in either sending the command or receiving the response.
+        """
+
+        try:
+
+            self._socket.sendall(command.encode())
+
+            # wait for, read and return the response from HUBER (will be at most TBD chars)
+
+            return_string = self.read()
+
+            return return_string.decode().replace("\r\n", "").replace("+","")
+
+        except socket.timeout as e_timeout:
+            raise LakeShore336Error(self.device_id, "Socket timeout error") from e_timeout
+        except socket.error as e_socket:
+            # Interpret any socket-related error as an I/O error
+            raise LakeShore336Error(self.device_id, "Socket communication error.") from e_socket
+        except ConnectionError as exc:
+            raise LakeShore336Error(self.device_id, "Connection error.") from exc
+        except AttributeError:
+            if not self._is_connection_open:
+                raise LakeShore336Error(self.device_id, "Device not connected, use the connect() method.")
+
+    def read(self) -> bytes:
+        """ Reads the device buffer.
+
+        Returns: Content of the device buffer.
+        """
+
+        n_total = 0
+        buf_size = 2048
+
+        try:
+            for idx in range(100):
+                time.sleep(0.05)  # Give the device time to fill the buffer
+                data = self._socket.recv(buf_size)
+                n = len(data)
+                n_total += n
+                if n < buf_size:
+                    break
+            return data
+        except socket.timeout as e_timeout:
+            logger.warning(f"Socket timeout error from {e_timeout}")
+            return b"\r\n"

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
@@ -8,7 +8,7 @@ from egse.command import ClientServerCommand
 from egse.device import DeviceConnectionInterface, DeviceTransport
 from egse.settings import Settings
 
-DEVICE_SETTINGS = Settings.load("LakeShore336")
+DEVICE_SETTINGS = Settings.load("LakeShore336 Control Server")
 
 logger = logging.getLogger(__name__)
 

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_devif.py
@@ -1,0 +1,21 @@
+from egse.command import ClientServerCommand
+
+
+class LakeShore336Command(ClientServerCommand):
+    """ Commands for the Lakeshore336 temperature controller.
+
+    A Command is basically a string that is sent to a device and for which the device returns a response.  The command
+    string can contain placeholders that will be filled when the command is called.  The arguments that are given, will
+    be filled into the formatted string.  Arguments can be positional or keyword arguments, not both.
+    """
+
+    def get_cmd_string(self, *args, **kwargs) -> str:
+        """ Returns the formatted command string with the given positional and/or keyword arguments filled out.
+
+        Args:
+            *args: Positional arguments that are needed to construct the command string
+            **kwargs: Keyword arguments that are needed to construct the command string
+        """
+
+        out = super().get_cmd_string(*args, **kwargs)
+        return out + "\n"

--- a/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_protocol.py
+++ b/projects/generic/lakeshore-tempcontrol/src/egse/tempcontrol/lakeshore/lakeshore336_protocol.py
@@ -1,0 +1,115 @@
+import logging
+from pathlib import Path
+
+from egse.control import ControlServer
+from egse.protocol import CommandProtocol
+from egse.settings import Settings
+from egse.setup import load_setup
+from egse.system import format_datetime
+from egse.tempcontrol.lakeshore.lakeshore336 import LakeShore336Interface, LakeShore336Simulator, LakeShore336Controller
+from egse.tempcontrol.lakeshore.lakeshore336_devif import LakeShore336Command
+from egse.zmq_ser import bind_address
+
+logger = logging.getLogger(__name__)
+_HERE = Path(__file__).parent
+COMMAND_SETTINGS = Settings.load(filename="lakeshore336.yaml", location=_HERE)
+CTRL_SETTINGS = Settings.load("LakeShore336 Control Server")
+SITE_ID = Settings.load("SITE").ID
+
+
+
+class LakeShore336Protocol(CommandProtocol):
+    def __init__(self, control_server: ControlServer, device_id: str, simulator: bool = False):
+
+        super().__init__(control_server)
+        self.device_id = device_id
+        self.simulator = simulator
+
+        setup = load_setup()
+        self.input_channels = setup.gse.tempcontrol.lakeshore336[device_id]["input_channels"]
+        if isinstance(self.input_channels, str):
+            self.input_channels = [self.input_channels]
+        self.output_channels = setup.gse.tempcontrol.lakeshore336[device_id]["output_channels"]
+        if isinstance(self.output_channels, int):
+            self.output_channels = [self.output_channels]
+
+        if self.simulator:
+            self.lakeshore: LakeShore336Interface = LakeShore336Simulator(device_id)
+        else:
+            self.lakeshore: LakeShore336Interface = LakeShore336Controller(device_id)
+
+        self.storage_mnemonic = self.control_server.get_storage_mnemonic()
+
+        self.load_commands(COMMAND_SETTINGS.Commands, LakeShore336Command, LakeShore336Interface)
+
+        self.build_device_method_lookup_table(self.lakeshore)
+
+        # self.synoptics = SynopticsManagerProxy()
+
+
+    def get_bind_address(self):
+        return bind_address(
+            self.control_server.get_communication_protocol(),
+            self.control_server.get_commanding_port(),
+        )
+
+    def get_status(self):
+        return super().get_status()
+
+    def get_housekeeping(self) -> dict:
+
+        hk_dict = dict()
+
+        try:
+
+            # Temperature sensors (input)
+
+            for input_channel in self.input_channels:
+
+                hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_T_{input_channel}"] \
+                    = self.lakeshore.get_temperature(input_channel=input_channel)
+
+            # Heaters (output)
+
+            # for output_channel in self.output_channels:
+            for output_channel in self.output_channels: # list(set(self.output_channels) & {1, 2}):
+
+                if output_channel in {1, 2}:
+
+                    pid_parameters = self.lakeshore.get_pid_parameters(output_channel)
+                    hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_P_{output_channel}"] = pid_parameters[0]
+                    hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_I_{output_channel}"] = pid_parameters[1]
+                    hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_D_{output_channel}"] = pid_parameters[2]
+
+                    hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_HEATER_{output_channel}"] \
+                        = self.lakeshore.get_heater_output(output_channel)
+
+                hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_SETPOINT_{output_channel}"]  \
+                    = self.lakeshore.get_temperature_setpoint(output_channel)
+
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_TEMP_A"] = self.lakeshore.get_temperature()
+            # pid_params = self.lakeshore.get_pid_parameters(1)
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_P_VALUE"] = pid_params[0]
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_I_VALUE"] = pid_params[1]
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_D_VALUE"] = pid_params[2]
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_HEATER_VALUE"] = self.lakeshore.get_heater_output(
+            #     output_channel=1)
+            # hk_dict[f"G{SITE_ID}_{self.storage_mnemonic}_SETPOINT_VALUE"] = self.lakeshore.get_temperature_setpoint(
+            #     output_channel=1)
+
+            # for hk_name in metrics_dict.keys():
+            #     index_lsci = hk_name.split("_")
+            #     if (len(index_lsci) > 2):
+            #         if int(index_lsci[2]) == int(self.device_id):
+            #             metrics_dict[hk_name].set(hk_dict[hk_name])
+
+            # # Send the HK acquired so far to the Synoptics Manager
+            # self.synoptics.store_th_synoptics(hk_dict)
+        except Exception as exc:
+            logger.warning(f'failed to get HK ({exc})')
+        hk_dict["timestamp"] = format_datetime()
+
+        return hk_dict
+
+    def quit(self):
+        self.lakeshore.quit()

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_explore.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_explore.py
@@ -1,0 +1,10 @@
+__all__ = [
+    "show_processes",
+]
+
+from egse.process import ps_egrep
+
+
+def show_processes():
+    """Show the lines from the `ps -ef` command that match processes from this package."""
+    return ps_egrep("(lsci336)_(ui|cs|sim)")

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
@@ -77,7 +77,10 @@ def status_lakeshore336(device_id: Annotated[str, typer.Argument(help="the devic
         device_id (str): Device identifier
     """
 
-    rich.print("Printing the status of LakeShore336")
+    rich.print(f"Status of LakeShore336 {device_id}")
+
+    from egse.tempcontrol.lakeshore import lakeshore336_cs
+    lakeshore336_cs.status(device_id)
 
 
 @lakeshore336.command(name="start-simulator")

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
@@ -18,10 +18,10 @@ lakeshore336 = typer.Typer(
 
 @lakeshore336.command(name="start")
 def start_lakeshore336(
-        device_id: str,
+        device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")],
         simulator: Annotated[bool, typer.Option("--simulator", "--sim",
                                                 help="Start the LakeShore336 simulator as the backend")]=False,
-        background: Annotated[bool, typer.Option(help="Start the LakeShore336 in the background")] = True
+        background: Annotated[bool, typer.Option(help="Start the LakeShore336 in the background")] = False
 ):
     """ Starts the LakeShore336 Control Server.
 
@@ -33,7 +33,7 @@ def start_lakeshore336(
         background (bool): Indicates whether the LakeShore336 Control Server should be started in the background
     """
 
-    rich.print("Starting service LakeShore336")
+    rich.print(f"Starting service LakeShore336 {device_id}")
 
     if background:
         location = get_log_file_location()
@@ -57,20 +57,20 @@ def start_lakeshore336(
 
 
 @lakeshore336.command(name="stop")
-def stop_lakeshore336(device_id: str):
+def stop_lakeshore336(device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")]):
     """ Stops the LakeShore336 service.
 
     Args:
         device_id (str): Device identifier
     """
 
-    rich.print("Terminating service LakeShore336")
+    rich.print(f"Terminating service LakeShore336 {device_id}")
 
     from egse.tempcontrol.lakeshore import lakeshore336_cs
     lakeshore336_cs.stop(device_id)
 
 @lakeshore336.command(name="status")
-def status_lakeshore336(device_id: str):
+def status_lakeshore336(device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")],):
     """ Prints status information on the LakeShore336 service.
 
     Args:
@@ -81,7 +81,7 @@ def status_lakeshore336(device_id: str):
 
 
 @lakeshore336.command(name="start-simulator")
-def start_lakeshore336_sim(device_id: str):
+def start_lakeshore336_sim(device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")]):
     """ Starts the LakeShore336 Simulator.
 
     Args:

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
@@ -1,0 +1,94 @@
+import subprocess
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import rich
+import typer
+
+from egse.env import get_log_file_location
+
+lakeshore336 = typer.Typer(
+    name="LakeShore336",
+    help="LakeShore336 Data Acquisition Unit, LakeShore, temperature monitoring",
+    no_args_is_help=True
+)
+
+
+@lakeshore336.command(name="start")
+def start_lakeshore336(
+        device_id: str,
+        simulator: Annotated[bool, typer.Option("--simulator", "--sim",
+                                                help="Start the LakeShore336 simulator as the backend")]=False,
+        background: Annotated[bool, typer.Option(help="Start the LakeShore336 in the background")] = True
+):
+    """ Starts the LakeShore336 Control Server.
+
+    This Control Server is started in the background by default.
+
+    Args:
+        device_id (str): Device identifier
+        simulator (bool): Indicates whether the LakeShore336 Control Server should be started in simulator mode
+        background (bool): Indicates whether the LakeShore336 Control Server should be started in the background
+    """
+
+    rich.print("Starting service LakeShore336")
+
+    if background:
+        location = get_log_file_location()
+        output_filename = "lakeshore336_cs.start.out"
+        output_path = Path(location, output_filename).expanduser()
+
+        rich.print(f"Starting the LakeShore336 Control Server ({device_id}) – {simulator = }")
+        rich.print(f"Output will be redirected to {output_path!s}")
+
+        out = open(output_path, 'w')
+
+        cmd = [sys.executable, '-m', 'egse.tempcontrol.lakeshore.lakeshore336_cs', 'start', device_id]
+        if simulator:
+            cmd.append("--simulator")
+
+        subprocess.Popen(cmd, stdout=out, stderr=out, stdin=subprocess.DEVNULL, close_fds=True)
+
+    else:
+        from egse.tempcontrol.lakeshore import lakeshore336_cs
+        lakeshore336_cs.start(device_id, simulator)
+
+
+@lakeshore336.command(name="stop")
+def stop_lakeshore336(device_id: str):
+    """ Stops the LakeShore336 service.
+
+    Args:
+        device_id (str): Device identifier
+    """
+
+    rich.print("Terminating service LakeShore336")
+
+    from egse.tempcontrol.lakeshore import lakeshore336_cs
+    lakeshore336_cs.stop(device_id)
+
+@lakeshore336.command(name="status")
+def status_lakeshore336(device_id: str):
+    """ Prints status information on the LakeShore336 service.
+
+    Args:
+        device_id (str): Device identifier
+    """
+
+    rich.print("Printing the status of LakeShore336")
+
+
+@lakeshore336.command(name="start-simulator")
+def start_lakeshore336_sim(device_id: str):
+    """ Starts the LakeShore336 Simulator.
+
+    Args:
+        device_id (str): Device identifier
+    """
+
+    rich.print("Starting service LakeShore336 Simulator")
+
+    from egse.tempcontrol.lakeshore import lakeshore336_cs
+    lakeshore336_cs.status(device_id)

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/settings.yaml
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/settings.yaml
@@ -1,0 +1,2 @@
+PACKAGES:
+    LAKESHORE_TEMPCONTROL: LakeShore temperature control

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/settings.yaml
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/settings.yaml
@@ -1,2 +1,8 @@
 PACKAGES:
     LAKESHORE_TEMPCONTROL: LakeShore temperature control
+
+
+LakeShore336 Control Server:
+
+    PROTOCOL:                     tcp
+    HOSTNAME:               localhost

--- a/projects/generic/lakeshore-tempcontrol/tests/test_lakeshore336_simulator.py
+++ b/projects/generic/lakeshore-tempcontrol/tests/test_lakeshore336_simulator.py
@@ -1,0 +1,70 @@
+import logging
+
+from egse.tempcontrol.lakeshore.lakeshore336 import LakeShore336Simulator, SelfTestResult
+
+MODULE_LOGGER = logging.getLogger(__name__)
+
+
+def test_constructor():
+
+    lakeshore = LakeShore336Simulator("TEST")
+    assert lakeshore.device_id == "TEST"
+    assert lakeshore.is_connected()
+
+
+def test_disconnect():
+
+    lakeshore = LakeShore336Simulator("TEST")
+    assert lakeshore.is_connected()
+
+    lakeshore.disconnect()
+    assert not lakeshore.is_connected()
+
+
+def test_reconnect():
+
+    lakeshore = LakeShore336Simulator("TEST")
+
+    lakeshore.reconnect()
+    assert lakeshore.is_connected()
+
+
+def test_info():
+
+    lakeshore = LakeShore336Simulator("TEST")
+    info = lakeshore.info()
+
+    assert type(info) == tuple
+    assert info[0] == "LakeShore"
+    assert info[1] == "LSCI336"
+    assert info[2] == "1234567/1234567"
+    assert info[3] == 1.0
+
+def test_get_temperature():
+
+    with LakeShore336Simulator("TEST") as sim:
+        assert -100.0 < sim.get_temperature('A') < 25.0
+
+def test_get_pid_parameters():
+
+    with LakeShore336Simulator("TEST") as sim:
+
+        for output_channel in [1, 2]:
+
+            sim.set_pid_parameters(output_channel, 1 * output_channel, 2 * output_channel, 3 * output_channel)
+            assert sim.get_pid_parameters(output_channel) == (1 * output_channel, 2 * output_channel, 3 * output_channel)
+
+def test_get_heater_output():
+
+    with LakeShore336Simulator("TEST") as sim:
+
+        for output_channel in [1, 2]:
+
+            sim.set_heater_output(output_channel, 3 * output_channel)
+            assert sim.get_heater_output(output_channel) == 3 * output_channel
+
+def test_get_selftest_result():
+
+    with LakeShore336Simulator("TEST") as sim:
+
+        assert sim.get_selftest_result() == SelfTestResult.NO_ERRORS_FOUND.value


### PR DESCRIPTION
# Summary of the changes

- Migrated the LakeShore336 code from plato-common-egse;
- Cleaned up commanding, ditched semaphore,...;
- Metrics propagated to InfluxDB instead of Grafana;
- Added CGSE commands.

# Related issues

#18

# Test results

Tested LakeShore336 simulator on my laptop with the core services running:

- Can be started/stopped successfully with the CGSE commands ;
- Status can be checked successfully with the CGSE command;
- HK written to dedicated CSV file.