### PR TITLE
Feature: file based signaling

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.11.4"
+version = "0.11.5"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.10.0"
+version = "0.11.0"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.11.3"
+version = "0.11.4"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 ]
 
 [project.scripts]
-cgse = 'scripts.cgse:app'
+cgse = 'cgse_common.cgse:app'
 monitor = "egse.monitoring:app"
 
 [project.entry-points."cgse.version"]

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.11.0"
+version = "0.11.1"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.11.2"
+version = "0.11.3"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.11.1"
+version = "0.11.2"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "pyzmq>=25.1.0; python_version >= '3.10'",
 
     # Python 3.10+ entrypoints interface changed
-    "importlib_metadata>=4.6.0; python_version == '3.9'",
+    "importlib_metadata>=4.6.0; python_version <= '3.11'",
     "influxdb3-python",
 ]
 

--- a/libs/cgse-common/src/cgse_common/__init__.py
+++ b/libs/cgse-common/src/cgse_common/__init__.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class AppState:
+    """Global Typer app parameters."""
+    verbose: bool = False

--- a/libs/cgse-common/src/cgse_common/cgse.py
+++ b/libs/cgse-common/src/cgse_common/cgse.py
@@ -69,7 +69,7 @@ class SortedCommandGroup(TyperGroup):
         commands = super().list_commands(ctx)
 
         # Define priority commands in specific order
-        priority_commands = ["init", "version", "show", "top", "core", "log_cs", "rm_cs"]
+        priority_commands = ["init", "version", "show", "top", "core", "registry", "log", "cm", "sm", "pm"]
 
         # Custom sort:
         # First the priority commands in the given order (their index)

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -6,6 +6,7 @@ __all__ = [
     "load_plugins",
     "get_file_infos",
     "entry_points",
+    "HierarchicalEntryPoints",
 ]
 import logging
 import os

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -15,7 +15,7 @@ import textwrap
 import traceback
 from pathlib import Path
 
-if sys.version_info >= (3, 10):    # Use the standard library version (Python 3.10+)
+if sys.version_info >= (3, 12):    # Use the standard library version (Python 3.10+)
     from importlib.metadata import entry_points as lib_entry_points
     from importlib.metadata import EntryPoint
 else:
@@ -114,11 +114,13 @@ class HierarchicalEntryPoints:
     def _discover_groups(self):
         """Discover all groups that match the base group pattern."""
         all_eps = lib_entry_points()
+        rich.print(f"{type(all_eps) = }")
 
         self.groups = {}
         self.flat_entries = []
 
         for ep in all_eps:
+            rich.print(f"{type(ep) = }, {dir(ep) = }")
             if ep.group == self.base_group or ep.group.startswith(f"{self.base_group}."):
                 self.groups[ep.group] = ep
                 self.flat_entries.append(ep)

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -114,13 +114,13 @@ class HierarchicalEntryPoints:
     def _discover_groups(self):
         """Discover all groups that match the base group pattern."""
         all_eps = lib_entry_points()
-        rich.print(f"{type(all_eps) = }")
+        # rich.print(f"{type(all_eps) = }")
 
         self.groups = {}
         self.flat_entries = []
 
         for ep in all_eps:
-            rich.print(f"{type(ep) = }, {dir(ep) = }")
+            # rich.print(f"{type(ep) = }, {dir(ep) = }")
             if ep.group == self.base_group or ep.group.startswith(f"{self.base_group}."):
                 self.groups[ep.group] = ep
                 self.flat_entries.append(ep)

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -105,6 +105,44 @@ def get_file_infos(entry_point: str) -> dict[str, tuple[Path, str]]:
     return eps
 
 
+class HierarchicalEntryPoints:
+    def __init__(self, base_group: str):
+        self.base_group = base_group
+        self._discover_groups()
+
+    def _discover_groups(self):
+        """Discover all groups that match the base group pattern."""
+        all_eps = lib_entry_points()
+
+        self.groups = {}
+        self.flat_entries = []
+
+        for ep in all_eps:
+            if ep.group == self.base_group or ep.group.startswith(f"{self.base_group}."):
+                self.groups[ep.group] = ep
+                self.flat_entries.append(ep)
+
+    def get_all_entry_points(self):
+        """Get all entry points as a flat list."""
+        return self.flat_entries
+
+    def get_by_subgroup(self, subgroup=None):
+        """Get entry points from a specific subgroup."""
+        if subgroup is None:
+            return self.groups.get(self.base_group, [])
+
+        full_group = f"{self.base_group}.{subgroup}"
+        return self.groups.get(full_group, [])
+
+    def get_all_groups(self):
+        """Get all discovered group names."""
+        return list(self.groups.keys())
+
+    def get_by_type(self, entry_type):
+        """Get entry points by type (assuming type is the subgroup name)."""
+        return self.get_by_subgroup(entry_type)
+
+
 # The following code was adapted from the inspiring package click-plugins
 # at https://github.com/click-contrib/click-plugins/
 

--- a/libs/cgse-common/src/egse/signal.py
+++ b/libs/cgse-common/src/egse/signal.py
@@ -1,0 +1,213 @@
+__all__ = [
+    "DEFAULT_SIGNAL_DIR",
+    "FileBasedSignaling",
+    "create_signal_command_file",
+]
+
+import json
+import logging
+import os
+import queue
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from egse.system import format_datetime
+
+logger = logging.getLogger('egse.signal')
+
+DEFAULT_SIGNAL_DIR = "/tmp/cgse_signals"
+
+
+class FileBasedSignaling:
+    """
+    Thread-safe file-based signaling system for inter-process communication.
+
+    Monitors a directory for JSON command files and queues them for processing
+    in the main thread. Commands are automatically removed after being read.
+
+    Usage:
+        signaling = FileBasedSignaling("my_service_id")
+        signaling.start_monitoring()
+        signaling.register_handler('reload', my_reload_function)
+
+        # In your main loop:
+        signaling.process_pending_commands()
+
+        # Send commands by creating JSON files:
+        echo '{"action": "reload", "params": {}}' > /tmp/cgse_signals/my_service_id_cmd.json
+
+    Thread Safety:
+        - File monitoring runs in a background daemon thread
+        - Commands are queued and processed with process_pending_commands()
+          which should be called from the main thread, main loop.
+        - All command handlers execute in the main thread context
+
+    Args:
+        service_id: the identifier of your service that shall execute the command.
+        signal_dir (str): Directory path to monitor for command files.
+            Created if it doesn't exist. Defaults to "/tmp/cgse_signals"
+
+    To trigger actions, create the files in `/tmp/cgse_signals`:
+
+      $ echo "{'action': 'reregister'}" > /tmp/cgse_signals/cm_cs_reregister.json
+
+    """
+    def __init__(self, service_id: str, signal_dir=DEFAULT_SIGNAL_DIR):
+        self.signal_dir: Path = Path(signal_dir)
+        self.signal_dir.mkdir(exist_ok=True)
+        self.service_id = service_id
+        self.running = True
+        self.thread = None  # the monitoring thread
+
+        # Queue to pass commands from monitoring thread to main thread
+        self.command_queue = queue.Queue()
+        self.command_handlers = {}
+
+        # Register some default handlers
+        self.register_handler('reregister', self.handle_reregister)
+        self.register_handler('reload', self.handle_reload)
+
+    def register_handler(self, action, handler_func):
+        """Register a handler function for a specific action."""
+
+        overwrite = True if action in self.command_handlers else False
+
+        self.command_handlers[action] = handler_func
+        logger.info(f"Registered handler for action: {action}{' (overwritten)' if overwrite else ''}")
+
+    def start_monitoring(self):
+        """
+        Start a monitoring thread for signal command file. The thread will put any commands that match
+        the service_id on the command queue to be processed by the main loop.
+        """
+        self.thread = threading.Thread(target=self._monitor_loop, daemon=True)
+        self.thread.start()
+        return self.thread
+
+    def _monitor_loop(self):
+        while self.running:
+            for filepath in self.signal_dir.glob(f"{self.service_id}*.json"):
+                if filepath.is_file():
+                    try:
+                        with open(filepath, 'r') as fd:
+                            command = json.load(fd)
+                        # File will only be deleted when json could load it
+                        filepath.unlink(missing_ok=True)
+
+                        # Put command in queue for main thread to process
+                        self.command_queue.put(
+                            {
+                                'command': command,
+                                'source': str(filepath),
+                                'timestamp': format_datetime()},
+                        )
+                    except Exception as exc:
+                        logger.error(f"Error reading command file {filepath!s}: {exc}")
+
+            time.sleep(0.1)
+
+    # Remember that this function needs to be called from the main thread
+
+    def process_pending_commands(self):
+        """
+        Process the commands that are on the command queue. The registered command handler that
+        matches the action will be called with any keyword arguments that are specified in the
+        `param` key.
+
+        Call this from your main thread to process signaling commands.
+        """
+
+        processed_count = 0
+
+        # Process all pending commands
+        while not self.command_queue.empty():
+            try:
+                command_data = self.command_queue.get_nowait()
+                command = command_data['command']
+                action = command.get('action')
+                params: dict = command.get('params', {})
+
+                if action in self.command_handlers:
+                    logger.info(f"🎯 Processing command in main thread: {action} with {params}")
+                    try:
+                        self.command_handlers[action](**params)
+                        processed_count += 1
+                    except Exception as exc:
+                        logger.error(f"Error in handler for {action}: {exc}")
+                else:
+                    logger.warning(f"No handler registered for action: {action}")
+
+                self.command_queue.task_done()
+
+            except queue.Empty:
+                break
+            except Exception as exc:
+                logger.error(f"Error processing command: {exc}")
+
+        return processed_count
+
+    def handle_reregister(self, **params):
+        """Default dummy handler for reregistration signals."""
+        logger.warning(f"🔄 Re-registering service with params: {params} -> register your own function")
+
+    def handle_reload(self, **params):
+        """Default dummy handler for reloading signals."""
+        logger.warning(f"⚙️ Reloading config with params: {params} -> register your own function")
+
+    def stop(self):
+        """Terminate the monitoring loop thread."""
+        self.running = False
+        if self.thread.is_alive():
+            self.thread.join(timeout=1)
+
+
+def create_signal_command_file(signal_dir, service_id, command):
+    """
+    Atomically create a signal command file for a specific service.
+
+    Creates a JSON command file using atomic file operations to prevent race
+    conditions. The file is first written to a temporary file, then atomically
+    renamed to the final destination.
+
+    Args:
+        signal_dir (Path): Directory where the signal file will be created
+        service_id (str): Unique identifier for the target service
+        command (dict): Command dictionary containing at least an 'action' key.
+                       Will be serialized as JSON with 2-space indentation.
+
+    Returns:
+        None
+
+    Raises:
+        OSError: If the signal directory is not writable or disk is full
+        json.JSONEncodeError: If the command cannot be serialized to JSON
+        Exception: Re-raises any other exception after cleaning up temp file
+
+    Example:
+        signal_dir = Path("/tmp/myapp_signals")
+        create_signal_command_file(
+            signal_dir,
+            "user-service-8001",
+            {"action": "reregister", "params": {"force": True}}
+        )
+        # Creates: /tmp/myapp_signals/user-service-8001_reregister.json
+
+    Note:
+        The final filename format is: {service_id}_{action}.json
+        If no 'action' key exists in command, defaults to 'cmd'.
+    """
+    temp_fd, temp_path = tempfile.mkstemp(dir=signal_dir, suffix='.tmp')
+
+    try:
+        filepath = signal_dir / f"{service_id}_{command.get('action', 'cmd')}.json"
+
+        with os.fdopen(temp_fd, 'w') as fd:
+            json.dump(command, fd, indent=2)
+
+        Path(temp_path).rename(filepath)
+
+    except Exception as exc:
+        Path(temp_path).unlink(missing_ok=True)
+        raise exc

--- a/libs/cgse-common/src/egse/signal.py
+++ b/libs/cgse-common/src/egse/signal.py
@@ -55,6 +55,9 @@ class FileBasedSignaling:
 
     """
     def __init__(self, service_id: str, signal_dir=DEFAULT_SIGNAL_DIR):
+
+        logger.info(f"Set up file-based signaling for {service_id} in {signal_dir!s}")
+
         self.signal_dir: Path = Path(signal_dir)
         self.signal_dir.mkdir(exist_ok=True)
         self.service_id = service_id

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -2222,6 +2222,28 @@ def get_logging_level(level: str | int):
     return int_level
 
 
+def camel_to_kebab(camel_str: str) -> str:
+    """Convert a string in CamelCase to kebab-case."""
+
+    # Handle sequences of uppercase letters followed by lowercase
+    s1 = re.sub('([A-Z]+)([A-Z][a-z])', r'\1-\2', camel_str)
+
+    # Handle lowercase/digit followed by uppercase
+    s2 = re.sub('([a-z0-9])([A-Z])', r'\1-\2', s1)
+    return s2.lower()
+
+
+def camel_to_snake(camel_str: str) -> str:
+    """Convert a string in CamelCase to snake_case."""
+
+    # Handle sequences of uppercase letters followed by lowercase
+    s1 = re.sub('([A-Z]+)([A-Z][a-z])', r'\1_\2', camel_str)
+
+    # Handle lowercase/digit followed by uppercase
+    s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
+    return s2.lower()
+
+
 ignore_m_warning("egse.system")
 
 if __name__ == "__main__":

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -1932,7 +1932,7 @@ SIGNAL_NAME = {
     30: "SIGUSR1",
     31: "SIGUSR2",
 }
-"""The signals that can be catch with the SignalCatcher."""
+"""The signals that can be caught with the SignalCatcher."""
 
 
 class SignalCatcher:

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -2244,6 +2244,16 @@ def camel_to_snake(camel_str: str) -> str:
     return s2.lower()
 
 
+def kebab_to_title(kebab_str: str) -> str:
+    """Convert kebab-case to Title Case (each word capitalized)"""
+    return kebab_str.replace('-', ' ').title()
+
+
+def snake_to_title(snake_str: str) -> str:
+    """Convert snake_case to Title Case (each word capitalized)"""
+    return snake_str.replace('_', ' ').title()
+
+
 ignore_m_warning("egse.system")
 
 if __name__ == "__main__":

--- a/libs/cgse-common/src/scripts/cgse.py
+++ b/libs/cgse-common/src/scripts/cgse.py
@@ -30,6 +30,8 @@ from egse.system import get_package_description
 
 from typer.core import TyperGroup
 
+from egse.system import snake_to_title
+
 
 def broken_command(name: str, module: str, exc: Exception):
     """
@@ -112,7 +114,12 @@ for ep in entry_points("cgse.command"):
 
 for ep in entry_points("cgse.service"):
     try:
-        app.add_typer(ep.load(), name=ep.name)
+        if ep.extras:
+            # rich.print(f"{ep.extras = }")
+            command_group = snake_to_title(ep.extras[0])
+            app.add_typer(ep.load(), name=ep.name, rich_help_panel=command_group)
+        else:
+            app.add_typer(ep.load(), name=ep.name)
     except Exception as exc:
         app.command()(broken_command(ep.name, ep.module, exc))
 

--- a/libs/cgse-common/tests/test_signal.py
+++ b/libs/cgse-common/tests/test_signal.py
@@ -1,0 +1,42 @@
+import logging
+import time
+
+from egse.signal import FileBasedSignaling
+from egse.signal import create_signal_command_file
+
+logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger("egse.test_signal")
+
+
+def test_reregister():
+
+    service_id = "SIGNAL-TEST"
+
+    signaling = FileBasedSignaling(service_id)
+    signaling.start_monitoring()
+
+    create_signal_command_file(signaling.signal_dir, service_id, {'action': 'reregister', 'params': {'x': 42, 'y': 23}})
+
+    running = True
+
+    def stop():
+        nonlocal running
+
+        logger.warning("Request to terminate the test.")
+
+        running = False
+
+    signaling.register_handler('stop', stop)
+
+    count = 10
+
+    while running:
+        signaling.process_pending_commands()
+        time.sleep(0.1)
+        if count == 0:
+            # This will be called after 10 seconds and end the test
+            create_signal_command_file(signaling.signal_dir, service_id, {'action': 'stop'})
+        count -= 1
+
+    signaling.stop()

--- a/libs/cgse-common/tests/test_system.py
+++ b/libs/cgse-common/tests/test_system.py
@@ -19,6 +19,8 @@ from egse.system import AttributeDict
 from egse.system import Periodic
 from egse.system import SignalCatcher
 from egse.system import Timer
+from egse.system import camel_to_kebab
+from egse.system import camel_to_snake
 from egse.system import check_argument_type
 from egse.system import clear_average_execution_times
 from egse.system import do_every
@@ -1079,3 +1081,20 @@ async def test_periodic_exception(caplog):
 
     assert "ValueError caught: This is not good!" in caplog.text
     assert not_good.counts() == 2
+
+
+def test_camel_to_kebab():
+
+    assert camel_to_kebab("ConfigurationControlServer") == "configuration-control-server"
+    assert camel_to_kebab("XMLHttpService") == "xml-http-service"
+    assert camel_to_kebab("My123BestProject") == "my123-best-project"
+
+    assert camel_to_kebab("is-already-kebab") == "is-already-kebab"
+
+def test_camel_to_snake():
+
+    assert camel_to_snake("ConfigurationControlServer") == "configuration_control_server"
+    assert camel_to_snake("XMLHttpService") == "xml_http_service"
+    assert camel_to_snake("My123BestProject") == "my123_best_project"
+
+    assert camel_to_snake("is_already_snake") == "is_already_snake"

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.11.2"
+version = "0.11.3"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.11.1"
+version = "0.11.2"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.11.4"
+version = "0.11.5"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.11.3"
+version = "0.11.4"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.10.0"
+version = "0.11.0"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.11.0"
+version = "0.11.1"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -44,7 +44,7 @@ cgse-core = "cgse_core:settings.yaml"
 
 [project.entry-points."cgse.service"]
 core = 'cgse_core.services:core'
-registry = 'cgse_core.services:reg'
+rm_cs = 'cgse_core.services:rm_cs'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.11.0"
+version = "0.11.1"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.10.0"
+version = "0.11.0"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}
@@ -43,9 +43,12 @@ cgse-core = 'egse.version:get_version_installed'
 cgse-core = "cgse_core:settings.yaml"
 
 [project.entry-points."cgse.service"]
-core = 'cgse_core.services:core'
-rm_cs = 'cgse_core.services:rm_cs'
-log_cs = 'cgse_core.services:log_cs'
+core = 'cgse_core.services:core[core_command]'
+rm_cs = 'cgse_core.services:rm_cs[core_command]'
+log_cs = 'cgse_core.services:log_cs[core_command]'
+cm_cs = 'cgse_core.services:cm_cs[core_command]'
+sm_cs = 'cgse_core.services:sm_cs[core_command]'
+pm_cs = 'cgse_core.services:pm_cs[core_command]'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.11.4"
+version = "0.11.5"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -42,13 +42,13 @@ cgse-core = 'egse.version:get_version_installed'
 [project.entry-points."cgse.settings"]
 cgse-core = "cgse_core:settings.yaml"
 
-[project.entry-points."cgse.service"]
-core = 'cgse_core.services:core[core_command]'
-rm_cs = 'cgse_core.services:rm_cs[core_command]'
-log_cs = 'cgse_core.services:log_cs[core_command]'
-cm_cs = 'cgse_core.services:cm_cs[core_command]'
-sm_cs = 'cgse_core.services:sm_cs[core_command]'
-pm_cs = 'cgse_core.services:pm_cs[core_command]'
+[project.entry-points."cgse.service.core_command"]
+core = 'cgse_core.services:core'
+rm_cs = 'cgse_core.services:rm_cs'
+log_cs = 'cgse_core.services:log_cs'
+cm_cs = 'cgse_core.services:cm_cs'
+sm_cs = 'cgse_core.services:sm_cs'
+pm_cs = 'cgse_core.services:pm_cs'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.11.1"
+version = "0.11.2"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -45,6 +45,7 @@ cgse-core = "cgse_core:settings.yaml"
 [project.entry-points."cgse.service"]
 core = 'cgse_core.services:core'
 rm_cs = 'cgse_core.services:rm_cs'
+log_cs = 'cgse_core.services:log_cs'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.11.2"
+version = "0.11.3"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}
@@ -44,11 +44,11 @@ cgse-core = "cgse_core:settings.yaml"
 
 [project.entry-points."cgse.service.core_command"]
 core = 'cgse_core.services:core'
-rm_cs = 'cgse_core.services:rm_cs'
-log_cs = 'cgse_core.services:log_cs'
-cm_cs = 'cgse_core.services:cm_cs'
-sm_cs = 'cgse_core.services:sm_cs'
-pm_cs = 'cgse_core.services:pm_cs'
+registry = 'cgse_core.services:rm_cs'
+log = 'cgse_core.services:log_cs'
+cm = 'cgse_core.services:cm_cs'
+sm = 'cgse_core.services:sm_cs'
+pm = 'cgse_core.services:pm_cs'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.11.3"
+version = "0.11.4"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import rich
 
 
-def start_rs_cs(log_level: str):
-    rich.print("Starting the registry service core service...")
+def start_rm_cs(log_level: str):
+    rich.print("Starting the service registry manager core service...")
 
-    out = open(Path('~/.rs_cs.start.out').expanduser(), 'w')
+    out = open(Path('~/.rm_cs.start.out').expanduser(), 'w')
 
     subprocess.Popen(
         [sys.executable, '-m', 'egse.registry.server', 'start', '--log-level', log_level],

--- a/libs/cgse-core/src/cgse_core/_status.py
+++ b/libs/cgse-core/src/cgse_core/_status.py
@@ -6,7 +6,7 @@ import rich
 
 async def run_all_status(full: bool = False, suppress_errors: bool = True):
     tasks = [
-        asyncio.create_task(status_rs_cs(suppress_errors)),
+        asyncio.create_task(status_rm_cs(suppress_errors)),
         asyncio.create_task(status_log_cs(suppress_errors)),
         asyncio.create_task(status_sm_cs(full, suppress_errors)),
         asyncio.create_task(status_cm_cs(suppress_errors)),
@@ -16,7 +16,7 @@ async def run_all_status(full: bool = False, suppress_errors: bool = True):
     await asyncio.gather(*tasks)
 
 
-async def status_rs_cs(suppress_errors):
+async def status_rm_cs(suppress_errors):
 
     proc = await asyncio.create_subprocess_exec(
         sys.executable, '-m', 'egse.registry.server', 'status',

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import rich
 
 
-def stop_rs_cs():
-    rich.print("Terminating the registry service core service...")
+def stop_rm_cs():
+    rich.print("Terminating the service registry manager core service...")
 
-    out = open(Path('~/.rs_cs.stop.out').expanduser(), 'w')
+    out = open(Path('~/.rm_cs.stop.out').expanduser(), 'w')
 
     subprocess.Popen(
         [sys.executable, '-m', 'egse.registry.server', 'stop'],

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -7,8 +7,9 @@ import typer
 
 from egse.registry.client import AsyncRegistryClient
 from egse.system import TyperAsyncCommand
-from ._start import start_rs_cs, start_log_cs, start_sm_cs, start_cm_cs, start_pm_cs
-from ._stop import stop_rs_cs, stop_log_cs, stop_sm_cs, stop_cm_cs, stop_pm_cs
+from ._start import start_rm_cs, start_log_cs, start_sm_cs, start_cm_cs, start_pm_cs
+from ._status import status_rm_cs
+from ._stop import stop_rm_cs, stop_log_cs, stop_sm_cs, stop_cm_cs, stop_pm_cs
 from ._status import run_all_status
 
 core = typer.Typer(
@@ -24,7 +25,7 @@ def start_core_services(log_level: str = "WARNING"):
 
     rich.print("[green]Starting the core services...[/]")
 
-    start_rs_cs(log_level)
+    start_rm_cs(log_level)
     start_log_cs()
     start_sm_cs()
     start_cm_cs()
@@ -43,7 +44,7 @@ def stop_core_services():
     stop_log_cs()
     # We need the registry server to stop other core services, so leave it running for one second
     time.sleep(1.0)
-    stop_rs_cs()
+    stop_rm_cs()
 
 
 @core.command(name="status")
@@ -61,15 +62,33 @@ def status_core_services(full: bool = False, suppress_errors: bool = True):
     asyncio.run(run_all_status(full, suppress_errors))
 
 
-reg = typer.Typer(
-    name="registry",
-    help="handle registry services: start, stop, status",
+rm_cs = typer.Typer(
+    name="rm_cs",
+    help="handle registry services: start, stop, status, list-services",
     no_args_is_help=True
 )
 
 
-@reg.command(cls=TyperAsyncCommand, name="show-services")
-async def reg_show_services():
+@rm_cs.command(name="start")
+def rm_cs_start(log_level: str = "WARNING"):
+    """Start the Service Registry Manager."""
+    start_rm_cs(log_level)
+
+
+@rm_cs.command(name="stop")
+def rm_cs_stop():
+    """Start the Service Registry Manager."""
+    stop_rm_cs()
+
+
+@rm_cs.command(cls=TyperAsyncCommand, name="status")
+async def rm_cs_status(suppress_errors: bool = True):
+    """Start the Service Registry Manager."""
+    await status_rm_cs(suppress_errors)
+
+
+@rm_cs.command(cls=TyperAsyncCommand, name="list-services")
+async def reg_list_services():
     """Print the active services that are registered."""
     with AsyncRegistryClient() as client:
         services = await client.list_services()

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -18,7 +18,9 @@ from ._start import start_sm_cs
 from ._status import run_all_status
 from ._status import status_cm_cs
 from ._status import status_log_cs
+from ._status import status_pm_cs
 from ._status import status_rm_cs
+from ._status import status_sm_cs
 from ._stop import stop_cm_cs
 from ._stop import stop_log_cs
 from ._stop import stop_pm_cs
@@ -73,6 +75,16 @@ def status_core_services(full: bool = False, suppress_errors: bool = True):
     rich.print("[green]Status of the core services...[/]")
 
     asyncio.run(run_all_status(full, suppress_errors))
+
+
+@core.command(name="re-register")
+def core_reregister(force: bool = False):
+    """Command all core services to re-register as a service."""
+
+    log_cs_reregister(force)
+    cm_cs_reregister(force)
+    sm_cs_reregister(force)
+    pm_cs_reregister(force)
 
 
 rm_cs = typer.Typer(
@@ -149,7 +161,7 @@ def log_cs_reregister(force: bool = False):
 
 cm_cs = typer.Typer(
     name="cm_cs",
-    help="handle configuration manager: start, stop, status",
+    help="handle configuration manager: start, stop, status, re-register",
     no_args_is_help=True,
 )
 
@@ -177,6 +189,82 @@ def cm_cs_reregister(force: bool = False):
     """Command the Configuration Manager to re-register as a service."""
 
     from egse.confman.confman_cs import app_name
+
+    create_signal_command_file(
+        Path(DEFAULT_SIGNAL_DIR),
+        app_name,
+        {'action': 'reregister', 'params': {'force': force}},
+    )
+
+
+sm_cs = typer.Typer(
+    name="sm_cs",
+    help="handle storage manager: start, stop, status, re-register",
+    no_args_is_help=True,
+)
+
+
+@sm_cs.command(name="start")
+def sm_cs_start():
+    """Start the Storage Manager."""
+    start_sm_cs()
+
+
+@sm_cs.command(name="stop")
+def sm_cs_stop():
+    """Stop the Storage Manager."""
+    stop_sm_cs()
+
+
+@sm_cs.command(cls=TyperAsyncCommand, name="status")
+async def sm_cs_status(suppress_errors: bool = True):
+    """Print the status of the Storage Manager."""
+    await status_sm_cs(suppress_errors)
+
+
+@sm_cs.command(name="re-register")
+def sm_cs_reregister(force: bool = False):
+    """Command the Storage Manager to re-register as a service."""
+
+    from egse.storage.storage_cs import app_name
+
+    create_signal_command_file(
+        Path(DEFAULT_SIGNAL_DIR),
+        app_name,
+        {'action': 'reregister', 'params': {'force': force}},
+    )
+
+
+pm_cs = typer.Typer(
+    name="pm_cs",
+    help="handle process manager: start, stop, status, re-register",
+    no_args_is_help=True,
+)
+
+
+@pm_cs.command(name="start")
+def pm_cs_start():
+    """Start the Process Manager."""
+    start_pm_cs()
+
+
+@pm_cs.command(name="stop")
+def pm_cs_stop():
+    """Stop the Process Manager."""
+    stop_pm_cs()
+
+
+@pm_cs.command(cls=TyperAsyncCommand, name="status")
+async def pm_cs_status(suppress_errors: bool = True):
+    """Print the status of the Process Manager."""
+    await status_pm_cs(suppress_errors)
+
+
+@pm_cs.command(name="re-register")
+def pm_cs_reregister(force: bool = False):
+    """Command the Storage Manager to re-register as a service."""
+
+    from egse.procman.procman_cs import app_name
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -1,21 +1,34 @@
 import asyncio
 import logging
 import time
+from pathlib import Path
 
 import rich
 import typer
 
 from egse.registry.client import AsyncRegistryClient
+from egse.signal import DEFAULT_SIGNAL_DIR
+from egse.signal import create_signal_command_file
 from egse.system import TyperAsyncCommand
-from ._start import start_rm_cs, start_log_cs, start_sm_cs, start_cm_cs, start_pm_cs
-from ._status import status_rm_cs
-from ._stop import stop_rm_cs, stop_log_cs, stop_sm_cs, stop_cm_cs, stop_pm_cs
+from ._start import start_cm_cs
+from ._start import start_log_cs
+from ._start import start_pm_cs
+from ._start import start_rm_cs
+from ._start import start_sm_cs
 from ._status import run_all_status
+from ._status import status_log_cs
+from ._status import status_rm_cs
+from ._stop import stop_cm_cs
+from ._stop import stop_log_cs
+from ._stop import stop_pm_cs
+from ._stop import stop_rm_cs
+from ._stop import stop_sm_cs
 
 core = typer.Typer(
     name="core",
     help="handle core services: start, stop, status",
-    no_args_is_help=True
+    no_args_is_help=True,
+    rich_help_panel="Core Services"
 )
 
 
@@ -65,7 +78,8 @@ def status_core_services(full: bool = False, suppress_errors: bool = True):
 rm_cs = typer.Typer(
     name="rm_cs",
     help="handle registry services: start, stop, status, list-services",
-    no_args_is_help=True
+    no_args_is_help=True,
+    rich_help_panel="Core Services"
 )
 
 
@@ -94,3 +108,42 @@ async def reg_list_services():
         services = await client.list_services()
 
         rich.print(services)
+
+
+log_cs = typer.Typer(
+    name="log_cs",
+    help="handle log services: start, stop, status",
+    no_args_is_help=True,
+    rich_help_panel="Core Services"
+)
+
+
+@log_cs.command(name="start")
+def log_cs_start():
+    """Start the Logger."""
+    start_log_cs()
+
+
+@log_cs.command(name="stop")
+def log_cs_stop():
+    """Stop the Logger."""
+    stop_log_cs()
+
+
+@log_cs.command(cls=TyperAsyncCommand, name="status")
+async def log_cs_status(suppress_errors: bool = True):
+    """Return the status of the Logger."""
+    await status_log_cs(suppress_errors)
+
+
+@log_cs.command(name="re-register")
+def log_cs_reregister(force: bool = False):
+    """Command the Logger to re-register as a service."""
+
+    from egse.logger.log_cs import app_name
+
+    create_signal_command_file(
+        Path(DEFAULT_SIGNAL_DIR),
+        app_name,
+        {'action': 'reregister', 'params': {'force': force}},
+    )

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -29,7 +29,7 @@ from ._stop import stop_sm_cs
 
 core = typer.Typer(
     name="core",
-    help="handle core services: start, stop, status",
+    help="handle core services: start, stop, status, re-register",
     no_args_is_help=True,
 )
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -16,6 +16,7 @@ from ._start import start_pm_cs
 from ._start import start_rm_cs
 from ._start import start_sm_cs
 from ._status import run_all_status
+from ._status import status_cm_cs
 from ._status import status_log_cs
 from ._status import status_rm_cs
 from ._stop import stop_cm_cs
@@ -28,7 +29,6 @@ core = typer.Typer(
     name="core",
     help="handle core services: start, stop, status",
     no_args_is_help=True,
-    rich_help_panel="Core Services"
 )
 
 
@@ -79,7 +79,6 @@ rm_cs = typer.Typer(
     name="rm_cs",
     help="handle registry services: start, stop, status, list-services",
     no_args_is_help=True,
-    rich_help_panel="Core Services"
 )
 
 
@@ -91,13 +90,13 @@ def rm_cs_start(log_level: str = "WARNING"):
 
 @rm_cs.command(name="stop")
 def rm_cs_stop():
-    """Start the Service Registry Manager."""
+    """Stop the Service Registry Manager."""
     stop_rm_cs()
 
 
 @rm_cs.command(cls=TyperAsyncCommand, name="status")
 async def rm_cs_status(suppress_errors: bool = True):
-    """Start the Service Registry Manager."""
+    """Print the status of the Service Registry Manager."""
     await status_rm_cs(suppress_errors)
 
 
@@ -112,9 +111,8 @@ async def reg_list_services():
 
 log_cs = typer.Typer(
     name="log_cs",
-    help="handle log services: start, stop, status",
+    help="handle log services: start, stop, status, re-register",
     no_args_is_help=True,
-    rich_help_panel="Core Services"
 )
 
 
@@ -141,6 +139,44 @@ def log_cs_reregister(force: bool = False):
     """Command the Logger to re-register as a service."""
 
     from egse.logger.log_cs import app_name
+
+    create_signal_command_file(
+        Path(DEFAULT_SIGNAL_DIR),
+        app_name,
+        {'action': 'reregister', 'params': {'force': force}},
+    )
+
+
+cm_cs = typer.Typer(
+    name="cm_cs",
+    help="handle configuration manager: start, stop, status",
+    no_args_is_help=True,
+)
+
+
+@cm_cs.command(name="start")
+def cm_cs_start():
+    """Start the Configuration Manager."""
+    start_cm_cs()
+
+
+@cm_cs.command(name="stop")
+def cm_cs_stop():
+    """Stop the Configuration Manager."""
+    stop_cm_cs()
+
+
+@cm_cs.command(cls=TyperAsyncCommand, name="status")
+async def cm_cs_status(suppress_errors: bool = True):
+    """Print the status of the Configuration Manager."""
+    await status_cm_cs(suppress_errors)
+
+
+@cm_cs.command(name="re-register")
+def cm_cs_reregister(force: bool = False):
+    """Command the Configuration Manager to re-register as a service."""
+
+    from egse.confman.confman_cs import app_name
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -42,9 +42,12 @@ class ConfigurationManagerControlServer(ControlServer):
     def __init__(self):
         super().__init__()
 
-        multiprocessing.current_process().name = "cm_cs"
+        multiprocessing.current_process().name = app_name
 
         self.logger = logger
+        self.service_name = app_name
+        self.service_type = CTRL_SETTINGS.SERVICE_TYPE
+
         self.device_protocol = ConfigurationManagerProtocol(self)
 
         self.logger.debug(f"Binding ZeroMQ socket to {self.device_protocol.get_bind_address()}")
@@ -112,7 +115,8 @@ class ConfigurationManagerControlServer(ControlServer):
         self.deregister_service()
 
 
-app = typer.Typer(name="cm_cs", no_args_is_help=True)
+app_name = "cm_cs"
+app = typer.Typer(name=app_name, no_args_is_help=True)
 
 
 @app.command()

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -1235,3 +1235,11 @@ class AsyncRegistryClient:
             await self.stop_heartbeat()
             await self.deregister()
             await self.close()
+
+
+def is_service_registered(service_type: str):
+    """Convenience function to check if a service is registered."""
+    with RegistryClient() as reg:
+        response = reg.discover_service(service_type)
+
+    return False if response is None else True

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -839,17 +839,6 @@ class AsyncRegistryClient:
 
                         if not response.get('success'):
                             self.logger.warning(f"Heartbeat failed: {response.get('error')}")
-
-                            # Try to re-register if heartbeat fails
-                            if self._service_info:
-                                self.logger.info("Attempting to re-register service")
-                                self.logger.info(f'service_info: {self._service_info}')
-                                new_request = {
-                                    'action': 'register',
-                                    'service_info': self._service_info,
-                                    'ttl': self._ttl
-                                }
-                                await self._send_request(new_request)
                         else:
                             self.logger.info(response.get("message"))
                     except Exception as exc:

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -463,24 +463,6 @@ class RegistryClient:
                         self.logger.warning("ServiceRegistry not responding.")
                         return
 
-                    # Try to re-register if heartbeat fails..
-                    if not self.get_service(self._service_id) and self._service_info:
-                        self.logger.info("Attempting to re-register service")
-                        new_request = {
-                            'action': 'register',
-                            'service_info': self._service_info,
-                            'ttl': self._ttl
-                        }
-                        self._send_request(new_request)
-
-                        if response.get('success'):
-                            # Store service information for later use
-                            self._service_id = response.get('service_id')
-
-                            self.logger.info(f"Service registered with ID: {self._service_id}")
-                        else:
-                            self.logger.error(f"Failed to register service: {response.get('error')}")
-
                 else:
                     self.logger.debug(response.get("message"))
 
@@ -522,7 +504,7 @@ class AsyncRegistryClient:
     """
     Asynchronous client for interacting with the ZeroMQ-based service registry.
 
-    This class uses asyncio and ZeroMQ's async API for non-blocking operations.
+    This class uses asyncio and the ZeroMQ asyncio API for non-blocking operations.
     """
 
     def __init__(

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -43,8 +43,8 @@ class AsyncRegistryServer:
     This server uses the ZeroMQ async API and asyncio for non-blocking operations.
 
     Args:
-        req_port: Port for REQ-REP socket (service requests) [default=4242]
-        pub_port: Port for PUB socket (service notifications) [default=4243]
+        req_port: Port for the service requests socket [default=4242]
+        pub_port: Port for the service notifications socket [default=4243]
         hb_port: Port for receiving heartbeats [default=4244]
         backend: a registry backend, [default=AsyncSQLiteBackend]
         db_path: Path to the SQLite database file [default='service_registry.db']
@@ -124,7 +124,7 @@ class AsyncRegistryServer:
 
         self._running = True
         self.logger.info(
-            f"Async registry server started on ports {self.req_port} (REQ-REP), {self.pub_port} (PUB), "
+            f"Async registry server started on ports {self.req_port} (ROUTER-DEALER), {self.pub_port} (PUB), "
             f"and {self.hb_port} (Heartbeat)"
         )
 

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -45,9 +45,12 @@ class StorageControlServer(ControlServer):
     def __init__(self):
         super().__init__()
 
-        multiprocessing.current_process().name = "sm_cs"
+        multiprocessing.current_process().name = app_name
 
         self.logger = logger
+        self.service_name = app_name
+        self.service_type = CTRL_SETTINGS.SERVICE_TYPE
+
         self.device_protocol = StorageProtocol(self)
 
         self.logger.debug(f"Binding ZeroMQ socket to {self.device_protocol.get_bind_address()}")
@@ -99,7 +102,8 @@ class StorageControlServer(ControlServer):
         return get_port_number(self.dev_ctrl_mon_sock) or 0
 
 
-app = typer.Typer(name="sm_cs", no_args_is_help=True)
+app_name = "sm_cs"
+app = typer.Typer(name=app_name, no_args_is_help=True)
 
 
 @app.command()

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.11.0"
+version = "0.11.1"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.11.1"
+version = "0.11.2"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.11.3"
+version = "0.11.4"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.11.2"
+version = "0.11.3"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.10.0"
+version = "0.11.0"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.11.4"
+version = "0.11.5"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.10.0"
+version = "0.11.0"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.11.2"
+version = "0.11.3"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -38,7 +38,7 @@ clock = 'cgse_tools.cgse_clock:clock'
 show = 'cgse_tools.cgse_commands:show[group]'
 check = 'cgse_tools.cgse_commands:check[group]'
 
-[project.entry-points."cgse.service"]
+[project.entry-points."cgse.service.example"]
 dev-x = 'cgse_tools.cgse_services:dev_x'
 
 [tool.hatch.build.targets.sdist]

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.11.0"
+version = "0.11.1"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.11.4"
+version = "0.11.5"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -29,14 +29,12 @@ cgse-status = "egse.tools.status:main"
 [project.entry-points."cgse.version"]
 cgse-tools = 'egse.version:get_version_installed'
 
-# plugins for the `cgse` command, add [group] when the command has sub-commands
-
 [project.entry-points."cgse.command"]
 init = 'cgse_tools.cgse_commands:init'
 top = 'cgse_tools.cgse_commands:top'
 clock = 'cgse_tools.cgse_clock:clock'
-show = 'cgse_tools.cgse_commands:show[group]'
-check = 'cgse_tools.cgse_commands:check[group]'
+show = 'cgse_tools.cgse_commands:show'
+check = 'cgse_tools.cgse_commands:check'
 
 [project.entry-points."cgse.service.example"]
 dev-x = 'cgse_tools.cgse_services:dev_x'

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.11.1"
+version = "0.11.2"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.11.3"
+version = "0.11.4"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
@@ -10,6 +10,7 @@ from typing import Annotated
 import rich
 import typer
 
+from cgse_common import AppState
 from egse.plugin import entry_points
 from egse.setup import Setup
 from egse.system import format_datetime
@@ -18,12 +19,15 @@ app = typer.Typer()
 
 
 @app.command()
-def top():
+def top(ctx: typer.Context):
     """
     A top-like interface for core services and device control servers.
 
     Not yet implemented.
     """
+    state: AppState = ctx.obj
+
+    print(f"The `verbose` flag is {state.verbose}")
     print("This fancy top is not yet implemented.")
 
 

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.11.3"
+version = "0.11.4"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.11.0"
+version = "0.11.1"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.11.2"
+version = "0.11.3"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.10.0"
+version = "0.11.0"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}
@@ -43,7 +43,7 @@ keithley-tempcontrol = 'egse.version:get_version_installed'
 keithley-tempcontrol = "keithley_tempcontrol:settings.yaml"
 
 [project.entry-points."cgse.service"]
-daq6510 = 'keithley_tempcontrol.cgse_services:daq6510'
+daq6510 = 'keithley_tempcontrol.cgse_services:daq6510[device_command]'
 
 [project.entry-points."cgse.explore"]
 explore = "keithley_tempcontrol.cgse_explore"

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.11.1"
+version = "0.11.2"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -42,8 +42,8 @@ keithley-tempcontrol = 'egse.version:get_version_installed'
 [project.entry-points."cgse.settings"]
 keithley-tempcontrol = "keithley_tempcontrol:settings.yaml"
 
-[project.entry-points."cgse.service"]
-daq6510 = 'keithley_tempcontrol.cgse_services:daq6510[device_command]'
+[project.entry-points."cgse.service.device_command"]
+daq6510 = 'keithley_tempcontrol.cgse_services:daq6510'
 
 [project.entry-points."cgse.explore"]
 explore = "keithley_tempcontrol.cgse_explore"

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.11.4"
+version = "0.11.5"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -42,8 +42,8 @@ lakeshore-tempcontrol = 'egse.version:get_version_installed'
 [project.entry-points."cgse.settings"]
 lakeshore-tempcontrol = "lakeshore_tempcontrol:settings.yaml"
 
-[project.entry-points."cgse.service"]
-lakeshore336 = 'lakeshore_tempcontrol.cgse_services:lakeshore336[device_command]'
+[project.entry-points."cgse.service.device_command"]
+lakeshore336 = 'lakeshore_tempcontrol.cgse_services:lakeshore336'
 
 [project.entry-points."cgse.explore"]
 explore = "lakeshore_tempcontrol.cgse_explore"

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.11.1"
+version = "0.11.2"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.11.0"
+version = "0.11.1"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.10.0"
+version = "0.11.0"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}
@@ -43,7 +43,7 @@ lakeshore-tempcontrol = 'egse.version:get_version_installed'
 lakeshore-tempcontrol = "lakeshore_tempcontrol:settings.yaml"
 
 [project.entry-points."cgse.service"]
-lakeshore336 = 'lakeshore_tempcontrol.cgse_services:lakeshore336'
+lakeshore336 = 'lakeshore_tempcontrol.cgse_services:lakeshore336[device_command]'
 
 [project.entry-points."cgse.explore"]
 explore = "lakeshore_tempcontrol.cgse_explore"

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.11.3"
+version = "0.11.4"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.11.4"
+version = "0.11.5"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.11.2"
+version = "0.11.3"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -43,10 +43,10 @@ joran_ui = "egse.hexapod.symetrie.joran_ui:main"
 [project.entry-points."cgse.version"]
 symetrie-hexapod = 'egse.version:get_version_installed'
 
-[project.entry-points."cgse.service"]
-puna = 'symetrie_hexapod.cgse_services:puna[device_command]'
-zonda = 'symetrie_hexapod.cgse_services:zonda[device_command]'
-joran = 'symetrie_hexapod.cgse_services:joran[device_command]'
+[project.entry-points."cgse.service.device_command"]
+puna = 'symetrie_hexapod.cgse_services:puna'
+zonda = 'symetrie_hexapod.cgse_services:zonda'
+joran = 'symetrie_hexapod.cgse_services:joran'
 
 [project.entry-points."cgse.settings"]
 symetrie-hexapod = "symetrie_hexapod:settings.yaml"

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.11.2"
+version = "0.11.3"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.11.4"
+version = "0.11.5"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.11.1"
+version = "0.11.2"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.11.3"
+version = "0.11.4"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.11.0"
+version = "0.11.1"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.10.0"
+version = "0.11.0"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}
@@ -44,9 +44,9 @@ joran_ui = "egse.hexapod.symetrie.joran_ui:main"
 symetrie-hexapod = 'egse.version:get_version_installed'
 
 [project.entry-points."cgse.service"]
-puna = 'symetrie_hexapod.cgse_services:puna'
-zonda = 'symetrie_hexapod.cgse_services:zonda'
-joran = 'symetrie_hexapod.cgse_services:joran'
+puna = 'symetrie_hexapod.cgse_services:puna[device_command]'
+zonda = 'symetrie_hexapod.cgse_services:zonda[device_command]'
+joran = 'symetrie_hexapod.cgse_services:joran[device_command]'
 
 [project.entry-points."cgse.settings"]
 symetrie-hexapod = "symetrie_hexapod:settings.yaml"

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.11.3"
+version = "0.11.4"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.11.2"
+version = "0.11.3"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.10.0"
+version = "0.11.0"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.11.0"
+version = "0.11.1"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.11.1"
+version = "0.11.2"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.11.4"
+version = "0.11.5"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.11.4"
+version = "0.11.5"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.11.0"
+version = "0.11.1"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.11.1"
+version = "0.11.2"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.10.0"
+version = "0.11.0"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.11.2"
+version = "0.11.3"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.11.3"
+version = "0.11.4"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.11.0"
+version = "0.11.1"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.11.2"
+version = "0.11.3"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.10.0"
+version = "0.11.0"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.11.1"
+version = "0.11.2"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.11.4"
+version = "0.11.5"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.11.3"
+version = "0.11.4"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.11.3"
+version = "0.11.4"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.10.0"
+version = "0.11.0"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.11.0"
+version = "0.11.1"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.11.2"
+version = "0.11.3"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.11.1"
+version = "0.11.2"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.11.4"
+version = "0.11.5"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
This pull request brings file-based signalling to the services. 

Why would we need file-based signalling?

The services all use dynamic port allocation, which means their commanding, monitoring and other ports are allocated by the system and are not predefined fixed numbers. In order to communicate with a service, we will need to know the port to which to connect. That is where service registration comes into play. Any service with dynamic port allocation will register to the service registry. The service registry will have all information from all services and can provide proper endpoints to connect to each service. Services send heartbeats to the registry to keep their information alive.

Sometimes, due to network problems or when a system goes into sleep mode, a registration can expire and we need a way to command the service to re-register. But, since the registration expired, we do not have the port numbers for connecting and commanding the service. So, we are left with a service that is running and functioning properly, but we can not connect to it. That is where file-based signalling comes into play. This works by creating a file with instructions at a predefined location. The services will monitor for such a file and when it appears, the service will execute the action/command that is defined in the file (JSON format). 

All services now have file-based signalling implemented.

As a side-effect, all core services now have their individual command next to the `cgse core` command. We also removed the use of `extras` in `pyproject.toml` and moved the `cgse` command from `scripts` to `cgse_common`.

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/79202894-11e0-4172-a758-9a104b05be73" />

## Testing

The implementation is tested with the `test_signal.py` unit test.

Additional tests have been performed with the following commands:

- `cgse core re-register [--force]`
- `cgse log re-register [--force]`
- `cgse cm re-register [--force]`
- `cgse sm re-register [--force]`
- `cgse pm re-register [--force]`

```
➜ cgse registry list-services
[
    {
        'id': 'LOGGER-64bac6a0-3105-4bbf-9f42-c859ca967171',
        'name': 'LOGGER',
        'host': '192.168.0.239',
        'port': 54520,
        'metadata': {'receiver_port': 54519, 'type': 'LOGGER'},
        'ttl': 30,
        'last_heartbeat': 1750062249,
        'tags': ['LOGGER'],
        'health': 'passing'
    },
    {
        'id': 'pm_cs-dedfbbee-12f3-4244-bc6d-6968968a3141',
        'name': 'pm_cs',
        'host': '192.168.0.239',
        'port': 54552,
        'metadata': {'service_port': 54545, 'monitoring_port': 54546, 'type': 'PM_CS'},
        'ttl': 30,
        'last_heartbeat': 1750062250,
        'tags': ['PM_CS'],
        'health': 'passing'
    },
    {
        'id': 'cm_cs-293a5ceb-b11c-4fa2-9cfb-a7a0e0d471c8',
        'name': 'cm_cs',
        'host': '192.168.0.239',
        'port': 54554,
        'metadata': {'service_port': 54538, 'monitoring_port': 54540, 'type': 'CM_CS'},
        'ttl': 30,
        'last_heartbeat': 1750062250,
        'tags': ['CM_CS'],
        'health': 'passing'
    },
    {
        'id': 'sm_cs-1fdfcbad-78e0-4d75-a386-6370d4c4c304',
        'name': 'sm_cs',
        'host': '192.168.0.239',
        'port': 54565,
        'metadata': {'service_port': 54563, 'monitoring_port': 54564, 'type': 'SM_CS'},
        'ttl': 30,
        'last_heartbeat': 1750062250,
        'tags': ['SM_CS'],
        'health': 'passing'
    }
]
```
