### PR TITLE
fix termination of core services

### DIFF
--- a/libs/cgse-common/src/egse/control.py
+++ b/libs/cgse-common/src/egse/control.py
@@ -624,6 +624,7 @@ class ControlServer(metaclass=abc.ABCMeta):
 
     def deregister_service(self):
         if self.registry:
+            self.registry.stop_heartbeat()
             self.registry.deregister(self.service_id)
 
     def store_housekeeping_information(self, data: dict) -> None:
@@ -663,7 +664,6 @@ class ControlServer(metaclass=abc.ABCMeta):
         except NewConnectionError:
             _LOGGER.warning(f"No connection to InfluxDB could be established to propagate {origin} metrics.  Check "
                            f"whether this service is (still) running.")
-
 
     def register_to_storage_manager(self) -> None:
         """Registers this Control Server to the Storage Manager.

--- a/libs/cgse-common/src/egse/proxy.py
+++ b/libs/cgse-common/src/egse/proxy.py
@@ -255,7 +255,7 @@ class BaseProxy(ControlServerConnectionInterface):
 
         port = self.send("get_service_port")  # FIXME: Check if this is still returning the proper port
 
-        return ServiceProxy(AttributeDict({"PROTOCOL": transport, "HOSTNAME": address, "SERVICE_PORT": port}))
+        return ServiceProxy(protocol=transport, hostname=address, port=port)
 
 
 class DynamicProxy(BaseProxy, DynamicClientCommandMixin):

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -1314,7 +1314,10 @@ def do_every(
     while not stop_event.is_set():
         if count is not None and iteration >= count:
             break
-        time.sleep(next(g))
+        # Wait for the timeout or until the stop_event is set
+        # The wait functions returns True only when the event is set and returns False on a timeout
+        if stop_event.wait(timeout=next(g)):
+            break
         func(*args)
         iteration += 1
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -56,9 +56,11 @@ def stop_core_services():
     stop_pm_cs()
     stop_cm_cs()
     stop_sm_cs()
+    # We need the logger for logging the termination process for other services, so leave it running for half a second
+    time.sleep(0.5)
     stop_log_cs()
-    # We need the registry server to stop other core services, so leave it running for one second
-    time.sleep(1.0)
+    # We need the registry server to stop other core services, so leave it running for half a second
+    time.sleep(0.5)
     stop_rm_cs()
 
 

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -168,8 +168,8 @@ def stop():
         # rich.print("service = ", service)
 
         if service:
-            proxy = ServiceProxy(protocol="tcp", hostname=service["host"], port=service['metadata']['service_port'])
-            proxy.quit_server()
+            with ServiceProxy(hostname=service["host"], port=service['metadata']['service_port']) as proxy:
+                proxy.quit_server()
         else:
             rich.print("[red]ERROR: Couldn't connect to 'cm_cs', process probably not running.")
 

--- a/libs/cgse-core/src/egse/logger/__init__.py
+++ b/libs/cgse-core/src/egse/logger/__init__.py
@@ -130,7 +130,7 @@ class ZeroMQHandler(logging.Handler):
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception as exc:
-            logger.error(f"ZeroMQHandler: Exception - {exc}", exc_info=True)
+            logging.error(f"ZeroMQHandler: Exception - {exc}", exc_info=True)
             self.handleError(record)
 
 

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -1088,16 +1088,14 @@ class StorageProxy(Proxy, StorageInterface, EventInterface):
         """
         if hostname is None:
             with RegistryClient() as reg:
-                service = reg.discover_service(CTRL_SETTINGS.SERVICE_TYPE)
+                endpoint = reg.get_endpoint(CTRL_SETTINGS.SERVICE_TYPE)
 
-                if service:
-                    protocol = service.get('protocol', 'tcp')
-                    hostname = service['host']
-                    port = service['port']
-                else:
-                    raise RuntimeError(f"No service registered as {CTRL_SETTINGS.SERVICE_TYPE}")
+            if not endpoint:
+                raise RuntimeError(f"No service registered as {CTRL_SETTINGS.SERVICE_TYPE}")
+        else:
+            endpoint = connect_address(protocol, hostname, port)
 
-        super().__init__(connect_address(protocol, hostname, port), timeout=timeout)
+        super().__init__(endpoint, timeout=timeout)
 
 
 class StorageProtocol(CommandProtocol):

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -158,8 +158,8 @@ def stop():
         # rich.print("service = ", service)
 
         if service:
-            proxy = ServiceProxy(protocol="tcp", hostname=service["host"], port=service['metadata']['service_port'])
-            proxy.quit_server()
+            with ServiceProxy(hostname=service["host"], port=service['metadata']['service_port']) as proxy:
+                proxy.quit_server()
         else:
             rich.print("[red]ERROR: Couldn't connect to 'sm_cs', process probably not running.")
 


### PR DESCRIPTION
The core services are not terminated timely when using the command `cgse core stop`. This has several reasons which are fixed in this pull request:

- The ServiceProxy was not yet adapted to the dynamic port allocation. This proxy is mainly used to send the `quit_server()` service command which could not reach the server because the endpoints were obviously wrong
- The `stop_heartbeat()` would work properly because  it used an event to stop the thread, but the sleep time in the thread loop was about 10s. So, by the time the thread was ended, other services would have been terminated or were also hanging for the same reason. This thread loop is executed in the `do_every()` function and we replaced the `time.sleep()` with a `stop_event.wait()` function. This function properly reacts immediately when the event is set.
- When stopping the core services, the logger and the registry server need to be terminated only when the other core services are fully terminated. Otherwise, these services try to log to the logger using a ZMQHandler which is not available anymore or the service proxy can not find the correct endpoint because the registry is not active anymore. W have added two wait statements, one before the stop_loggerand one before the stop_register.

Tested as follows:

```
➜ cgse show procs

cgse on 🌱 main [!?⇡] (cgse) PROJECT=ARIEL SITE_ID=VACUUM_LAB took 0s
➜ cgse core start
Starting the core services...
Starting the service registry manager core service...
Starting the logging core service...
Starting the storage manager core service...
Starting the configuration manager core service...
Starting the process manager core service...

cgse on 🌱 main [!?⇡] (cgse) PROJECT=ARIEL SITE_ID=VACUUM_LAB
➜ cgse show procs
459800007 82987     1   0 11:10PM ttys006    0:00.15 /Users/rik/github/cgse/.venv/bin/python -m egse.registry.server start --log-level WARNING
459800007 82988     1   0 11:10PM ttys006    0:00.17 /Users/rik/github/cgse/.venv/bin/python -m egse.logger.log_cs start
459800007 82989     1   0 11:10PM ttys006    0:00.60 /Users/rik/github/cgse/.venv/bin/python -m egse.storage.storage_cs start
459800007 82990     1   0 11:10PM ttys006    0:00.58 /Users/rik/github/cgse/.venv/bin/python -m egse.confman.confman_cs start
459800007 82991     1   0 11:10PM ttys006    0:00.59 /Users/rik/github/cgse/.venv/bin/python -m egse.procman.procman_cs start

cgse on 🌱 main [!?⇡] (cgse) PROJECT=ARIEL SITE_ID=VACUUM_LAB
➜ cgse core stop
Terminating the core services...
Terminating the process manager core service...
Terminating the configuration manager core service...
Terminating the storage manager core service...
Terminating the logging core service...
Terminating the service registry manager core service...

cgse on 🌱 main [!?⇡] (cgse) PROJECT=ARIEL SITE_ID=VACUUM_LAB took 1s
➜ cgse show procs

cgse on 🌱 main [!?⇡] (cgse) PROJECT=ARIEL SITE_ID=VACUUM_LAB
➜
```