### PR TITLE
fix empty error frame which is printed when no subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 
 .pytest_cache
 .coverage
+.coverage.*
 .nox
 htmlcov
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,0 @@
-# TODO
-
-* [x] we will use one global version for the monorepo -> create a bump script that updates all version numbers from the master pyproject.toml

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
     "software framework"
 ]
 dependencies = [
-    "click>=8.1.8",
+    "click>=8.2.1",
     "deepdiff>=8.1.1",
     "distro>=1.9.0",
     "gitpython>=3.1.44",
@@ -27,7 +27,7 @@ dependencies = [
     "psutil>=6.1.1",
     "pyyaml>=6.0.2",
     "rich>=13.9.4",
-    "typer>=0.15.1",
+    "typer>=0.16.0",
     "navdict>=0.5.9",
     # Python 3.9 specific dependencies
     "numpy==1.26.4; python_version == '3.9'",
@@ -58,7 +58,7 @@ cgse-common = "cgse_common:settings.yaml"
 [tool.pytest.ini_options]
 pythonpath = "src"
 testpaths = ["tests"]
-addopts = "-rA --cov --cov-branch --cov-report html"
+addopts = "-ra --cov --cov-branch --cov-report html"
 log_cli = true
 log_cli_level = "INFO"
 filterwarnings = [

--- a/libs/cgse-common/src/cgse_common/cgse.py
+++ b/libs/cgse-common/src/cgse_common/cgse.py
@@ -85,7 +85,7 @@ class SortedCommandGroup(TyperGroup):
         return sorted(commands, key=get_command_priority)
 
 
-app = typer.Typer(add_completion=True, cls=SortedCommandGroup, rich_markup_mode="markdown")
+app = typer.Typer(add_completion=True, cls=SortedCommandGroup)
 
 
 @app.command()
@@ -121,22 +121,33 @@ def version(ctx: typer.Context):
             )
 
 
+def subcommand_callback(ctx: typer.Context):
+    """Normal callback."""
+    if ctx.invoked_subcommand is None:
+        typer.echo("No command specified:")
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+
+
 def build_app():
     global app
+
+    # rich.print("Available command groups:", entry_points("cgse.command"))
 
     for ep in entry_points("cgse.command"):
         try:
             obj = ep.load()
             if isinstance(obj, typer.Typer):
-                app.add_typer(ep.load(), name=ep.name)
+                obj.callback(invoke_without_command=True)(subcommand_callback)
+                app.add_typer(obj, name=ep.name)
             else:
-                app.command()(ep.load())
+                app.command()(obj)
         except Exception as exc:
             app.command()(broken_command(ep.name, ep.module, exc))
 
     cgse_eps = HierarchicalEntryPoints("cgse.service")
 
-    # rich.print("Available groups:", cgse_eps.get_all_groups())
+    # rich.print("Available services groups:", cgse_eps.get_all_groups())
 
     for group in cgse_eps.get_all_groups():
         for ep in entry_points(group):
@@ -145,12 +156,14 @@ def build_app():
                     app.add_typer(ep.load(), name=ep.name)
                 else:
                     command_group = snake_to_title(group.split(".")[-1])
-                    app.add_typer(ep.load(), name=ep.name, rich_help_panel=command_group)
+                    plugin_app: typer.Typer = ep.load()
+                    plugin_app.callback(invoke_without_command=True)(subcommand_callback)
+                    app.add_typer(plugin_app, name=ep.name, rich_help_panel=command_group)
             except Exception as exc:
                 app.command()(broken_command(ep.name, ep.module, exc))
 
 
-@app.callback(no_args_is_help=True, invoke_without_command=True)
+@app.callback(invoke_without_command=True)
 def main(ctx: typer.Context, verbose: bool = False):
     """
     The `cgse` command is used to:
@@ -167,6 +180,9 @@ def main(ctx: typer.Context, verbose: bool = False):
 
     ctx.obj = AppState(verbose=verbose)
 
+    if ctx.invoked_subcommand is None:
+        # print("Try 'cgse --help' for a list of commands.")
+        typer.echo(ctx.get_help())
 
 build_app()
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -30,7 +30,6 @@ from ._stop import stop_sm_cs
 core = typer.Typer(
     name="core",
     help="handle core services: start, stop, status, re-register",
-    no_args_is_help=True,
 )
 
 
@@ -92,7 +91,6 @@ def core_reregister(force: bool = False):
 rm_cs = typer.Typer(
     name="rm_cs",
     help="handle registry services: start, stop, status, list-services",
-    no_args_is_help=True,
 )
 
 
@@ -126,7 +124,6 @@ async def reg_list_services():
 log_cs = typer.Typer(
     name="log_cs",
     help="handle log services: start, stop, status, re-register",
-    no_args_is_help=True,
 )
 
 
@@ -164,7 +161,6 @@ def log_cs_reregister(force: bool = False):
 cm_cs = typer.Typer(
     name="cm_cs",
     help="handle configuration manager: start, stop, status, re-register",
-    no_args_is_help=True,
 )
 
 
@@ -209,7 +205,6 @@ def cm_cs_register_to_storage():
 sm_cs = typer.Typer(
     name="sm_cs",
     help="handle storage manager: start, stop, status, re-register",
-    no_args_is_help=True,
 )
 
 
@@ -247,7 +242,6 @@ def sm_cs_reregister(force: bool = False):
 pm_cs = typer.Typer(
     name="pm_cs",
     help="handle process manager: start, stop, status, re-register",
-    no_args_is_help=True,
 )
 
 

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -122,7 +122,7 @@ class ConfigurationManagerControlServer(ControlServer):
 
 
 app_name = "cm_cs"
-app = typer.Typer(name=app_name, no_args_is_help=True)
+app = typer.Typer(name=app_name)
 
 
 @app.command()

--- a/libs/cgse-core/src/egse/logger/log_cs.py
+++ b/libs/cgse-core/src/egse/logger/log_cs.py
@@ -92,7 +92,7 @@ class DateTimeFormatter(logging.Formatter):
 file_formatter = DateTimeFormatter(fmt=LOG_FORMAT_KEY_VALUE, datefmt=LOG_FORMAT_DATE)
 
 app_name = "log_cs"
-app = typer.Typer(name=app_name, no_args_is_help=True)
+app = typer.Typer(name=app_name)
 
 
 @app.command()

--- a/libs/cgse-core/src/egse/procman/procman_cs.py
+++ b/libs/cgse-core/src/egse/procman/procman_cs.py
@@ -115,7 +115,7 @@ class ProcessManagerControlServer(ControlServer):
 
 
 app_name = "pm_cs"
-app = typer.Typer(name=app_name, no_args_is_help=True)
+app = typer.Typer(name=app_name)
 
 
 @app.command()

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -34,7 +34,7 @@ from egse.registry.client import AsyncRegistryClient
 from egse.system import TyperAsyncCommand
 from egse.system import get_logging_level
 
-app = typer.Typer(name="rs_cs", no_args_is_help=True)
+app = typer.Typer(name="rs_cs")
 
 
 class AsyncRegistryServer:

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -103,7 +103,7 @@ class StorageControlServer(ControlServer):
 
 
 app_name = "sm_cs"
-app = typer.Typer(name=app_name, no_args_is_help=True)
+app = typer.Typer(name=app_name)
 
 
 @app.command()

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-python_versions = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python_versions = ["3.10", "3.11", "3.12", "3.13"]
 
 
 # Define monorepo-wide sessions

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
@@ -129,7 +129,7 @@ def init(project: str = ""):
         )
 
 
-show = typer.Typer(help="Show information about settings, environment, setup, ...", no_args_is_help=True)
+show = typer.Typer(help="Show information about settings, environment, setup, ...")
 
 
 @show.command(name="settings")
@@ -255,7 +255,7 @@ def show_setup(
             rich.print("[red]No setup files were found.[/]")
 
 
-check = typer.Typer(help="Check installation, settings, required files, etc.", no_args_is_help=True)
+check = typer.Typer(help="Check installation, settings, required files, etc.")
 
 
 @check.command(name="setups")

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_services.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_services.py
@@ -4,7 +4,7 @@ import rich
 import typer
 
 dev_x = typer.Typer(
-    name="dev-x", help="device-x is an imaginary device that serves as an example", no_args_is_help=True
+    name="dev-x", help="device-x is an imaginary device that serves as an example",
 )
 
 

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
@@ -12,7 +12,6 @@ from egse.env import get_log_file_location
 lakeshore336 = typer.Typer(
     name="LakeShore336",
     help="LakeShore336 Data Acquisition Unit, LakeShore, temperature monitoring",
-    no_args_is_help=True,
 )
 
 

--- a/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
+++ b/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
@@ -11,11 +11,11 @@ import typer
 from egse.env import get_log_file_location
 from egse.system import all_logging_disabled
 
-puna = typer.Typer(name="puna", help="PUNA Positioning Hexapod, Symétrie", no_args_is_help=True)
+puna = typer.Typer(name="puna", help="PUNA Positioning Hexapod, Symétrie")
 
-zonda = typer.Typer(name="zonda", help="ZONDA Positioning Hexapod, Symétrie", no_args_is_help=True)
+zonda = typer.Typer(name="zonda", help="ZONDA Positioning Hexapod, Symétrie")
 
-joran = typer.Typer(name="joran", help="JORAN Positioning Hexapod, Symétrie", no_args_is_help=True)
+joran = typer.Typer(name="joran", help="JORAN Positioning Hexapod, Symétrie")
 
 
 def redirect_output_to(output_fn: str) -> TextIO:

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,5 +21,5 @@ exclude = [
 line-length = 120
 indent-width = 4
 
-# Assume Python 3.9
-target-version = "py39"
+# Assume Python 3.10
+target-version = "py310"


### PR DESCRIPTION
This fixes issue #164 which reports printing an extra `Error` frame after the help message when no sub-command is provided.
The problem is due to a breaking change in the Click package where `no_args_is_help=True` always returns '1' which results in an error exit code. 