### PR TITLE
Maintenance/remove obsolete dry run+

### DIFF
--- a/libs/cgse-common/src/egse/state.py
+++ b/libs/cgse-common/src/egse/state.py
@@ -64,20 +64,11 @@ class _GlobalState:
     # TODO (rik): turn command sequence into a class and move add_, clear_ and get_ to that class
 
     def __init__(self):
-        self._dry_run = False
         self._command_sequence = []
         self._setup: Optional[Setup] = None
 
     def __call__(self, *args, **kwargs):
         return self
-
-    @property
-    def dry_run(self):
-        return self._dry_run
-
-    @dry_run.setter
-    def dry_run(self, flag: bool):
-        self._dry_run = flag
 
     def add_command(self, cmd):
         self._command_sequence.append(cmd)
@@ -169,7 +160,6 @@ if __name__ == "__main__":
             f"""\
             GlobalState info:
               Setup loaded: {GlobalState.setup.get_id()}
-              Dry run: {"ON" if GlobalState.dry_run else "OFF"}
               Command Sequence: {GlobalState.get_command_sequence()} \
         """
         )

--- a/libs/cgse-common/src/egse/state.py
+++ b/libs/cgse-common/src/egse/state.py
@@ -61,23 +61,11 @@ class _GlobalState:
     This class implements global state that is shared between instances of this class.
     """
 
-    # TODO (rik): turn command sequence into a class and move add_, clear_ and get_ to that class
-
     def __init__(self):
-        self._command_sequence = []
         self._setup: Optional[Setup] = None
 
     def __call__(self, *args, **kwargs):
         return self
-
-    def add_command(self, cmd):
-        self._command_sequence.append(cmd)
-
-    def get_command_sequence(self):
-        return self._command_sequence
-
-    def clear_command_sequence(self):
-        self._command_sequence.clear()
 
     @property
     def setup(self) -> Optional[Setup]:
@@ -130,21 +118,6 @@ class _GlobalState:
 
         return self._setup
 
-    # FIXME:
-    #  These two 'private' methods are still called in plato-test-scripts, so until that is fixed,
-    #  leave the methods here
-
-    @deprecate(reason="this is a private function", alternative="reload_setup()")
-    def _reload_setup(self):
-        self._setup = Setup.from_yaml_file()
-        return self._setup
-
-    @deprecate(reason="this is a private function", alternative="reload_setup_from()")
-    def _reload_setup_from(self, filename: Path):
-        """Used by the unit tests to load a predefined setup."""
-        self._setup = Setup.from_yaml_file(filename=filename)
-        return self.setup
-
 
 GlobalState = _GlobalState()
 
@@ -160,7 +133,6 @@ if __name__ == "__main__":
             f"""\
             GlobalState info:
               Setup loaded: {GlobalState.setup.get_id()}
-              Command Sequence: {GlobalState.get_command_sequence()} \
-        """
+            """
         )
     )

--- a/libs/cgse-common/tests/test_command.py
+++ b/libs/cgse-common/tests/test_command.py
@@ -40,33 +40,6 @@ def add_cr_to_string(self, cmd_string):
     return cmd_string + "\r\n"
 
 
-def test_dry_run(monkeypatch):
-    monkeypatch.setattr(HexapodCommand, "execute", return_command_string)
-    cmd = HexapodCommand(name="dry-run-cmd", cmd="dry-run-test {flag} {arg}")
-
-    rc = cmd("--dr", "arg_1")
-    assert rc.startswith("dry-run-test")
-
-    with pytest.raises(AttributeError):
-        rc = cmd.client_call(None, "--dr", "arg_1")
-
-    GlobalState.dry_run = True
-
-    rc = cmd.client_call(None, "--dr", "arg_1")
-    assert rc.successful
-    cmd_seq = GlobalState.get_command_sequence()
-    assert cmd_seq
-    assert len(cmd_seq) == 1
-    assert str(cmd_seq[0]).startswith("[HexapodCommand] ")
-
-    print(cmd_seq[0])
-
-    # Clean up = reset global state
-
-    GlobalState.dry_run = False
-    GlobalState.clear_command_sequence()
-
-
 def test_command_class(mocker):
     mocker.patch.object(Command, "execute")
 

--- a/libs/cgse-common/tests/test_process.py
+++ b/libs/cgse-common/tests/test_process.py
@@ -53,7 +53,7 @@ def test_zombie():
     zombies = list_zombies()
     print(f"{zombies = }")
 
-    assert len(list_zombies()) == 2
+    assert len(list_zombies()) >= 2
 
 
 def test_is_process_running():

--- a/libs/cgse-common/tests/test_setup.py
+++ b/libs/cgse-common/tests/test_setup.py
@@ -1066,12 +1066,18 @@ def test_find_devices():
                 device_name: BBB
                 device: dev-zzz-bbb
 
+            ccc:
+                device_name: CCC
+                device_id: 3578
+                device: dev-zzz-ccc
+                device_args: ["True", "False"]
         """
     )
 
     devices = {}
     devices = Setup.find_devices(setup, devices)
 
-    assert len(devices) == 4
-    assert devices["BBB"] == ("dev-zzz-bbb", ())
-    assert devices["AAA"] == ("dev-zzz-aaa", [1, 2, 3])
+    assert len(devices) == 5
+    assert devices["BBB"] == ("dev-zzz-bbb", None, ())
+    assert devices["AAA"] == ("dev-zzz-aaa", None, [1, 2, 3])
+    assert devices["CCC"] == ("dev-zzz-ccc", 3578, ["True", "False"])


### PR DESCRIPTION
This pull request removes all `dry_run` and `command_sequence` from CGSE
	- see GlobalState in `egse.state`
	- see `@dry_run` decorator in `egse.command` 
	- tests