### PR TITLE
suppress errors when running a status command

### DIFF
--- a/libs/cgse-core/src/cgse_core/_status.py
+++ b/libs/cgse-core/src/cgse_core/_status.py
@@ -4,18 +4,18 @@ import sys
 import rich
 
 
-async def run_all_status(full: bool = False):
+async def run_all_status(full: bool = False, suppress_errors: bool = True):
     tasks = [
-        asyncio.create_task(status_rs_cs()),
-        asyncio.create_task(status_log_cs()),
-        asyncio.create_task(status_sm_cs(full)),
-        asyncio.create_task(status_cm_cs()),
+        asyncio.create_task(status_rs_cs(suppress_errors)),
+        asyncio.create_task(status_log_cs(suppress_errors)),
+        asyncio.create_task(status_sm_cs(full, suppress_errors)),
+        asyncio.create_task(status_cm_cs(suppress_errors)),
     ]
 
     await asyncio.gather(*tasks)
 
 
-async def status_rs_cs():
+async def status_rs_cs(suppress_errors):
 
     proc = await asyncio.create_subprocess_exec(
         sys.executable, '-m', 'egse.registry.server', 'status',
@@ -26,11 +26,11 @@ async def status_rs_cs():
     stdout, stderr = await proc.communicate()
 
     rich.print(stdout.decode().rstrip())
-    if stderr:
+    if stderr and not suppress_errors:
         rich.print(f"[red]{stderr.decode()}[/]")
 
 
-async def status_log_cs():
+async def status_log_cs(suppress_errors):
 
     proc = await asyncio.create_subprocess_exec(
         sys.executable, '-m', 'egse.logger.log_cs', 'status',
@@ -41,11 +41,11 @@ async def status_log_cs():
     stdout, stderr = await proc.communicate()
 
     rich.print(stdout.decode().rstrip())
-    if stderr:
+    if stderr and not suppress_errors:
         rich.print(f"[red]{stderr.decode()}[/]")
 
 
-async def status_sm_cs(full: bool = False):
+async def status_sm_cs(full: bool = False, suppress_errors: bool = True):
 
     cmd = [sys.executable, '-m', 'egse.storage.storage_cs', 'status']
     if full:
@@ -60,11 +60,11 @@ async def status_sm_cs(full: bool = False):
     stdout, stderr = await proc.communicate()
 
     rich.print(stdout.decode().rstrip())
-    if stderr:
+    if stderr and not suppress_errors:
         rich.print(f"[red]{stderr.decode()}[/]")
 
 
-async def status_cm_cs():
+async def status_cm_cs(suppress_errors):
 
     proc = await asyncio.create_subprocess_exec(
         sys.executable, '-m', 'egse.confman.confman_cs', 'status',
@@ -75,5 +75,5 @@ async def status_cm_cs():
     stdout, stderr = await proc.communicate()
 
     rich.print(stdout.decode().rstrip())
-    if stderr:
+    if stderr and not suppress_errors:
         rich.print(f"[red]{stderr.decode()}[/]")

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -45,7 +45,7 @@ def stop_core_services():
 
 
 @core.command(name="status")
-def status_core_services(full: bool = False):
+def status_core_services(full: bool = False, suppress_errors: bool = True):
     """Print the status of the core services."""
     # from scripts._status import status_log_cs, status_sm_cs, status_cm_cs
 
@@ -56,7 +56,7 @@ def status_core_services(full: bool = False):
 
     rich.print("[green]Status of the core services...[/]")
 
-    asyncio.run(run_all_status(full))
+    asyncio.run(run_all_status(full, suppress_errors))
 
 
 reg = typer.Typer(


### PR DESCRIPTION
When a service is down, the `cgse core status` will print correctly that the service is not active, but it also prints the error log coming from the server.

```
Configuration Manager Status: not active
2025-05-26 11:39:28,930:         MainProcess: WARNING:egse.registry            :  258:client.py           :Service discovery failed: No healthy service of type CM_CS found
```

That information is only useful when debugging, so we will suppress it by default and you can use the `--no-suppress-errors` switch to show these error messages.