### PR TITLE
fix GlobalState.setup

### DIFF
--- a/libs/cgse-common/src/egse/setup.py
+++ b/libs/cgse-common/src/egse/setup.py
@@ -944,7 +944,7 @@ def list_setups(**attr):
         print("Could not make a connection with the Configuration Manager, no Setup to show you.")
 
 
-def get_setup(setup_id: int = None):
+def get_setup(setup_id: int = None) -> Setup | None:
     """
     Retrieve the currently active Setup from the configuration manager.
 
@@ -958,7 +958,7 @@ def get_setup(setup_id: int = None):
         from egse.confman import ConfigurationManagerProxy
     except ImportError:
         print("WARNING: package 'cgse-core' is not installed, service not available.")
-        return
+        return None
 
     try:
         with ConfigurationManagerProxy() as proxy:
@@ -966,6 +966,7 @@ def get_setup(setup_id: int = None):
         return setup
     except ConnectionError:
         print("Could not make a connection with the Configuration Manager, no Setup returned.")
+        return None
 
 
 def _check_conditions_for_get_path_of_setup_file(site_id: str) -> Path:
@@ -1079,6 +1080,9 @@ def load_setup(setup_id: int = None, site_id: str = None, from_disk: bool = Fals
 
     When no setup_id is provided, the current Setup is loaded from the configuration manager.
 
+    When `from_disk` is True, the Setup will not be loaded from the configuration manager, but it
+    will be loaded from disk. No interaction with the configuration manager happens in this case.
+
     Args:
         setup_id (int): the identifier for the Setup
         site_id (str): the name of the test house
@@ -1103,7 +1107,7 @@ def load_setup(setup_id: int = None, site_id: str = None, from_disk: bool = Fals
 
         return Setup.from_yaml_file(setup_file_path)
 
-    # When we arrive here the Setup shall be loaded from the Configuration manager
+    # When we arrive here the Setup shall be loaded from the Configuration manager.
 
     try:
         from egse.confman import ConfigurationManagerProxy

--- a/libs/cgse-coordinates/src/egse/coordinates/__init__.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/__init__.py
@@ -198,18 +198,16 @@ def __focal_plane_to_ccd_coordinates__(x_fp, y_fp, ccd_code):
         Pixel coordinates (row, column) on the given CCD.
     """
 
-    setup = GlobalState.setup
-
-    if setup is not None:
-        ccd_orientation = setup.camera.ccd.orientation[int(ccd_code) - 1]
-        pixel_size = setup.camera.ccd.pixel_size / 1000.0  # [mm]
-        ccd_origin_x = GlobalState.setup.camera.ccd.origin_offset_x[int(ccd_code) - 1]
-        ccd_origin_y = GlobalState.setup.camera.ccd.origin_offset_y[int(ccd_code) - 1]
-    else:
+    if GlobalState.setup is None:
         ccd_orientation = CCD_SETTINGS.ORIENTATION[int(ccd_code) - 1]
         pixel_size = CCD_SETTINGS.PIXEL_SIZE / 1000  # Pixel size [mm]
         ccd_origin_x = CCD_SETTINGS.ZEROPOINT[0]
         ccd_origin_y = CCD_SETTINGS.ZEROPOINT[1]
+    else:
+        ccd_orientation = GlobalState.setup.camera.ccd.orientation[int(ccd_code) - 1]
+        pixel_size = GlobalState.setup.camera.ccd.pixel_size / 1000.0  # [mm]
+        ccd_origin_x = GlobalState.setup.camera.ccd.origin_offset_x[int(ccd_code) - 1]
+        ccd_origin_y = GlobalState.setup.camera.ccd.origin_offset_y[int(ccd_code) - 1]
 
     ccd_angle = radians(ccd_orientation)
 
@@ -229,6 +227,9 @@ def focal_plane_coordinates_to_angles(x_fp, y_fp):
     Conversion from focal-plane coordinates to the gnomonic distance from the optical axis and
     the in-field angle.
 
+    NOTE: if no valid Setup is loaded in the global state, the FOV_SETTINGS will be used to
+          determine the focal length.
+
     Args:
         x_fp: Focal-plane x-coordinate [mm].
         y_fp: Focal-plane y-coordinate [mm].
@@ -236,12 +237,10 @@ def focal_plane_coordinates_to_angles(x_fp, y_fp):
         Gnomonic distance from the optical axis and in-field angle [degrees].
     """
 
-    setup = GlobalState.setup
-
-    if setup is not None:
-        focal_length_mm = GlobalState.setup.camera.fov.focal_length_mm
-    else:
+    if GlobalState.setup is None:
         focal_length_mm = FOV_SETTINGS.FOCAL_LENGTH
+    else:
+        focal_length_mm = GlobalState.setup.camera.fov.focal_length_mm
 
     theta = degrees(atan(sqrt(pow(x_fp, 2) + pow(y_fp, 2)) / focal_length_mm))
     phi = degrees(atan2(y_fp, x_fp))
@@ -253,6 +252,9 @@ def ccd_to_focal_plane_coordinates(row, column, ccd_code):
     """
     Conversion from pixel-coordinates on the given CCD to focal-plane coordinates.
 
+    NOTE: if no valid Setup is loaded in the global state, the CCD_SETTINGS will be used to
+          determine the ccd information.
+
     Args:
         row: Row coordinate [pixels].
         column: Column coordinate [pixels].
@@ -261,18 +263,16 @@ def ccd_to_focal_plane_coordinates(row, column, ccd_code):
         Focal-plane coordinates (x, y) [mm].
     """
 
-    setup = GlobalState.setup
-
-    if setup is not None:
-        ccd_orientation = setup.camera.ccd.orientation[int(ccd_code) - 1]
-        pixel_size_mm = setup.camera.ccd.pixel_size / 1000.0  # [mm]
-        ccd_origin_x = GlobalState.setup.camera.ccd.origin_offset_x[int(ccd_code) - 1]
-        ccd_origin_y = GlobalState.setup.camera.ccd.origin_offset_y[int(ccd_code) - 1]
-    else:
+    if GlobalState.setup is None:
         ccd_orientation = CCD_SETTINGS.ORIENTATION[int(ccd_code) - 1]
         pixel_size_mm = CCD_SETTINGS.PIXEL_SIZE / 1000  # Pixel size [mm]
         ccd_origin_x = CCD_SETTINGS.ZEROPOINT[0]
         ccd_origin_y = CCD_SETTINGS.ZEROPOINT[1]
+    else:
+        ccd_orientation = GlobalState.setup.camera.ccd.orientation[int(ccd_code) - 1]
+        pixel_size_mm = GlobalState.setup.camera.ccd.pixel_size / 1000.0  # [mm]
+        ccd_origin_x = GlobalState.setup.camera.ccd.origin_offset_x[int(ccd_code) - 1]
+        ccd_origin_y = GlobalState.setup.camera.ccd.origin_offset_y[int(ccd_code) - 1]
 
     # Convert the pixel coordinates into [mm] coordinates
 
@@ -296,6 +296,9 @@ def angles_to_focal_plane_coordinates(theta, phi):
     Conversion from the gnomonic distance from the optical axis and
     the in-field angle to focal-plane coordinates.
 
+    NOTE: if no valid Setup is loaded in the global state, the FOV_SETTINGS will be used to
+          determine the focal length.
+
     Args:
         theta: Gnomonic distance from the optical axis [degrees].
         phi: In-field angle [degrees].
@@ -303,12 +306,10 @@ def angles_to_focal_plane_coordinates(theta, phi):
         Focal-plane coordinates (x, y) [mm].
     """
 
-    setup = GlobalState.setup
-
-    if setup is not None:
-        focal_length_mm = GlobalState.setup.camera.fov.focal_length_mm
-    else:
+    if GlobalState.setup is None:
         focal_length_mm = FOV_SETTINGS.FOCAL_LENGTH
+    else:
+        focal_length_mm = GlobalState.setup.camera.fov.focal_length_mm
 
     distance = focal_length_mm * tan(radians(theta))  # [mm]
 

--- a/libs/cgse-coordinates/src/egse/coordinates/avoidance.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/avoidance.py
@@ -25,8 +25,7 @@ def is_avoidance_ok(hexusr, hexobj, setup: Setup = None, verbose=False):
              xy plane = FPA_SEN
              z axis pointing towards L6
 
-    setup  : GlobalSetup.setup, optional
-             if not provided, GlobalState.setup is used
+    setup  : optional, if not provided, load_setup() is used
 
 
     OUTPUT :  Boolean indicating whether the FPA is outside the avoidance volume around L6

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -34,8 +34,8 @@ keyword arguments which are the attributes of the Setup and compares the attribu
 given value. An example should make this clear. A setup has a `site_id` and for the CSL site
 also a `position`. You can access these value as follows:
 
-    >>> from egse.state import GlobalState
-    >>> setup = GlobalState.setup
+    >>> from egse.setup import load_setup
+    >>> setup = load_setup()
     >>> setup.site_id
     'CSL'
     >>> setup.position

--- a/projects/plato/plato-spw/src/egse/spw.py
+++ b/projects/plato/plato-spw/src/egse/spw.py
@@ -528,12 +528,16 @@ class DataPacketType:
         self._data_type = x
 
     def __str__(self) -> str:
-        from egse.fee import n_fee_mode
+        try:
+            from egse.fee import n_fee_mode
+            mode = n_fee_mode(self.mode).name
+        except ImportError:
+            mode = str(self.mode)
 
         n_fee_side = GlobalState.setup.camera.fee.ccd_sides.enum
 
         return (
-            f"mode:{n_fee_mode(self.mode).name}, last_packet:{self.last_packet}, "
+            f"mode:{mode}, last_packet:{self.last_packet}, "
             f"CCD side:{n_fee_side(self.ccd_side).name}, CCD number:{self.ccd_number}, "
             f"Frame number:{self.frame_number}, Packet Type:{PacketType(self.packet_type).name}"
         )
@@ -553,7 +557,11 @@ def to_string(data: Union[DataPacketType]) -> str:
     Args:
         data: a DataPacketType
     """
-    from egse.fee import n_fee_mode
+    try:
+        from egse.fee import n_fee_mode
+        mode = n_fee_mode(data.mode).name
+    except ImportError:
+        mode = str(data.mode)
 
     n_fee_side = GlobalState.setup.camera.fee.ccd_sides.enum
 
@@ -563,7 +571,7 @@ def to_string(data: Union[DataPacketType]) -> str:
         except AttributeError:
             raise SetupError("No entry in the setup for camera.fee.ccd_numbering.CCD_BIN_TO_ID")
         return (
-            f"mode:{n_fee_mode(data.mode).name}, last_packet:{data.last_packet}, "
+            f"mode:{mode}, last_packet:{data.last_packet}, "
             f"CCD side:{n_fee_side(data.ccd_side).name}, CCD number:"
             f"{ccd_bin_to_id[data.ccd_number]}, "
             f"Frame number:{data.frame_number}, Packet Type:{PacketType(data.packet_type).name}"
@@ -679,9 +687,14 @@ class DataPacketHeader:
         self.header_data[8:10] = value.to_bytes(2, "big")
 
     def as_dict(self):
-        from egse.fee import n_fee_mode
 
         data_packet_type = DataPacketType(self.type)
+        try:
+            from egse.fee import n_fee_mode
+            mode = n_fee_mode(data_packet_type.mode).name
+        except ImportError:
+            mode = str(data_packet_type.mode)
+
         return dict(
             logical_address=f"0x{self.logical_address:02X}",
             protocol_id=f"0x{self.protocol_id:02X}",
@@ -694,7 +707,7 @@ class DataPacketHeader:
             ccd_number=data_packet_type.ccd_number,
             ccd_side=self.n_fee_side(data_packet_type.ccd_side).name,
             last_packet=data_packet_type.last_packet,
-            mode=n_fee_mode(data_packet_type.mode).name,
+            mode=mode,
         )
 
 

--- a/projects/plato/plato-spw/src/egse/spw.py
+++ b/projects/plato/plato-spw/src/egse/spw.py
@@ -530,6 +530,7 @@ class DataPacketType:
     def __str__(self) -> str:
         try:
             from egse.fee import n_fee_mode
+
             mode = n_fee_mode(self.mode).name
         except ImportError:
             mode = str(self.mode)
@@ -559,6 +560,7 @@ def to_string(data: Union[DataPacketType]) -> str:
     """
     try:
         from egse.fee import n_fee_mode
+
         mode = n_fee_mode(data.mode).name
     except ImportError:
         mode = str(data.mode)
@@ -687,10 +689,10 @@ class DataPacketHeader:
         self.header_data[8:10] = value.to_bytes(2, "big")
 
     def as_dict(self):
-
         data_packet_type = DataPacketType(self.type)
         try:
             from egse.fee import n_fee_mode
+
             mode = n_fee_mode(data_packet_type.mode).name
         except ImportError:
             mode = str(data_packet_type.mode)


### PR DESCRIPTION
This pull request fixes the problem of GlobalState.setup to automatically load the Setup from the configuration manager. That function is for the `load_setup()` method instead. `GlobalState.setup` is a property that now returns the current Setup in the process or None when no Setup was previously loaded.