### PR TITLE
registry server improved stability

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -23,15 +23,13 @@ dependencies = [
     "deepdiff>=8.1.1",
     "distro>=1.9.0",
     "gitpython>=3.1.44",
-    #    "numpy==1.22.4",
-    #    "pandas>=1.5.1",
-    "pip>=24.3.1", # only used in setup
     "prometheus-client>=0.21.1",
     "psutil>=6.1.1",
     "pyyaml>=6.0.2",
-    #    "pyzmq == 23.2.1",
     "rich>=13.9.4",
     "typer>=0.15.1",
+    "navdict>=0.2.4",
+
     # Python 3.9 specific dependencies
     "numpy==1.26.4; python_version == '3.9'",
     "pandas==1.5.1; python_version == '3.9'",
@@ -40,6 +38,7 @@ dependencies = [
     "numpy>=2.1; python_version >= '3.10'",
     "pandas>=2.2.0; python_version >= '3.10'",
     "pyzmq>=25.1.0; python_version >= '3.10'",
+
     # Python 3.10+ entrypoints interface changed
     "importlib_metadata>=4.6.0; python_version == '3.9'",
     "influxdb3-python",

--- a/libs/cgse-common/src/egse/decorators.py
+++ b/libs/cgse-common/src/egse/decorators.py
@@ -218,6 +218,31 @@ def timer(*, name: str = "timer", level: int = logging.INFO, precision: int = 4)
     return actual_decorator
 
 
+def async_timer(*, name: str = "timer", level: int = logging.INFO, precision: int = 4):
+    """
+    Print the runtime of the decorated async function.
+
+    Args:
+        name: a name for the Timer, will be printed in the logging message
+        level: the logging level for the time message [default=INFO]
+        precision: the number of decimals for the time [default=3 (ms)]
+    """
+
+    def actual_decorator(func):
+        @functools.wraps(func)
+        async def wrapper_timer(*args, **kwargs):
+            start_time = time.perf_counter()
+            value = await func(*args, **kwargs)
+            end_time = time.perf_counter()
+            run_time = end_time - start_time
+            _LOGGER.log(level, f"{name}: Finished {func.__name__!r} in {run_time:.{precision}f} secs")
+            return value
+
+        return wrapper_timer
+
+    return actual_decorator
+
+
 def time_it(count: int = 1000, precision: int = 4) -> Callable:
     """Print the runtime of the decorated function.
 

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -5,13 +5,13 @@ from pathlib import Path
 import rich
 
 
-def start_rs_cs():
+def start_rs_cs(log_level: str):
     rich.print("Starting the registry service core service...")
 
     out = open(Path('~/.rs_cs.start.out').expanduser(), 'w')
 
     subprocess.Popen(
-        [sys.executable, '-m', 'egse.registry.server', 'start'],
+        [sys.executable, '-m', 'egse.registry.server', 'start', '--log-level', log_level],
         stdout=out, stderr=out, stdin=subprocess.DEVNULL,
         close_fds=True
     )

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -19,12 +19,12 @@ core = typer.Typer(
 
 
 @core.command(name="start")
-def start_core_services():
+def start_core_services(log_level: str = "WARNING"):
     """Start the core services in the background."""
 
     rich.print("[green]Starting the core services...[/]")
 
-    start_rs_cs()
+    start_rs_cs(log_level)
     start_log_cs()
     start_sm_cs()
     start_cm_cs()

--- a/libs/cgse-core/src/egse/confman/confman.yaml
+++ b/libs/cgse-core/src/egse/confman/confman.yaml
@@ -37,6 +37,9 @@ Commands:
                         When no test is running, i.e. we have not started an observation,
                         then a Message is returned.
 
+    register_to_storage:
+        description:    Register the configuration manager to the storage.
+    
     # Commands for handling Setups
 
     load_setup:

--- a/libs/cgse-core/src/egse/registry/__init__.py
+++ b/libs/cgse-core/src/egse/registry/__init__.py
@@ -1,8 +1,21 @@
 import logging
+from enum import Enum
 
 # Default ports that are assigned to REQ-REP and PUB-SUB protocols of the registry services
 DEFAULT_RS_REQ_PORT = 4242  # Handle requests
 DEFAULT_RS_PUB_PORT = 4243  # Publish events
 DEFAULT_RS_HB_PORT = 4244  # Heartbeats
+
+DEFAULT_RS_DB_PATH = 'service_registry.db'
+
+
+class MessageType(Enum):
+    """Message types using the envelope frame in the ROUTER-DEALER protocol."""
+    REQUEST_WITH_REPLY = b"REQ"     # Client expects a reply
+    REQUEST_NO_REPLY = b"NO-REQ"    # No reply expected by the client
+    RESPONSE = b"REP"               # Response to a request
+    NOTIFICATION = b"NOTIF"         # Server-initiated notification
+    HEARTBEAT = b"HB"               # Heartbeat/health check
+
 
 logger = logging.getLogger("egse.registry")

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -25,6 +25,7 @@ from egse.registry import DEFAULT_RS_DB_PATH
 from egse.registry import DEFAULT_RS_HB_PORT
 from egse.registry import DEFAULT_RS_PUB_PORT
 from egse.registry import DEFAULT_RS_REQ_PORT
+from egse.registry import MessageType
 from egse.registry import logger
 from egse.registry.backend import AsyncRegistryBackend
 from egse.registry.backend import AsyncSQLiteBackend
@@ -66,26 +67,10 @@ class AsyncRegistryServer:
         self.cleanup_interval = cleanup_interval
         self.logger = logger
 
-        # Set ZeroMQ to use asyncio
-        self.context = zmq.asyncio.Context()
-
-        # Socket to handle REQ-REP pattern
-        req_rep_endpoint = f"tcp://*:{req_port}"
-        self.req_rep_socket = self.context.socket(zmq.REP)
-        self.req_rep_socket.bind(req_rep_endpoint)
-        self.logger.info(f"Binding request socket to {req_rep_endpoint}")
-
-        # Socket to publish service events
-        pub_endpoint = f"tcp://*:{pub_port}"
-        self.pub_socket = self.context.socket(zmq.PUB)
-        self.pub_socket.bind(pub_endpoint)
-        self.logger.info(f"Binding publish socket to {pub_endpoint}")
-
-        # Socket to handle heartbeats
-        hb_endpoint = f"tcp://*:{hb_port}"
-        self.hb_socket = self.context.socket(zmq.REP)
-        self.hb_socket.bind(hb_endpoint)
-        self.logger.info(f"Binding heartbeat socket to {hb_endpoint}")
+        self.context = None
+        self.req_socket = None
+        self.pub_socket = None
+        self.hb_socket = None
 
         # Initialize the storage backend
         self.backend = backend or AsyncSQLiteBackend(db_path)
@@ -97,8 +82,32 @@ class AsyncRegistryServer:
         # Tasks
         self._tasks = set()
 
-    async def initialize(self):
-        """Initialize the server."""
+    async def setup_sockets(self):
+        """Set up the communication sockets."""
+
+        # Set ZeroMQ to use asyncio
+        self.context = zmq.asyncio.Context()
+
+        # Socket to handle requests and commands
+        req_rep_endpoint = f"tcp://*:{self.req_port}"
+        self.req_socket = self.context.socket(zmq.ROUTER)
+        self.req_socket.bind(req_rep_endpoint)
+        self.logger.info(f"Binding request socket to {req_rep_endpoint}")
+
+        # Socket to publish service events
+        pub_endpoint = f"tcp://*:{self.pub_port}"
+        self.pub_socket = self.context.socket(zmq.PUB)
+        self.pub_socket.bind(pub_endpoint)
+        self.logger.info(f"Binding publish socket to {pub_endpoint}")
+
+        # Socket to handle heartbeats
+        hb_endpoint = f"tcp://*:{self.hb_port}"
+        self.hb_socket = self.context.socket(zmq.REP)
+        self.hb_socket.bind(hb_endpoint)
+        self.logger.info(f"Binding heartbeat socket to {hb_endpoint}")
+
+    async def initialize_backend(self):
+        """Initialize the storage backend."""
         await self.backend.initialize()
 
     async def start(self):
@@ -109,8 +118,9 @@ class AsyncRegistryServer:
         if self._running:
             return
 
-        # Initialize the backend
-        await self.initialize()
+        await self.setup_sockets()
+
+        await self.initialize_backend()
 
         self._running = True
         self.logger.info(
@@ -159,7 +169,7 @@ class AsyncRegistryServer:
         await self.backend.close()
 
         # Close ZeroMQ sockets
-        self.req_rep_socket.close()
+        self.req_socket.close()
         self.pub_socket.close()
         self.hb_socket.close()
 
@@ -203,49 +213,28 @@ class AsyncRegistryServer:
                     # Wait for a request with timeout to allow checking if still running
                     try:
                         # self.logger.info("Waiting for a request with 1s timeout...")
-                        message_json = await asyncio.wait_for(
-                            self.req_rep_socket.recv_string(),
+                        message_parts = await asyncio.wait_for(
+                            self.req_socket.recv_multipart(),
                             timeout=1.0
                         )
                     except asyncio.TimeoutError:
                         self.logger.debug("waiting for command request...")
                         continue
 
-                    # Parse the request
-                    request = json.loads(message_json)
-                    self.logger.info(f"Received request: {request}")
+                    if len(message_parts) >= 3:
+                        client_id = message_parts[0]
+                        message_type = MessageType(message_parts[1])
+                        message_data = message_parts[2]
 
-                    # Process the request
-                    response = await self._process_request(request)
+                        self.logger.info(f"{client_id = }, {message_type = }, {message_data = }")
+                        response = await self._process_request(message_data)
 
-                    # Send the response
-                    await self.req_rep_socket.send_string(json.dumps(response))
+                        await self._send_response(client_id, message_type, response)
+
                 except zmq.ZMQError as exc:
-                    self.logger.error(f"ZMQ error: {exc}")
-                except json.JSONDecodeError as exc:
-                    self.logger.error(f"Invalid JSON received: {exc}")
-                    await self.req_rep_socket.send_string(
-                        json.dumps(
-                            {
-                                'success': False,
-                                'error': 'Invalid JSON format'
-                            }
-                        )
-                    )
+                    self.logger.error(f"ZMQ error: {exc}", exc_info=True)
                 except Exception as exc:
                     self.logger.error(f"Error handling request: {exc}", exc_info=True)
-                    try:
-                        await self.req_rep_socket.send_string(
-                            json.dumps(
-                                {
-                                    'success': False,
-                                    'error': str(exc)
-                                }
-                            )
-                        )
-                    except Exception as exc:
-                        self.logger.error("Second Exception when handling error...", exc_info=True)
-                        pass
         except asyncio.CancelledError:
             self.logger.warning("Request handler task cancelled")
 
@@ -275,16 +264,22 @@ class AsyncRegistryServer:
         except Exception as exc:
             self.logger.error(f"Failed to publish event: {exc}")
 
-    async def _process_request(self, request: dict[str, Any]) -> dict[str, Any]:
+    async def _process_request(self, msg_data: bytes):
         """
         Process a client request and generate a response.
 
         Args:
-            request: The request message
+            msg_data: the actual JSON with the request
 
-        Returns:
-            The response message
         """
+        try:
+            request = json.loads(msg_data.decode())
+            self.logger.info(f"Received request: {request}")
+
+        except json.JSONDecodeError as exc:
+            self.logger.error(f"Invalid JSON received: {exc}")
+            return {'success': False, 'error': 'Invalid JSON format'}
+
         action = request.get('action')
         if not action:
             return {'success': False, 'error': 'Missing required field: action'}
@@ -306,6 +301,19 @@ class AsyncRegistryServer:
             return {'success': False, 'error': f'Unknown action: {action}'}
 
         return await handler(request)
+
+    async def _send_response(self, client_id: bytes, msg_type: MessageType, response: dict[str, Any]):
+        """
+        If the client expects a reply, send the response.
+
+        Args:
+            client_id: the client identification, part 1 of the multipart message
+            msg_type: the type of the message, e.g. if reply is required
+            response: a dictionary with the status and response
+
+        """
+        if msg_type == MessageType.REQUEST_WITH_REPLY:
+            await self.req_socket.send_multipart([client_id, MessageType.RESPONSE.value, json.dumps(response).encode()])
 
     async def _handle_register(self, request: dict[str, Any]) -> dict[str, Any]:
         """Handle a service registration request."""

--- a/libs/cgse-core/tests/stress_test_registry_server.py
+++ b/libs/cgse-core/tests/stress_test_registry_server.py
@@ -1,0 +1,89 @@
+import asyncio
+import logging
+import time
+
+import rich
+
+from egse.decorators import async_timer
+from egse.decorators import timer
+from egse.registry.client import AsyncRegistryClient
+from egse.registry.client import RegistryClient
+
+logging.basicConfig(level=logging.INFO)
+
+
+@timer()
+def main(count: int = 1):
+    for _ in range(count):
+        with RegistryClient() as reg:
+            if reg.health_check():
+                rich.print("[green]registry server is healthy.")
+            else:
+                rich.print("[red]error: health check failed.[/]")
+
+            service_id = reg.register("stress-test", "localhost", 1234, "testing")
+            if service_id is None:
+                rich.print("[red]error: Couldn't register stress-test[/]")
+
+            endpoint = reg.get_endpoint("testing")
+            if endpoint is None:
+                rich.print("[red]error: no endpoint for testing[/]")
+
+            service = reg.get_service(service_id)
+            if service is None:
+                rich.print(f"[red]error: no service {service_id} found[/]")
+
+            if not reg.deregister(service_id):
+                rich.print("[red]error: Couldn't de-register stress-test[/]")
+
+
+@async_timer()
+async def amain(count: int = 1):
+    for _ in range(count):
+        with AsyncRegistryClient() as reg:
+            if await reg.health_check():
+                rich.print("[green]registry server is healthy.")
+            else:
+                rich.print("[red]error: health check failed.[/]")
+
+            service_id = await reg.register("stress-test", "localhost", 1234, "testing")
+            if service_id is None:
+                rich.print("[red]error: Couldn't register stress-test[/]")
+
+            endpoint = await reg.get_endpoint("testing")
+            if endpoint is None:
+                rich.print("[red]error: no endpoint for testing[/]")
+
+            service = await reg.get_service(service_id)
+            if service is None:
+                rich.print(f"[red]error: no service {service_id} found[/]")
+
+            if not await reg.deregister(service_id):
+                rich.print("[red]error: Couldn't de-register stress-test[/]")
+
+
+if __name__ == '__main__':
+
+    with RegistryClient() as reg:
+        service_id = reg.register("stress-test-heartbeat", "localhost", 5678)
+        reg.start_heartbeat(3)
+
+        main()
+
+        time.sleep(10)
+        response = reg.server_status()
+        rich.print(response)
+        time.sleep(10)
+
+        asyncio.run(amain())
+
+        reg.stop_heartbeat()
+        reg.deregister(service_id)
+
+        response = reg.server_status()
+        rich.print(response)
+
+        if reg.terminate_registry_server():
+            rich.print("[green]Registry Server terminated successfully[/]")
+        else:
+            rich.print("[red]error: Couldn't terminate registry server..[/]")


### PR DESCRIPTION
This pull request improves the stability of the service registry server. We have seen that the request socket goes into an invalid state often when there is a network problem or the machine goes into sleep mode. That happens when a request is received, but the reply was not sent. We fixed this issue with moving the request protocol from REQ-REP to ROUTER-DEALER. 

Added a test script in `tests`: `stress-test-registry-server.py`. This script creates sync and asynchronous clients, registers/de-registers, performs other functions on the registry server. All these requests are executes count times in a loop while the script itself also register and sends heartbeats to the registry server. The server performs well, even if hundreds of registrations and other requests are done.