### PR TITLE
abstract metrics database

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "rich>=13.9.4",
     "typer>=0.15.1",
     "navdict>=0.2.4",
-
     # Python 3.9 specific dependencies
     "numpy==1.26.4; python_version == '3.9'",
     "pandas==1.5.1; python_version == '3.9'",
@@ -38,10 +37,12 @@ dependencies = [
     "numpy>=2.1; python_version >= '3.10'",
     "pandas>=2.2.0; python_version >= '3.10'",
     "pyzmq>=25.1.0; python_version >= '3.10'",
-
     # Python 3.10+ entrypoints interface changed
     "importlib_metadata>=4.6.0; python_version <= '3.11'",
     "influxdb3-python",
+    "duckdb>=1.3.1",
+    "requests>=2.32.4",
+    "psycopg>=3.2.9",
 ]
 
 [project.scripts]

--- a/libs/cgse-common/src/egse/control.py
+++ b/libs/cgse-common/src/egse/control.py
@@ -22,12 +22,15 @@ from urllib3.exceptions import NewConnectionError
 from egse.decorators import retry
 from egse.decorators import retry_with_exponential_backoff
 from egse.listener import Listeners
+from egse.metrics import get_metrics_repo
 from egse.registry.client import RegistryClient
 from egse.signal import FileBasedSignaling
 from egse.system import SignalCatcher
 from egse.system import camel_to_kebab
 from egse.system import camel_to_snake
+from egse.system import str_to_datetime
 from egse.system import time_in_ms
+from egse.system import type_name
 from egse.zmq_ser import get_port_number
 
 try:
@@ -47,9 +50,6 @@ from egse.system import get_average_execution_times
 from egse.system import get_full_classname
 from egse.system import get_host_ip
 from egse.system import save_average_execution_time
-from influxdb_client_3 import InfluxDBClient3
-from influxdb_client_3.write_client.domain.write_precision import WritePrecision
-from influxdb_client_3 import Point
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -179,12 +179,15 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         token = os.getenv("INFLUXDB3_AUTH_TOKEN")
         project = os.getenv("PROJECT")
-        self.metrics_time_precision = WritePrecision.MS
 
         if project and token:
-            self.client = InfluxDBClient3(database=project, host="http://localhost:8181", token=token)
+            self.metrics_client = get_metrics_repo(
+                "influxdb", {"host": "http://localhost:8181", "database": project, "token": token}
+            )
+            # self.metrics_client = get_metrics_repo("duckdb", {"db_path": "duckdb_metrics.db", "table_name": "cs_timeseries"})
+            self.metrics_client.connect()
         else:
-            self.client = None
+            self.metrics_client = None
             _LOGGER.warning(
                 "INFLUXDB3_AUTH_TOKEN and/or PROJECT environment variable is not set. "
                 "Metrics will not be propagated to InfluxDB."
@@ -545,7 +548,7 @@ class ControlServer(metaclass=abc.ABCMeta):
                 except Exception as exc:
                     _LOGGER.error(
                         textwrap.dedent(
-                            f"""\
+                            f"""{type_name(exc)}
                             An Exception occurred while collecting housekeeping from the device to be stored in {self.get_storage_mnemonic()}.
                             This might be a temporary problem, still needs to be looked into:
         
@@ -659,20 +662,19 @@ class ControlServer(metaclass=abc.ABCMeta):
             return
 
         try:
-            if self.client:
-                metrics_dictionary = {
-                    "measurement": origin.lower(),  # Table name
-                    "tags": {"site_id": SITE_ID, "origin": origin},  # Site ID, Origin
-                    "fields": dict((hk_name.lower(), hk[hk_name]) for hk_name in hk if hk_name != "timestamp"),
-                    "time": hk["timestamp"],
+            if self.metrics_client:
+                point = {
+                    "measurement": origin.lower(),
+                    "tags": {"site_id": SITE_ID, "origin": origin},
+                    "fields": {hk_name.lower(): hk[hk_name] for hk_name in hk if hk_name != "timestamp"},
+                    "time": str_to_datetime(hk["timestamp"]),
                 }
-                point = Point.from_dict(metrics_dictionary, write_precision=self.metrics_time_precision)
-                self.client.write(point)
+                self.metrics_client.write(point)
             else:
-                _LOGGER.warning(f"Could not write {origin} metrics to InfluxDB (self.client is None).")
+                _LOGGER.warning(f"Could not write {origin} metrics to the time series database (self.metrics_client is None).")
         except NewConnectionError:
             _LOGGER.warning(
-                f"No connection to InfluxDB could be established to propagate {origin} metrics.  Check "
+                f"No connection to the time series database could be established to propagate {origin} metrics.  Check "
                 f"whether this service is (still) running."
             )
 

--- a/libs/cgse-common/src/egse/metrics.py
+++ b/libs/cgse-common/src/egse/metrics.py
@@ -1,14 +1,31 @@
+__all__ = [
+    "DataPoint",
+    "TimeSeriesRepository",
+    "define_metrics",
+    "get_metrics_repo",
+]
+
 import logging
+from dataclasses import dataclass
+from typing import Any
 from typing import Optional
+from typing import Protocol
+from typing import Self
 
 import numpy as np
 from prometheus_client import Gauge
 
 from egse.hk import TmDictionaryColumns
+from egse.plugin import load_plugins_fn
 from egse.settings import Settings
-from egse.setup import SetupError, load_setup, Setup
+from egse.setup import Setup
+from egse.setup import SetupError
+from egse.setup import load_setup
+from egse.system import format_datetime
+from egse.system import str_to_datetime
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger("egse.metrics")
+
 SITE_ID = Settings.load("SITE").ID
 
 
@@ -64,7 +81,7 @@ def define_metrics(origin: str, dashboard: str = None, use_site: bool = False, s
             try:
                 metrics[syn_name] = Gauge(syn_name, description)
             except ValueError:
-                LOGGER.warning(f"ValueError for {syn_name}")
+                logger.warning(f"ValueError for {syn_name}")
 
         return metrics
 
@@ -100,4 +117,105 @@ def update_metrics(metrics: dict, updates: dict):
             else:
                 metrics[metric_name].set(float(value))
         except KeyError:
-            LOGGER.warning(f"Unknown metric name: {metric_name=}")
+            logger.warning(f"Unknown metric name: {metric_name=}")
+
+
+class PointLike(Protocol):
+    @staticmethod
+    def measurement(measurement_name: str) -> "PointLike": ...
+
+    def tag(self, key, value) -> Self: ...
+
+    def field(self, field, value) -> Self: ...
+
+    def time(self, time) -> Self: ...
+
+    def as_dict(self) -> dict: ...
+
+
+class DataPoint(PointLike):
+    def __init__(self, measurement_name: str):
+        self.measurement: str = measurement_name
+        self.tags: dict[str, str] = {}
+        self.fields: dict[str, Any] = {}
+        self.timestamp: int | str = format_datetime()
+
+    def as_dict(self):
+        if isinstance(self.timestamp, str):
+            timestamp = str_to_datetime(self.timestamp).timestamp()
+        else:
+            timestamp = self.timestamp
+
+        return {
+            "measurement": self.measurement,
+            "tags": self.tags,
+            "fields": self.fields,
+            "time": timestamp,
+        }
+
+    @staticmethod
+    def measurement(measurement_name):
+        p = DataPoint(measurement_name)
+        return p
+
+    def tag(self, key, value):
+        self.tags[key] = value
+        return self
+
+    def field(self, field, value):
+        self.fields[field] = value
+        return self
+
+    def time(self, time):
+        self.timestamp = time
+        return self
+
+
+class TimeSeriesRepository(Protocol):
+    def connect(self) -> None: ...
+
+    def write(self, points: PointLike | dict | list[PointLike | dict]) -> None: ...
+
+    def query(self, query_str: str, mode: str) -> Any: ...
+
+    def get_table_names(self) -> list[str]: ...
+
+    def get_column_names(self, table_name: str) -> list[str]: ...
+
+    def get_values_last_hours(self, table_name: str, column_name: str, hours: int, mode: str) -> Any: ...
+
+    def get_values_in_range(
+            self, table_name: str, column_name: str, start_time: str, end_time: str, mode: str
+    ) -> Any: ...
+
+    def close(self) -> None: ...
+
+
+def get_metrics_repo(plugin_name: str, config: dict[str, Any]) -> TimeSeriesRepository:
+    """
+    Create a TimeSeriesRepository instance from a plugin.
+
+    Args:
+        plugin_name: Name of the plugin (without .py extension)
+        config: Configuration parameters for the repository
+
+    Returns:
+        Configured TimeSeriesRepository instance.
+
+    Raises:
+        ModuleNotFoundError: If plugin not found
+        NotImplementedError: If plugin is missing get_repository_class()
+    """
+
+    package_name = "egse.plugins"
+    plugins = load_plugins_fn(f"{plugin_name}.py", package_name)
+
+    if plugin_name in plugins:
+        plugin = plugins[plugin_name]
+        if hasattr(plugin, "get_repository_class"):
+            repo_class = plugin.get_repository_class()
+        else:
+            raise NotImplementedError(f"Missing 'get_repository_class()` function in metrics plugin {plugin_name}.")
+        return repo_class(**config)
+    else:
+        raise ModuleNotFoundError(f"No plugin found for {plugin_name} in {package_name}.")

--- a/libs/cgse-common/src/egse/plugin.py
+++ b/libs/cgse-common/src/egse/plugin.py
@@ -3,17 +3,24 @@ This module provides function to load plugins and settings from entry-points.
 """
 
 __all__ = [
-    "load_plugins",
+    "load_plugins_ep",
+    "load_plugins_fn",
     "get_file_infos",
     "entry_points",
     "HierarchicalEntryPoints",
 ]
+
+import importlib.util
 import logging
 import os
 import sys
 import textwrap
 import traceback
+import types
+from functools import lru_cache
 from pathlib import Path
+
+from egse.system import type_name
 
 if sys.version_info >= (3, 12):  # Use the standard library version (Python 3.10+)
     from importlib.metadata import entry_points as lib_entry_points
@@ -26,7 +33,8 @@ else:
 import click
 import rich
 
-_LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
+HERE = Path(__file__).parent
 
 
 def entry_points(group: str) -> set[EntryPoint]:
@@ -43,7 +51,7 @@ def entry_points(group: str) -> set[EntryPoint]:
         return set()
 
 
-def load_plugins(entry_point: str) -> dict:
+def load_plugins_ep(entry_point: str) -> dict:
     """
     Returns a dictionary with plugins loaded. The keys are the names of the entry-points,
     the values are the loaded modules or objects.
@@ -58,9 +66,88 @@ def load_plugins(entry_point: str) -> dict:
             eps[ep.name] = ep.load()
         except Exception as exc:
             eps[ep.name] = None
-            _LOGGER.error(f"Couldn't load entry point: {exc}")
+            logger.error(f"Couldn't load entry point {entry_point}: {type_name(exc)} – {exc}")
 
     return eps
+
+
+@lru_cache
+def load_plugins_fn(pattern: str, package_name: str = None) -> dict[str, types.ModuleType]:
+    """
+    Returns a dictionary with plugins loaded for the filenames that match the given pattern.
+    The keys are the names of the modules, the values are the loaded modules.
+
+    If no package_name is provided, the pattern is relative to the location of this module
+    (which is in the top-level module `egse`).
+
+    If the pattern results in two or more modules with the same name, a warning will be logged
+    and only the last imported module will be returned in the dictionary.
+
+    Plugins are usually located in the `egse.plugins` module. Remember that `egse.plugins`
+    is a namespace and external packages can also deliver plugin modules in that location.
+
+    Note:
+        When a plugin cannot be loaded, an error is logged.
+
+        This function uses an LRU cache to avoid reloading modules. If you need to reload,
+        use `load_plugins_fn.cache_clear()` to reset the cache.
+
+    Raises:
+        ImportError when the given package_name cannot be imported as a module.
+
+    Examples:
+
+        # Loading the InfluxDB plugin for time series metrics
+        >>> influxdb = load_plugins_fn("influxdb.py", "egse.plugins.metrics")
+
+        # Loading the HDF5 storage plugin for PLATO
+        >>> hdf5 = load_plugins_fn("hdf5.py", "egse.plugins.storage")
+
+        # Loading all plugins
+        >>> x = load_plugins_fn("**/*.py", "egse.plugins")
+
+    """
+    loaded_modules = {}
+    failed_modules = {}  # we keep failed modules for housekeeping only
+
+    if package_name is None:
+        package_path = [HERE]
+    else:
+        try:
+            package = importlib.import_module(package_name)
+        except ImportError as exc:
+            raise ImportError(f"Cannot import package '{package_name}': {exc}")
+
+        if hasattr(package, '__path__'):
+            package_path = package.__path__
+        else:
+            package_path = [package.__file__.replace('__init__.py', '')]
+
+    # rich.print(package_path)
+
+    for path_entry in map(Path, package_path):
+        # rich.print(path_entry)
+        for plugin_file in path_entry.rglob(pattern):
+            # rich.print("    ", plugin_file)
+            module_name = plugin_file.stem
+            try:
+                spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                if module_name in loaded_modules:
+                    logger.warning(
+                        f"Overwriting module '{module_name}' from {loaded_modules[module_name].__file__} "
+                        f"with {plugin_file}."
+                    )
+                loaded_modules[module_name] = module
+            except Exception as exc:
+                error_msg = f"Couldn't load module '{module_name}' from {plugin_file}: {type_name(exc)} – {exc}"
+                logger.error(error_msg)
+                if module_name in failed_modules:
+                    logger.warning(f"Overwriting previously unloaded module '{module_name}' with {plugin_file}.")
+                failed_modules[module_name] = error_msg
+
+    return loaded_modules
 
 
 def get_file_infos(entry_point: str) -> dict[str, tuple[Path, str]]:
@@ -93,7 +180,7 @@ def get_file_infos(entry_point: str) -> dict[str, tuple[Path, str]]:
             path = get_module_location(ep.module)
 
             if path is None:
-                _LOGGER.error(
+                logger.error(
                     f"The entry-point '{ep.name}' is ill defined. The module part doesn't exist or is a "
                     f"namespace. No settings are loaded for this entry-point."
                 )
@@ -101,7 +188,7 @@ def get_file_infos(entry_point: str) -> dict[str, tuple[Path, str]]:
                 eps[ep.name] = (path, ep.attr)
 
         except Exception as exc:
-            _LOGGER.error(f"The entry point '{ep.name}' is ill defined: {exc}")
+            logger.error(f"The entry point '{ep.name}' is ill defined: {exc}")
 
     return eps
 

--- a/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
@@ -1,0 +1,187 @@
+"""
+A TimeSeriesRepository implementation for the InfluxDB3 database.
+
+An example query:
+
+    import os
+    from egse.metrics import get_metrics_repo
+
+    token = os.environ.get("INFLUXDB3_AUTH_TOKEN")
+    project = os.environ.get("PROJECT")
+
+    influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": project, "token": token})
+    influxdb.connect()
+
+    df = influxdb.query("SELECT * FROM cm ORDER BY TIME LIMIT 20")
+
+    influxdb.close()
+
+Other queries:
+
+    SHOW TABLES;
+        - this is equivalent to using `get_table_names()`
+
+    SHOW COLUMNS IN cm;
+        - this is equivalent to using `get_column_names()`
+
+"""
+__all__ = [
+    "InfluxDBRepository",
+    "get_repository_class",
+]
+
+import logging
+
+import pandas
+import pyarrow
+from influxdb_client_3 import InfluxDBClient3
+from influxdb_client_3 import Point
+from influxdb_client_3 import SYNCHRONOUS
+from influxdb_client_3 import write_client_options
+from influxdb_client_3.exceptions import InfluxDB3ClientError
+from influxdb_client_3.write_client.domain.write_precision import WritePrecision
+
+from egse.metrics import TimeSeriesRepository
+from egse.system import type_name
+
+logger = logging.getLogger("egse.plugins")
+
+
+class InfluxDBRepository(TimeSeriesRepository):
+    def __init__(self, host: str, database: str, token: str):
+        self.host = host
+        self.database = database
+        self.token = token
+        self.metrics_time_precision = WritePrecision.NS
+
+        self.client = None
+
+    def __enter__(self):
+        self.connect()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def connect(self):
+        wco = write_client_options(write_options=SYNCHRONOUS, write_precision=self.metrics_time_precision,
+                                   flush_interval=200)
+        self.client = InfluxDBClient3(host=self.host, database=self.database, token=self.token, write_options=wco)
+
+    def write(self, points: Point | dict | list[Point | dict]):
+        self.client.write(record=points, write_precision=self.metrics_time_precision)
+
+    def query(self, query_str: str, mode: str = "all") -> pyarrow.Table | pandas.DataFrame:
+        try:
+            table = self.client.query(query_str, database=self.database)
+        except InfluxDB3ClientError as exc:
+            logger.error(f"Caught {type_name(exc)}; {exc}")
+            raise ValueError(f"Caught {type_name(exc)}: check the query \"{query_str}\"") from exc
+
+        match mode:
+            case "all":
+                return table
+            case "pandas":
+                df = table.to_pandas()
+                return df
+            case _:
+                raise ValueError(f"Invalid mode '{mode}', use 'all', or 'pandas'.")
+
+    def get_table_names(self) -> list[str]:
+        """Get all tables (measurements) in the database."""
+        query = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'iox'"
+
+        try:
+            result: pandas.DataFrame = self.query(query, mode='pandas')
+            return [x for x in result["table_name"]]
+        except Exception as exc:
+            logger.error(f"Caught {type_name(exc)} while getting tables: {exc}")
+            return []
+
+    def get_column_names(self, table_name: str) -> list[str]:
+        """Get column information for a specific table."""
+        query = f"SHOW COLUMNS IN {table_name}"
+
+        try:
+            result: pandas.DataFrame = self.query(query, mode='pandas')
+            return [x for x in result["column_name"]]
+        except Exception as exc:
+            logger.error(f"Caught {type_name(exc)} while getting column names: {exc}")
+            return []
+
+    def close(self):
+        if self.client:
+            self.client.close()
+
+    def get_values_last_hours(
+        self, table_name: str, column_name: str, hours: int = 24, mode: str = "pandas"
+    ) -> pandas.DataFrame | list[list]:
+        """Get column values from the last N hours."""
+        query = f"""
+            SELECT time, {column_name}
+            FROM {table_name}
+            WHERE time >= NOW() - INTERVAL '{hours} hours'
+            ORDER BY time DESC
+        """
+        df = self.query(query, mode="pandas")
+
+        if mode == "pandas":
+            return df
+        else:
+            return _safe_convert_to_datetime_lists(df, "time", column_name)
+
+    def get_values_in_range(
+            self, table_name: str, column_name: str, start_time: str, end_time: str, mode: str = "pandas"
+    ) -> pandas.DataFrame | list[list]:
+        """Get column values within a time range."""
+        query = f"""
+            SELECT time, {column_name}
+            FROM {table_name}
+            WHERE time >= '{start_time}' 
+              AND time < '{end_time}'
+            ORDER BY time DESC
+        """
+        df = self.query(query, mode="pandas")
+
+        if mode == "pandas":
+            return df
+        else:
+            return _safe_convert_to_datetime_lists(df, "time", column_name)
+
+
+def _safe_convert_to_datetime_lists(df, time_col, value_col):
+    """Safely convert DataFrame to [datetimes_list, values_list] with type checking."""
+
+    # Check if time column exists and is convertible to datetime
+    if time_col not in df.columns:
+        raise ValueError(f"Time column '{time_col}' not found in data frame")
+
+    if not pandas.api.types.is_datetime64_any_dtype(df[time_col]):
+        print(f"Converting {time_col} from {df[time_col].dtype} to datetime")
+        df[time_col] = pandas.to_datetime(df[time_col])
+
+    # Check if value column exists and is numeric
+    if value_col not in df.columns:
+        raise ValueError(f"Value column '{value_col}' not found in data frame")
+
+    if pandas.api.types.is_object_dtype(df[value_col]):
+        print(f"No conversion needed for {value_col} from object type")
+    elif pandas.api.types.is_integer_dtype(df[value_col]):
+        print(f"Converting {value_col} from {df[value_col].dtype} to numeric")
+        df[value_col] = pandas.to_numeric(df[value_col], errors='coerce')
+    elif pandas.api.types.is_float_dtype(df[value_col]):
+        print(f"Converting {value_col} from {df[value_col].dtype} to numeric")
+        df[value_col] = pandas.to_numeric(df[value_col], errors='coerce')
+    elif pandas.api.types.is_string_dtype(df[value_col]):
+        print(f"No conversion needed  for {value_col} from string type")
+
+    # Convert to lists
+    datetimes = df[time_col].dt.to_pydatetime().tolist()
+    values = df[value_col].tolist()
+
+    return [datetimes, values]
+
+
+# This method is required when loading the plugin with `get_metrics_repo()`.
+def get_repository_class() -> TimeSeriesRepository:
+    """Returns the class that implements the TimeSeriesRepository."""
+    return InfluxDBRepository

--- a/libs/cgse-common/tests/test_influxdb_plugin.py
+++ b/libs/cgse-common/tests/test_influxdb_plugin.py
@@ -1,0 +1,149 @@
+import datetime
+import os
+import random
+import time
+
+import pandas as pd
+from influxdb_client_3 import Point
+from rich import print
+
+from egse.metrics import get_metrics_repo
+from egse.plugins.metrics.influxdb import InfluxDBRepository
+from egse.system import Timer
+from egse.system import format_datetime
+from egse.system import str_to_datetime
+
+
+def test_influxdb_access():
+    token = os.environ.get("INFLUXDB3_AUTH_TOKEN")
+
+    influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
+    influxdb.connect()
+
+    result = influxdb.query("SELECT * FROM cm ORDER BY TIME DESC LIMIT 20", mode='pandas')
+    print(result)
+    assert isinstance(result, pd.DataFrame)
+
+    result = influxdb.get_values_last_hours("cm", "cm_setup_id", hours=24, mode='pandas')
+    print(f"Values from 'cm_setup_id': \n{result}")
+
+    result = influxdb.get_values_in_range("cm", "cm_site_id", "2025-06-26T08:10:00Z", "2025-06-26T08:15:00Z", mode='')
+    print(f"Values from 'cm_site_id': \n{result}")
+
+    result = influxdb.get_table_names()
+    print(f"Tables in ARIEL: {result}")
+
+    result = influxdb.get_column_names('cm')
+    print(f"Columns in cm: {result}")
+
+    result = influxdb.get_column_names('storagecontrolserver')
+    print(f"Columns in storagecontrolserver: {result}")
+
+    result = influxdb.get_column_names('unit_test')
+    print(f"Columns in unit_test: {result}")
+
+    influxdb.close()
+
+
+def test_influxdb_write():
+
+    token = os.environ.get("INFLUXDB3_AUTH_TOKEN")
+
+    influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
+
+    print()
+
+    with influxdb:
+        points = []
+        measurements = [
+            "unit_test", "ariel", "localhost", "random"
+        ]
+        for count in range(500):
+            points.append(
+                Point
+                .measurement(random.choice(measurements))
+                .tag("site_id", "KUL")
+                .tag("origin", "UNITTEST")
+                .field("count", count)
+                .field("random", random.randint(0, 100))
+                .time(datetime.datetime.now(tz=datetime.timezone.utc))
+            )
+            # with Timer("influxdb.write", precision=3):
+            #     influxdb.write(points[count])
+            # print('.', end="", flush=True)
+
+        print()
+        with Timer("influxdb.writes", precision=3):
+            influxdb.write(points)
+
+        names = influxdb.get_table_names()
+        print(f"{names = }")
+        assert "unit_test" in names
+
+        names = influxdb.get_column_names("unit_test")
+        assert "count" in names
+
+        result = influxdb.get_values_last_hours("unit_test", "count", hours=1, mode='pandas')
+        print(f"Values from 'count': {result}")
+
+        result = influxdb.query("SELECT * FROM unit_test ORDER BY TIME DESC LIMIT 20", mode='pandas')
+        print(result)
+
+
+def test_speed():
+    import time
+
+    class DiagnosticInfluxDBRepository(InfluxDBRepository):
+        def write_points(self, points):
+            start_time = time.time()
+
+            try:
+                super().write(points)
+
+            except Exception as exc:
+                print(f"Write error: {exc}")
+                raise
+
+            finally:
+                duration = time.time() - start_time
+                print(f"Wrote {len(points)} points in {duration:.3f}s")
+
+                if duration > 0.1:  # Warn if > 100ms
+                    print(f"⚠️  Slow write detected: {duration:.3f}s for {len(points)} points")
+
+    token = os.environ.get("INFLUXDB3_AUTH_TOKEN")
+    influxdb = DiagnosticInfluxDBRepository(host="http://localhost:8181", database="ARIEL", token=token)
+    influxdb.connect()
+
+    points = []
+    for count in range(10):
+        points.append(
+            {
+                "measurement": "unit_test",
+                "tags": {
+                    "site_id": "KUL",
+                    "origin": "UNITTEST"
+                },
+                "fields": {
+                    "count": count,
+                    "random": random.randint(0, 100),
+                },
+                "time": str_to_datetime(format_datetime()),
+            }
+        )
+
+    influxdb.write_points(points)
+
+    influxdb.close()
+
+
+def test_connection_speed():
+    import requests
+
+    start = time.time()
+    response = requests.get("http://localhost:8181/health")
+    duration = time.time() - start
+
+    print(f"Health check took {duration:.3f}s")
+    if duration > 0.1:
+        print("⚠️  Network latency detected")

--- a/libs/cgse-common/tests/test_metrics.py
+++ b/libs/cgse-common/tests/test_metrics.py
@@ -1,0 +1,25 @@
+import os
+
+from egse.metrics import get_metrics_repo
+
+
+def test_get_metrics_repo():
+    token = os.environ.get("INFLUXDB3_AUTH_TOKEN")
+
+    influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
+    influxdb.connect()
+
+    result = influxdb.query("SELECT * FROM cm ORDER BY TIME DESC LIMIT 20", mode='pandas')
+    print(result)
+
+    # result = influxdb.query("SHOW TABLES;")
+    # result = influxdb.query("SHOW COLUMNS IN cm;", mode="pandas")
+    # print(f"Columns in cm: {result}")
+
+    result = influxdb.get_table_names()
+    print(f"Tables in ARIEL: {result}")
+
+    result = influxdb.get_column_names('cm')
+    print(f"Columns in cm: {result}")
+
+    influxdb.close()

--- a/libs/cgse-common/tests/test_plugin.py
+++ b/libs/cgse-common/tests/test_plugin.py
@@ -1,0 +1,30 @@
+import logging
+
+from egse.plugin import load_plugins_fn
+
+logger = logging.getLogger("test")
+
+
+def test_load_plugins_fn():
+
+    # Load ALL plugins from the `egse.plugins` namespace
+    plugins_1 = load_plugins_fn("plugins/**/*.py", "egse")
+    print(plugins_1)
+
+    # Load ALL plugins from the `egse.plugins` namespace
+    plugins_2 = load_plugins_fn("**/*.py", "egse.plugins")
+    print(plugins_2)
+
+    assert plugins_1.keys() == plugins_2.keys()
+
+    assert "influxdb" in plugins_1
+    assert "fits" in plugins_1
+    assert "hdf5" in plugins_1
+
+    # No Exception should be raised when the module doesn't exist
+    plugins = load_plugins_fn("not-a-module")
+    assert plugins == {}
+
+    # Load a normal regular module
+    plugins = load_plugins_fn("bits.py", "egse")
+    assert "bits" in plugins

--- a/libs/cgse-common/tests/test_zmq_ser.py
+++ b/libs/cgse-common/tests/test_zmq_ser.py
@@ -1,0 +1,71 @@
+import pickle
+
+from egse.zmq_ser import zmq_error_response
+from egse.zmq_ser import zmq_json_request
+from egse.zmq_ser import zmq_json_response
+from egse.zmq_ser import zmq_string_request
+from egse.zmq_ser import zmq_string_response
+
+
+def test_zmq_requests():
+    assert zmq_string_request("") == [b"MESSAGE_TYPE:STRING", b""]
+    assert zmq_string_request("hello") == [b"MESSAGE_TYPE:STRING", b"hello"]
+
+    assert zmq_json_request({}) == [b"MESSAGE_TYPE:JSON", b"{}"]
+    assert zmq_json_request({"command": "do_something"}) == [b"MESSAGE_TYPE:JSON", b'{"command": "do_something"}']
+
+
+def test_zmq_responses():
+    assert zmq_string_response("") == [b"MESSAGE_TYPE:STRING", b""]
+    assert zmq_string_response("Good Job!") == [b"MESSAGE_TYPE:STRING", b"Good Job!"]
+
+    assert zmq_json_response({}) == [b"MESSAGE_TYPE:JSON", b"{}"]
+    assert zmq_json_response({"success": True, "message": "all good", "metadata": {"version": "0.1.0"}}) == [
+        b"MESSAGE_TYPE:JSON",
+        b'{"success": true, "message": "all good", "metadata": {"version": "0.1.0"}}',
+    ]
+    assert zmq_json_response(
+        {
+            "success": True,
+            "message": {"name": "cgse", "description": "Great software"},
+            "metadata": {"version": "0.1.0"},
+        }
+    ) == [
+        b"MESSAGE_TYPE:JSON",
+        b"{"
+        b'"success": true, '
+        b'"message": {"name": "cgse", "description": "Great software"}, "metadata": {"version": "0.1.0"}'
+        b"}",
+    ]
+
+
+def test_zmq_error_responses():
+    assert zmq_error_response({}) == [b"MESSAGE_TYPE:ERROR", b"\x80\x04}\x94."]
+    response = zmq_error_response(
+        {
+            "success": False,
+            "message": "Incorrect message type: MESSAGE_TYPE:PICKLE",
+            "metadata": {
+                "data": {
+                    "file": "/Users/rik/github/cgse/libs/cgse-common/src/egse/async_control.py",
+                    "lineno": 322,
+                    "function": "_process_device_command",
+                },
+            },
+        }
+    )
+    assert isinstance(response, list)
+    assert len(response) == 2
+    assert response[0] == b"MESSAGE_TYPE:ERROR"
+    assert isinstance(response[1], bytes)
+    assert pickle.loads(response[1]) == {
+        "success": False,
+        "message": "Incorrect message type: MESSAGE_TYPE:PICKLE",
+        "metadata": {
+            "data": {
+                "file": "/Users/rik/github/cgse/libs/cgse-common/src/egse/async_control.py",
+                "lineno": 322,
+                "function": "_process_device_command",
+            },
+        },
+    }

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -20,8 +20,16 @@ Storage Control Server:                          # SM_CS
     SERVICE_TYPE:                 SM_CS
     DELAY:                            1          # The delay time between publishing status information [seconds]
 
-Process Manager Control Server:                # PM_CS
+Process Manager Control Server:                  # PM_CS
 
-    SERVICE_TYPE:                PM_CS
-    DELAY:                          1          # The delay time between publishing status information [seconds]
-    STORAGE_MNEMONIC:              PM          # The mnemonic to be used in the filename storing the housekeeping data
+    SERVICE_TYPE:                 PM_CS
+    DELAY:                            1          # The delay time between publishing status information [seconds]
+    STORAGE_MNEMONIC:                PM          # The mnemonic to be used in the filename storing the housekeeping data
+
+Notify Hub:
+    SERVICE_TYPE:            NOTIFY_HUB
+    COLLECTOR_PORT:                4245
+    PUBLISHER_PORT:                4246
+    
+Metrics Hub:
+    SERVICE_TYPE:           METRICS_HUB

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -112,6 +112,7 @@ from __future__ import annotations
 
 import logging
 import operator
+import random
 import textwrap
 import threading
 from pathlib import Path
@@ -1034,6 +1035,7 @@ class ConfigurationManagerProtocol(CommandProtocol):
 
         hk = {
             "timestamp": format_datetime(),
+            "random": random.randint(0, 100),
             "CM_SITE_ID": site_id,
             "CM_SETUP_ID": setup_id,
             "CM_TEST_ID": test_id,

--- a/libs/cgse-core/src/egse/procman/procman_protocol.py
+++ b/libs/cgse-core/src/egse/procman/procman_protocol.py
@@ -1,3 +1,4 @@
+import random
 from pathlib import Path
 
 from egse.control import ControlServer
@@ -89,4 +90,7 @@ class ProcessManagerProtocol(CommandProtocol):
         Returns: Dictionary with housekeeping data for the Control Server for Process Management.
         """
 
-        return {"timestamp": format_datetime()}
+        return {
+            "timestamp": format_datetime(),
+            "random": random.randint(0, 100),
+        }

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -109,6 +109,7 @@ import abc
 import datetime
 import logging
 import os
+import random
 import shutil
 import textwrap
 from functools import partial
@@ -1105,6 +1106,7 @@ class StorageProtocol(CommandProtocol):
     def get_housekeeping(self) -> dict:
         return {
             "timestamp": format_datetime(),
+            "random": random.randint(0, 100),
         }
 
 

--- a/libs/cgse-core/src/egse/storage/persistence.py
+++ b/libs/cgse-core/src/egse/storage/persistence.py
@@ -11,7 +11,7 @@ from sqlite3 import Connection
 from typing import Optional
 from typing import Union
 
-from egse.plugin import load_plugins
+from egse.plugin import load_plugins_ep
 from egse.storage import PersistenceLayer
 from egse.system import read_last_line
 
@@ -525,6 +525,6 @@ TYPES = {
     "TXT": TXT,
 }
 
-for name, ep in load_plugins(entry_point="cgse.storage.persistence").items():
+for name, ep in load_plugins_ep(entry_point="cgse.storage.persistence").items():
     if ep is not None:
         TYPES[name] = ep


### PR DESCRIPTION
This pull request is the initial implementation of an abstraction of the metrics database that is used.

- control: uses generic functions to set up the metrics client
- metrics: added PointLike, DataPoint, and TimeSeriesRepository as Protocol classes
- plugin: added a function to load plugins from files, added metrics/plugin `influxdb.py`
- tests: added unit tests for the new features
- cm, pm, and sm: added a temporary `random` HK field to test metrics data