### PR TITLE
fix optional root argument in config and resource and remove get_common_egse_root

### DIFF
--- a/libs/cgse-common/src/egse/config.py
+++ b/libs/cgse-common/src/egse/config.py
@@ -309,62 +309,6 @@ def get_common_egse_root(path: Union[str, PurePath] = None) -> Optional[PurePath
     return Path(egse_path)
 
 
-def get_resource_dirs(root_dir: Union[str, PurePath] = None) -> List[Path]:
-    """
-    Define directories that contain resources like images, icons, and data files.
-
-    Resource directories can have the following names: `resources`, `data`, `icons`, or `images`.
-    This function checks if any of the resource directories exist in the project root directory,
-    in the `root_dir` that is given as an argument or in the `src/egse` sub-folder.
-
-    So, the directories that are searched for the resource folders are:
-
-    * `root_dir` or the project's root directory
-    * the `src/egse` sub-folder of one of the above
-
-    For all existing directories the function returns the absolute path.
-
-    Args:
-        root_dir (str): the directory to search for resource folders
-
-    Returns:
-        a list of absolute Paths.
-    """
-    project_dir = Path(root_dir).resolve() if root_dir else get_common_egse_root()
-    result = []
-    for dir_ in ["resources", "data", "icons", "images"]:
-        if (project_dir / dir_).is_dir():
-            result.append(Path(project_dir, dir_).resolve())
-        if (project_dir / "src" / "egse" / dir_).is_dir():
-            result.append(Path(project_dir, "src", "egse", dir_).resolve())
-    return result
-
-
-def get_resource_path(name: str, resource_root_dir: Union[str, PurePath] = None) -> PurePath:
-    """
-    Searches for a data file (resource) with the given name.
-
-    When `resource_root_dir` is not given, the search for resources will start at the root
-    folder of the project (using the function `get_common_egse_root()`). Any other root
-    directory can be given, e.g. if you want to start the search from the location of your
-    source code file, use `Path(__file__).parent` as the `resource_root_dir` argument.
-
-    Args:
-        name (str): the name of the resource that is requested
-        resource_root_dir (str): the root directory where the search for resources should be started
-
-    Returns:
-        the absolute path of the data file with the given name. The first name that matches
-            is returned. If no file with the given name or path exists, a FileNotFoundError is raised.
-
-    """
-    for resource_dir in get_resource_dirs(resource_root_dir):
-        resource_path = join(resource_dir, name)
-        if exists(resource_path):
-            return Path(resource_path).absolute()
-    raise FileNotFoundError(errno.ENOENT, f"Could not locate resource '{name}'")
-
-
 def set_logger_levels(logger_levels: List[Tuple] = None):
     """
     Set the logging level for the given loggers.

--- a/libs/cgse-common/src/egse/config.py
+++ b/libs/cgse-common/src/egse/config.py
@@ -141,7 +141,7 @@ def find_dirs(pattern: str, root: Path | str) -> Generator[Path, None, None]:
                 yield Path(path) / name
 
 
-def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None) -> Generator[Path, None, None]:
+def find_files(pattern: str, root: Path | str, in_dir: str = None) -> Generator[Path, None, None]:
     """
     Generator for returning file paths from a top folder, matching the pattern.
 
@@ -155,22 +155,24 @@ def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None) ->
 
         >>> file_pattern = 'EtherSpaceLink*.dylib'
         >>> in_dir = 'lib/CentOS-7'
-        >>> for file in find_files(file_pattern, in_dir=in_dir):
+        >>> for file in find_files(file_pattern, root='.', in_dir=in_dir):
         ...     assert file.match("*lib/CentOS-7/EtherSpaceLink*")
 
     Args:
         pattern (str) : sorting pattern (use * for wildcard)
-        root (str): the top level folder to search [default=common-egse-root]
+        root (Path | str): the top level folder to search
         in_dir (str): the 'leaf' directory in which the file shall be
 
     Returns:
         Paths of files matching pattern, from root.
     """
-    root = Path(root).resolve() if root else get_common_egse_root()
+    root = Path(root).resolve()
     if not root.is_dir():
         root = root.parent
+    if not root.exists():
+        raise ValueError(f"The root argument didn't resolve into a valid directory: {root}.")
 
-    exclude_dirs = ("venv", "venv38", ".git", ".idea", ".DS_Store")
+    exclude_dirs = ("venv", "venv38", ".venv", ".nox", ".git", ".idea", ".DS_Store")
 
     for path, folders, files in os.walk(root):
         folders[:] = list(filter(lambda x: x not in exclude_dirs, folders))
@@ -180,7 +182,7 @@ def find_files(pattern: str, root: PurePath | str = None, in_dir: str = None) ->
             yield Path(path) / name
 
 
-def find_file(name: str, root: PurePath | str = None, in_dir: str = None) -> Path | None:
+def find_file(name: str, root: Path | str, in_dir: str = None) -> Path | None:
     """
     Find the path to the given file starting from the root directory of the
     distribution.
@@ -195,12 +197,12 @@ def find_file(name: str, root: PurePath | str = None, in_dir: str = None) -> Pat
 
         >>> file_pattern = 'EtherSpaceLink*.dylib'
         >>> in_dir = 'lib/CentOS-7'
-        >>> file = find_file(file_pattern, in_dir=in_dir)
+        >>> file = find_file(file_pattern, root='.', in_dir=in_dir)
         >>> assert file.match("*/lib/CentOS-7/EtherSpace*")
 
     Args:
         name (str): the name of the file
-        root (Path | str): the top level folder to search [default=common-egse-root]
+        root (Path | str): the top level folder to search
         in_dir (str): the 'leaf' directory in which the file shall be
 
     Returns:

--- a/libs/cgse-common/src/egse/config.py
+++ b/libs/cgse-common/src/egse/config.py
@@ -74,7 +74,7 @@ def find_first_occurrence_of_dir(pattern: str, root: Path | str) -> Path | None:
     return None
 
 
-def find_dir(pattern: str, root: str = None) -> Path | None:
+def find_dir(pattern: str, root: Path | str) -> Path | None:
     """
     Find the first folder that matches the given pattern.
 
@@ -84,8 +84,8 @@ def find_dir(pattern: str, root: str = None) -> Path | None:
     `find_dirs()` function and check if there is just one item returned in the list.
 
     Args:
-        pattern (str): pattern to match (use * for wildcard)
-        root (str): the top level folder to search [default=common-egse-root]
+        pattern: pattern to match (use * for wildcard)
+        root: the top level folder to search
 
     Returns:
         the first occurrence of the directory pattern or None when not found.
@@ -96,7 +96,7 @@ def find_dir(pattern: str, root: str = None) -> Path | None:
     return None
 
 
-def find_dirs(pattern: str, root: str = None) -> Generator[Path, None, None]:
+def find_dirs(pattern: str, root: Path | str) -> Generator[Path, None, None]:
     """
     Generator for returning directory paths from a walk started at `root` and matching pattern.
 
@@ -107,7 +107,7 @@ def find_dirs(pattern: str, root: str = None) -> Generator[Path, None, None]:
 
     Args:
         pattern (str): pattern to match (use * for wildcard)
-        root (str): the top level folder to search [default=common-egse-root]
+        root (str): the top level folder to search
 
     Returns:
          Generator: Paths of folders matching pattern, from root.
@@ -122,9 +122,10 @@ def find_dirs(pattern: str, root: str = None) -> Generator[Path, None, None]:
         ```
 
     """
+    root_arg = root
     root = Path(root).resolve() if root else get_common_egse_root()
     if not root.is_dir():
-        root = root.parent
+        raise ValueError(f"The root argument is not a valid directory: {root_arg}.")
 
     parts = pattern.rsplit("/", maxsplit=1)
     if len(parts) == 2:

--- a/libs/cgse-common/src/egse/resource.py
+++ b/libs/cgse-common/src/egse/resource.py
@@ -75,6 +75,8 @@ their functionality is fully replaced by this `egse.resource` module.
 
 """
 
+from __future__ import annotations
+
 __all__ = [
     "AmbiguityError",
     "NoSuchFileError",
@@ -190,7 +192,7 @@ def get_resource_locations() -> Dict[str, List[Path]]:
     return resources.copy()
 
 
-def get_resource_dirs(root_dir: Union[str, PurePath]) -> List[Path]:
+def get_resource_dirs(root_dir: Path | str) -> List[Path]:
     """
     Define directories that contain resources like images, icons, and data files.
 
@@ -224,7 +226,7 @@ def get_resource_dirs(root_dir: Union[str, PurePath]) -> List[Path]:
     return result
 
 
-def get_resource_path(name: str, resource_root_dir: Union[str, PurePath] = None) -> PurePath:
+def get_resource_path(name: str, resource_root_dir: Path | str) -> PurePath:
     """
     Searches for a data file (resource) with the given name.
 
@@ -249,7 +251,7 @@ def get_resource_path(name: str, resource_root_dir: Union[str, PurePath] = None)
     raise FileNotFoundError(errno.ENOENT, f"Could not locate resource '{name}'")
 
 
-def initialise_resources(root: Union[Path, str] = Path(__file__).parent):
+def initialise_resources(root: Path | str = Path(__file__).parent):
     """
     Initialise the default resources and any resource published by a package entry point.
 
@@ -302,7 +304,7 @@ def print_resources():
             print(f"    {location}")
 
 
-def add_resource_id(resource_id: str, location: Union[Path, str]):
+def add_resource_id(resource_id: str, location: Path | str):
     """
     Adds a resource identifier with the given location. Resources can then be specified
     using this resource id.

--- a/libs/cgse-common/src/egse/resource.py
+++ b/libs/cgse-common/src/egse/resource.py
@@ -109,7 +109,7 @@ from egse.exceptions import InternalError
 from egse.plugin import entry_points
 from egse.system import get_package_location
 
-_LOGGER = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class ResourceError(Exception):
@@ -211,7 +211,7 @@ def get_resource_dirs(root_dir: Path | str) -> List[Path]:
     """
 
     if root_dir is None:
-        _LOGGER.warning("The argument root_dir can not be None, an empty list is returned.")
+        _logger.warning("The argument root_dir can not be None, an empty list is returned.")
         return []
 
     root_dir = Path(root_dir).resolve()
@@ -230,14 +230,9 @@ def get_resource_path(name: str, resource_root_dir: Path | str) -> PurePath:
     """
     Searches for a data file (resource) with the given name.
 
-    When `resource_root_dir` is not given, the search for resources will start at the root
-    folder of the project (using the function `get_common_egse_root()`). Any other root
-    directory can be given, e.g. if you want to start the search from the location of your
-    source code file, use `Path(__file__).parent` as the `resource_root_dir` argument.
-
     Args:
         name (str): the name of the resource that is requested
-        resource_root_dir (str): the root directory w_HERE the search for resources should be started
+        resource_root_dir (str): the root directory where the search for resources should be started
 
     Returns:
         the absolute path of the data file with the given name. The first name that matches
@@ -286,7 +281,7 @@ def initialise_resources(root: Path | str = Path(__file__).parent):
             if location not in x:
                 x.append(location)
 
-    _LOGGER.debug(f"Resources have been initialised: {resources = }")
+    _logger.debug(f"Resources have been initialised: {resources = }")
 
 
 def print_resources():

--- a/libs/cgse-common/tests/data/COPYING
+++ b/libs/cgse-common/tests/data/COPYING
@@ -1,0 +1,1 @@
+# This file is used in the test_config.py unit test. It searches files that start with "COPY".

--- a/libs/cgse-common/tests/test_config.py
+++ b/libs/cgse-common/tests/test_config.py
@@ -48,6 +48,14 @@ def test_find_first_occurrence_of_dir():
 
     shutil.rmtree(_HERE / "x_data")
 
+    # Pass incorrect arguments
+
+    with pytest.raises(ValueError, match="The root argument is not a valid directory"):
+        assert find_first_occurrence_of_dir("data", "non-existing-folder")
+
+    with pytest.raises(TypeError, match="missing 1 required positional argument"):
+        find_first_occurrence_of_dir("data")
+
 
 def test_find_root():
     assert find_root(None) is None

--- a/libs/cgse-common/tests/test_config.py
+++ b/libs/cgse-common/tests/test_config.py
@@ -9,7 +9,6 @@ from egse.config import find_file
 from egse.config import find_files
 from egse.config import find_first_occurrence_of_dir
 from egse.config import find_root
-from egse.config import get_common_egse_root
 
 _HERE = Path(__file__).parent.resolve()
 
@@ -64,40 +63,9 @@ def test_find_root():
     assert find_root("/", tests=("non-existing-tmp",)) is None
 
 
-def test_get_common_egse_root():
-    print()
-
-    # for the following test I assume that we are in the repository, but we can not test
-    # the value as it will be different for each installation
-    assert get_common_egse_root() is not None
-
-    print(f"{get_common_egse_root() = }")
-
-    # for the following test I assume that we are on a unix system (Linux or macOS)
-    assert get_common_egse_root(Path("/tmp")) is None
-
-
 def test_find_root_exceptions():
     assert find_root("/non-existing-path") is None
     assert find_root(None) is None
-
-
-def test_get_common_egse_root_with_env():
-    import os
-
-    os.environ["COMMON_EGSE_PATH"] = "/Users/rik/git"
-
-    # I added lru_cache to speed up the get_common_egse_root() function, but this
-    # is of course fatal for test harnesses. T_HEREfore, clear the cache before and
-    # after this test.
-
-    get_common_egse_root.cache_clear()
-
-    assert get_common_egse_root() == Path("/Users/rik/git")
-
-    get_common_egse_root.cache_clear()
-
-    del os.environ["COMMON_EGSE_PATH"]
 
 
 def test_find_files():

--- a/libs/cgse-common/tests/test_config.py
+++ b/libs/cgse-common/tests/test_config.py
@@ -126,16 +126,19 @@ def test_find_files():
 
 
 def test_find_dirs():
+    print()
     dir_name = "dev[12]"
-    dirs = list(find_dirs(dir_name))
+    dirs = list(find_dirs(dir_name, _HERE))
+    print(dirs)
     assert dirs
 
     dir_name = "dev1"
-    dirs = list(find_dirs(dir_name))
+    dirs = list(find_dirs(dir_name, _HERE))
+    print(dirs)
     assert dirs
 
     dir_name = "lib/dev*"
-    dirs = list(find_dirs(dir_name))
+    dirs = list(find_dirs(dir_name, _HERE))
     print(dirs)
     # The third file could be in the build folder which doesn't always exists.
     # A fourth file could be in the virtual environment venv or venv38
@@ -144,7 +147,7 @@ def test_find_dirs():
     # use the leading '/' to prevent that another 'lib/dev' is matched.
 
     dir_name = "/lib/dev*"
-    dirs = list(find_dirs(dir_name))
+    dirs = list(find_dirs(dir_name, _HERE))
     print(dirs)
     # The second file could be in the build folder which doesn't always exists.
     assert len(dirs) in (1, 2)

--- a/libs/cgse-common/tests/test_config.py
+++ b/libs/cgse-common/tests/test_config.py
@@ -101,7 +101,10 @@ def test_get_common_egse_root_with_env():
 
 
 def test_find_files():
-    files = list(find_files("COPY*", root=get_common_egse_root()))
+    print()
+
+    files = list(find_files("COPY*", root=_HERE))
+    print(files)
     assert files
 
     for f in files:
@@ -109,14 +112,14 @@ def test_find_files():
 
     # no files named 'data', only folders that are named 'data', use find_dirs for this.
 
-    files = list(find_files("data", root=get_common_egse_root() / "src"))
+    files = list(find_files("data", root=_HERE / "src"))
+    print(files)
     assert not files
 
     # When I want to find a file in a specific directory, use the in_dir keyword
 
     filename_pattern = "shared-lib.so"
-    files = list(find_files(filename_pattern, in_dir="lib/dev1"))
-    print()
+    files = list(find_files(filename_pattern, root=_HERE, in_dir="lib/dev1"))
     print(files)
 
     # The expected file is in the src/egse/lib/CentOS-7 folder, but
@@ -154,11 +157,13 @@ def test_find_dirs():
 
 
 def test_find_file():
-    assert find_file("pyproject.toml")
-    assert find_file("data-file.txt")
-    assert not find_file("non-existing-file.txt")
+    project_root = _HERE.parent
 
-    assert find_file("config.py", in_dir="egse")
+    assert find_file("pyproject.toml", project_root)
+    assert find_file("data-file.txt", project_root)
+    assert not find_file("non-existing-file.txt", project_root)
+
+    assert find_file("config.py", root=project_root, in_dir="egse")
 
 
 def test_working_directory():

--- a/libs/cgse-common/tests/test_process.py
+++ b/libs/cgse-common/tests/test_process.py
@@ -59,7 +59,7 @@ def test_zombie():
 def test_is_process_running():
     # The empty_process.py should be located in the src/tests/scripts directory of the project
 
-    stub = SubProcess("Stub Process", [sys.executable, str(find_file("empty_process.py").resolve())])
+    stub = SubProcess("Stub Process", [sys.executable, str(find_file("empty_process.py", root=HERE).resolve())])
     stub.execute()
 
     time.sleep(0.1)  # allow process time to start/terminate
@@ -82,7 +82,7 @@ def test_is_process_running():
 def test_get_process_info():
     # The empty_process.py should be located in the src/tests/scripts directory of the project
 
-    stub = SubProcess("Stub Process", [sys.executable, str(find_file("empty_process.py").resolve())])
+    stub = SubProcess("Stub Process", [sys.executable, str(find_file("empty_process.py", root=HERE).resolve())])
     stub.execute()
 
     time.sleep(0.1)  # allow process time to start/terminate
@@ -131,7 +131,7 @@ def test_error_during_execute():
 def test_terminated_process():
     # Process void-0 exits with an exit code of 0
 
-    process = SubProcess("Stub Process", [sys.executable, str(find_file("void-0.py").resolve())])
+    process = SubProcess("Stub Process", [sys.executable, str(find_file("void-0.py", root=HERE).resolve())])
 
     assert process.execute()
     time.sleep(0.5)  # allow process time to terminate
@@ -140,7 +140,7 @@ def test_terminated_process():
 
     # Process void-1 exits with an exit code of 1
 
-    process = SubProcess("Stub Process", [sys.executable, str(find_file("void-1.py").resolve())])
+    process = SubProcess("Stub Process", [sys.executable, str(find_file("void-1.py", root=HERE).resolve())])
 
     assert process.execute()
     time.sleep(0.5)  # allow process time to terminate
@@ -152,7 +152,7 @@ def test_quit_process():
     # when --ignore-sigterm is given, the process will be killed and return code will be -9.
 
     process = SubProcess(
-        "Handle SIGTERM", [sys.executable, str(find_file("handle_sigterm.py").resolve()), "--ignore-sigterm"]
+        "Handle SIGTERM", [sys.executable, str(find_file("handle_sigterm.py", root=HERE).resolve()), "--ignore-sigterm"]
     )
 
     assert process.execute()
@@ -170,7 +170,7 @@ def test_quit_process():
 
     # when --ignore-sigterm is not given, the process will handle the SIGTERM and exit with 42.
 
-    process = SubProcess("Handle SIGTERM", [sys.executable, str(find_file("handle_sigterm.py").resolve())])
+    process = SubProcess("Handle SIGTERM", [sys.executable, str(find_file("handle_sigterm.py", root=HERE).resolve())])
 
     assert process.execute()
     time.sleep(1.0)  # allow process to start

--- a/libs/cgse-common/tests/test_resource.py
+++ b/libs/cgse-common/tests/test_resource.py
@@ -314,7 +314,7 @@ def test_get_resource_dirs(caplog):
 
 def test_get_resource_path():
     with pytest.raises(FileNotFoundError):
-        get_resource_path("non-existing-file")
+        get_resource_path("non-existing-file", HERE)
 
     # The following resources should all exist in this project
     # We don't need the return value as the function raises a FileNotFoundError

--- a/libs/cgse-gui/src/egse/gui/switch.py
+++ b/libs/cgse-gui/src/egse/gui/switch.py
@@ -12,7 +12,6 @@ from PyQt5.QtGui import QPainter
 from PyQt5.QtSvg import QSvgRenderer
 from PyQt5.QtWidgets import QWidget
 
-from egse.config import find_dir
 from egse.resource import get_resource
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
- in following functions in `egse.config` shall require the `root` argument instead of making it optional:
	- `find_dir` and `find_dirs` 
	- `find_file` and `find_files`
	- `find_first_occurrence_of_dir`
	- `get_resource_dirs` and `get_resource_path` ⚠️ ‼️ these function were defined in both `egse/config.py` and `egse/resource.py`
- the `get_common_egse_root()` function shall be removed


Unit tests for `test_config.py` and `test_resource.py` have been updated accordingly.