### PR TITLE
core and common features to support service registration etc

### DIFF
--- a/bump.py
+++ b/bump.py
@@ -1,18 +1,17 @@
+#!/usr/bin/env -S uv run --script
 """
-This script bumps the version of all libs and projects in this monorepo to the version that
-is currently in the `pyproject.toml` file in the root folder of the monorepo.
+This script bumps the version of all libs and projects in this monorepo. The version that
+is currently in the `pyproject.toml` file in the root folder of the monorepo is used as the
+current version to be updated based on the argument, i.e. patch, minor, or major.
 
 Usage:
-    $ python bump.py <part>
+    $ ./bump.py <part>
 
 where `<part>` should be 'patch', 'minor', or 'major'.
 
 Note:
-    You are expected to be in the minimal virtual environment associated with this monorepo,
-    being a `pyenv` or Poetry environment, or your global environment shall include the tomlkit
-    and the rich package.
-
-    Alternatively (and preferably) you can use `uv run build.py <part>` to run this script.
+    The script should be executable and can be run directly as shown above.
+    Alternatively, you can use `uv run build.py <part>` to run this script.
 
 """
 
@@ -86,13 +85,13 @@ def update_all_projects_in_monorepo(root_dir: pathlib.Path, part: str, dry_run: 
     Updates all pyproject.toml files with the master version number.
 
     Parameters:
-        root_dir:
-        part:
-        dry_run:
-        verbose:
+        root_dir: the root folder of the monorepo
+        part: which part of the version to bump, 'patch', 'minor', or 'major'
+        dry_run: don't do anything, only report what will be done [default=False]
+        verbose: print more information during updates [default=True]
     """
 
-    excluded_subdirs = ["__pycache__", ".venv", ".git", ".idea", "cgse/build", "cgse/dist"]
+    excluded_subdirs = ["__pycache__", ".venv", ".git", ".idea", ".nox", "cgse/build", "cgse/dist"]
 
     master_version = get_master_version(os.path.join(root_dir, "pyproject.toml"))
 

--- a/libs/cgse-common/src/egse/proxy.py
+++ b/libs/cgse-common/src/egse/proxy.py
@@ -253,7 +253,7 @@ class BaseProxy(ControlServerConnectionInterface):
 
         transport, address, _ = split_address(self._endpoint)
 
-        port = self.send("get_service_port")
+        port = self.send("get_service_port")  # FIXME: Check if this is still returning the proper port
 
         return ServiceProxy(AttributeDict({"PROTOCOL": transport, "HOSTNAME": address, "SERVICE_PORT": port}))
 

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -20,6 +20,7 @@ import datetime
 import functools
 import importlib
 import importlib.metadata
+import importlib.util
 import inspect
 import itertools
 import logging
@@ -2133,6 +2134,11 @@ def log_rich_output(logger_: logging.Logger, level: int, obj: Any):
     captured_output = capture.get()
 
     logger_.log(level, captured_output)
+
+
+def is_package_installed(package_name):
+    """Check if a package is installed."""
+    return importlib.util.find_spec(package_name) is not None
 
 
 ignore_m_warning("egse.system")

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -27,9 +27,11 @@ dependencies = [
 
 [project.scripts]
 log_cs = 'egse.logger.log_cs:app'
+reg_cs = 'egse.registry.server:app'
 sm_cs = 'egse.storage.storage_cs:app'
 cm_cs = 'egse.confman.confman_cs:app'
 pm_cs = 'egse.procman.procman_cs:cli'
+
 
 [project.entry-points."cgse.version"]
 cgse-core = 'egse.version:get_version_installed'
@@ -38,7 +40,8 @@ cgse-core = 'egse.version:get_version_installed'
 cgse-core = "cgse_core:settings.yaml"
 
 [project.entry-points."cgse.service"]
-core = 'cgse_core.services:app'
+core = 'cgse_core.services:core'
+registry = 'cgse_core.services:reg'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -4,18 +4,20 @@ import logging
 import rich
 import typer
 
+from egse.registry.client import AsyncRegistryClient
+from egse.system import TyperAsyncCommand
 from ._start import start_rs_cs, start_log_cs, start_sm_cs, start_cm_cs
 from ._stop import stop_rs_cs, stop_log_cs, stop_sm_cs, stop_cm_cs
 from ._status import run_all_status
 
-app = typer.Typer(
+core = typer.Typer(
     name="core",
     help="handle core services: start, stop, status",
     no_args_is_help=True
 )
 
 
-@app.command(name="start")
+@core.command(name="start")
 def start_core_services():
     """Start the core services in the background."""
 
@@ -27,7 +29,7 @@ def start_core_services():
     start_cm_cs()
 
 
-@app.command(name="stop")
+@core.command(name="stop")
 def stop_core_services():
     """Stop the core services."""
 
@@ -39,7 +41,7 @@ def stop_core_services():
     stop_rs_cs()
 
 
-@app.command(name="status")
+@core.command(name="status")
 def status_core_services(full: bool = False):
     """Print the status of the core services."""
     # from scripts._status import status_log_cs, status_sm_cs, status_cm_cs
@@ -52,3 +54,19 @@ def status_core_services(full: bool = False):
     rich.print("[green]Status of the core services...[/]")
 
     asyncio.run(run_all_status(full))
+
+
+reg = typer.Typer(
+    name="registry",
+    help="handle registry services: start, stop, status",
+    no_args_is_help=True
+)
+
+
+@reg.command(cls=TyperAsyncCommand, name="show-services")
+async def reg_show_services():
+    """Print the active services that are registered."""
+    with AsyncRegistryClient() as client:
+        services = await client.list_services()
+
+        rich.print(services)


### PR DESCRIPTION
This is a maintenance pull request with changes to cgse-common and cgse-core that were needed to better support the development of device drivers.

- `egse.system` – added a method to check if a package is installed: `is_package_installed(<package name>)`
- `egse.control` – ControlServer now has two new methods `register_service()` and `deregister_service()` that need to be used by the sub-classes to register itself to the service registry.
- a new command `uv run cgse registry show-services` can be used to check which services exist and retrieve information about it
```
➜ uv run cgse registry show-services
[
    {
        'id': 'PunaControlServer-1411b612-6797-4735-8413-c0b9b2a76841',
        'name': 'PunaControlServer',
        'host': '192.168.68.70',
        'port': 52147,
        'metadata': {'service_port': 52145, 'monitoring_port': 52146, 'type': 'PUNA_01'},
        'ttl': 30,
        'last_heartbeat': 1747669915,
        'tags': ['PUNA_01'],
        'health': 'passing'
    },
    {
        'id': 'PunaControlServer-bc0c044e-f603-4354-bcdb-2e9598646190',
        'name': 'PunaControlServer',
        'host': '192.168.68.70',
        'port': 49954,
        'metadata': {'service_port': 49952, 'monitoring_port': 49953, 'type': 'PUNA_02'},
        'ttl': 30,
        'last_heartbeat': 1747669911,
        'tags': ['PUNA_02'],
        'health': 'passing'
    },
    {
        'id': 'ZondaControlServer-66f240bd-8570-4534-892d-d7da33804bc6',
        'name': 'ZondaControlServer',
        'host': '192.168.68.70',
        'port': 62641,
        'metadata': {'service_port': 62639, 'monitoring_port': 62640, 'type': 'ZONDA_01'},
        'ttl': 30,
        'last_heartbeat': 1747669912,
        'tags': ['ZONDA_01'],
        'health': 'passing'
    }
]
```
- the available commands in the help are now properly sorted:
```
➜ uv run cgse

 Usage: cgse [OPTIONS] COMMAND [ARGS]...

 The main cgse command to inspect, configure, monitor the core services and device control servers.

╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────╮
│ --install-completion          Install completion for the current shell.                                 │
│ --show-completion             Show completion for the current shell, to copy it or customize the        │
│                               installation.                                                             │
│ --help                        Show this message and exit.                                               │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ──────────────────────────────────────────────────────────────────────────────────────────────╮
│ init       Initialize your project.                                                                     │
│ version    Prints the version of the cgse-core and other registered packages.                           │
│ show       Show information about settings, environment, setup, ...                                     │
│ top        A top-like interface for core services and device control servers.                           │
│ check      Check installation, settings, required files, etc.                                           │
│ clock      Showcase for running an in-line Textual App.                                                 │
│ core       handle core services: start, stop, status                                                    │
│ daq6510    DAQ6510 Data Acquisition Unit, Keithley, temperature monitoring                              │
│ dev-x      device-x is an imaginary device that serves as an example                                    │
│ puna       PUNA Positioning Hexapod, Symétrie                                                           │
│ registry   handle registry services: start, stop, status                                                │
│ zonda      ZONDA Positioning Hexapod, Symétrie                                                          │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```
- the synchronous RegistryClient now also sends out heartbeats (from a separate thread)
- a few other small editorial fixes
