### PR TITLE
corrected timeout message, now print 's' instead of 'ms'

### DIFF
--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -476,6 +476,7 @@ class AsyncRegistryClient:
 
         Args:
             request: The request to send to the service registry server.
+            timeout: The number of milliseconds to wait
 
         Returns:
             The response from the registry as a dictionary.
@@ -491,7 +492,7 @@ class AsyncRegistryClient:
                 response_json = await asyncio.wait_for(self.req_socket.recv_string(), timeout=timeout)
                 return json.loads(response_json)
             except asyncio.TimeoutError:
-                self.logger.error(f"Request timed out after {timeout}ms")
+                self.logger.error(f"Request timed out after {timeout:.2f}s")
                 # Reset the socket to avoid invalid state
                 self.req_socket.close()
                 self.req_socket = self.context.socket(zmq.REQ)


### PR DESCRIPTION
When the service registry is not responding, a timeout message was printed which wrongly mentioned 'ms' instead of 's'. This has been corrected.