### PR TITLE
added notification hub + refactoring of the logger

### DIFF
--- a/libs/cgse-common/src/egse/log.py
+++ b/libs/cgse-common/src/egse/log.py
@@ -13,26 +13,63 @@ Environment variables that affect logging:
 
 __all__ = [
     "LOG_FORMAT_FULL",
+    "LOG_FORMAT_CLEAN",
+    "LOG_FORMAT_STYLE",
+    "LOG_DATE_FORMAT_FULL",
+    "LOG_DATE_FORMAT_CLEAN",
     "logger",
     "root_logger",
     "egse_logger",
+    "get_log_level_from_env",
+    "PackageFilter",
 ]
 
 import logging
 import os
 import textwrap
+from pathlib import Path
 
 import rich
+
+# The format for the log messages.
+# The log record attributes are listed: https://docs.python.org/3.12/library/logging.html#logrecord-attributes
 
 LOG_FORMAT_STYLE = "{"
 LOG_FORMAT_FULL = (
     "{asctime:19s}.{msecs:03.0f} : {processName:20s} : {levelname:8s} : {name:^25s} : {lineno:6d} : {filename:20s} : {"
     "message}"
 )
-LOG_FORMAT_CLEAN = "{asctime} [{levelname:>8s}] {message} ({filename}:{lineno:d})"
+LOG_FORMAT_CLEAN = "{asctime} [{levelname:>8s}] {message} ([{process}]{package_name}:{filename}:{lineno:d})"
 
 LOG_DATE_FORMAT_FULL = "%Y-%m-%d %H:%M:%S"
 LOG_DATE_FORMAT_CLEAN = "%Y-%m-%d %H:%M:%S"
+
+
+class PackageFilter(logging.Filter):
+    """Adds 'package_name' to the log record.
+
+    When this filter is added to a handler of a logger, the formatter of that
+    logger can use the 'package_name' attribute.
+
+    When the package name can not be determined, is will contain 'n/a'.
+
+    NOTE: this filer assumes the root package is 'egse'.
+    """
+    def filter(self, record):
+
+        if hasattr(record, 'pathname'):
+            parts = Path(record.pathname).parent.parts
+            try:
+                egse_index = parts.index('egse')
+                package_name = ".".join(parts[egse_index:])
+            except ValueError:
+                package_name = 'n/a'
+
+            record.package_name = package_name
+        else:
+            record.package_name = "n/a"
+
+        return True
 
 
 class EGSEFilter(logging.Filter):
@@ -40,15 +77,9 @@ class EGSEFilter(logging.Filter):
         return record.name.startswith("egse")
 
 
-egse_filter = EGSEFilter()
-
-
 class NonEGSEFilter(logging.Filter):
     def filter(self, record):
         return not record.name.startswith("egse")
-
-
-root_filter = NonEGSEFilter()
 
 
 def get_log_level_from_env(env_var: str = "LOG_LEVEL", default: int = logging.INFO):
@@ -89,20 +120,19 @@ else:
     egse_formatter = logging.Formatter(fmt=LOG_FORMAT_CLEAN, datefmt=LOG_DATE_FORMAT_CLEAN, style=LOG_FORMAT_STYLE)
 
 egse_handler.setFormatter(egse_formatter)
-egse_handler.addFilter(egse_filter)
+egse_handler.addFilter(EGSEFilter())
+egse_handler.addFilter(PackageFilter())
 
 root_logger.addHandler(egse_handler)
 
 for handler in root_logger.handlers:
     if handler != egse_handler:  # Don't filter our new handler
-        handler.addFilter(root_filter)
+        handler.addFilter(NonEGSEFilter())
+        handler.addFilter(PackageFilter())
 
 logger = egse_logger
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=get_log_level_from_env(), format=LOG_FORMAT_CLEAN, datefmt=LOG_DATE_FORMAT_CLEAN, style="{"
-    )
 
     root_logger = logging.getLogger()
 

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -49,6 +49,7 @@ log = 'cgse_core.services:log_cs'
 cm = 'cgse_core.services:cm_cs'
 sm = 'cgse_core.services:sm_cs'
 pm = 'cgse_core.services:pm_cs'
+notify = 'cgse_core.services:notifyhub'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"
@@ -73,8 +74,8 @@ filterwarnings = [
     "ignore::DeprecationWarning"
 ]
 log_cli = true
-log_cli_level = "INFO"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_level = "DEBUG"
+#log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.coverage.run]

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -73,3 +73,17 @@ def start_pm_cs():
         stdin=subprocess.DEVNULL,
         close_fds=True,
     )
+
+
+def start_notifyhub():
+    rich.print("Starting the notification hub core service...")
+
+    out = open(Path("~/.notifyhub.start.out").expanduser(), "w")
+
+    subprocess.Popen(
+        [sys.executable, "-m", "egse.notifyhub.server", "start"],
+        stdout=out,
+        stderr=out,
+        stdin=subprocess.DEVNULL,
+        close_fds=True,
+    )

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -103,3 +103,23 @@ def stop_pm_cs():
             waiting_for(lambda: not is_process_running(["procman_cs", "start"]), timeout=5.0)
     except TimeoutError:
         logger.warning("pm_cs should not be running anymore...")
+
+
+def stop_notifyhub():
+    rich.print("Terminating the notification hub core service...")
+
+    out = open(Path("~/.notifyhub.stop.out").expanduser(), "w")
+
+    subprocess.Popen(
+        [sys.executable, "-m", "egse.notifyhub.server", "stop"],
+        stdout=out,
+        stderr=out,
+        stdin=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+    try:
+        with Timer("notifyhub stop timer", log_level=logging.DEBUG):
+            waiting_for(lambda: not is_process_running(["egse.notifyhub.server", "start"]), timeout=5.0)
+    except TimeoutError:
+        logger.warning("notifyhub should not be running anymore...")

--- a/libs/cgse-core/src/cgse_core/cgse_explore.py
+++ b/libs/cgse-core/src/cgse_core/cgse_explore.py
@@ -12,7 +12,7 @@ def show_processes():
     """Returns of list of ProcessInfo data classes for matching processes from this package."""
 
     def filter_procs(pi: ProcessInfo):
-        pattern = r"(log|confman|storage|procman)_cs|registry\.server"
+        pattern = r"(log|confman|storage|procman)_cs|registry\.server|notifyhub\.server"
 
         return re.search(pattern, pi.command)
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -12,6 +12,7 @@ from egse.signal import create_signal_command_file
 from egse.system import TyperAsyncCommand
 from ._start import start_cm_cs
 from ._start import start_log_cs
+from ._start import start_notifyhub
 from ._start import start_pm_cs
 from ._start import start_rm_cs
 from ._start import start_sm_cs
@@ -23,6 +24,7 @@ from ._status import status_rm_cs
 from ._status import status_sm_cs
 from ._stop import stop_cm_cs
 from ._stop import stop_log_cs
+from ._stop import stop_notifyhub
 from ._stop import stop_pm_cs
 from ._stop import stop_rm_cs
 from ._stop import stop_sm_cs
@@ -40,6 +42,7 @@ def start_core_services(log_level: str = "WARNING"):
     rich.print("[green]Starting the core services...[/]")
 
     start_rm_cs(log_level)
+    start_notifyhub()
     start_log_cs()
     start_sm_cs()
     start_cm_cs()
@@ -60,6 +63,8 @@ def stop_core_services():
     stop_log_cs()
     # We need the registry server to stop other core services, so leave it running for a while
     time.sleep(1.0)
+    stop_notifyhub()
+    time.sleep(0.1)
     stop_rm_cs()
 
 
@@ -274,3 +279,19 @@ def pm_cs_reregister(force: bool = False):
         app_name,
         {"action": "reregister", "params": {"force": force}},
     )
+
+notifyhub = typer.Typer(
+    name="notifyhub",
+    help="handle notification hub: start, stop, status, re-register",
+)
+
+@notifyhub.command(name="start")
+def notifyhub_start():
+    """Start the Process Manager."""
+    start_notifyhub()
+
+
+@notifyhub.command(name="stop")
+def notifyhub_stop():
+    """Stop the Process Manager."""
+    stop_notifyhub()

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -3,9 +3,13 @@ PACKAGES:
 
 Logging Control Server:                          # LOG_CS
 
-    SERVICE_TYPE:                LOGGER
+    SERVICE_TYPE:                LOG_CS
     MAX_NR_LOG_FILES:                20          # The maximum number of log files that will be maintained in a roll-over
     MAX_SIZE_LOG_FILES:              20          # The maximum size one log file can become
+#    PROTOCOL:                       tcp
+#    HOSTNAME:                 localhost
+    RECEIVER_PORT:                 4248
+    COMMANDER_PORT:                4249
     TEXTUALOG_IP_ADDRESS:     127.0.0.1          # The IP address of the textualog listening server
     TEXTUALOG_LISTENING_PORT:     19996          # The port number on which the textualog server is listening
 
@@ -27,9 +31,11 @@ Process Manager Control Server:                  # PM_CS
     STORAGE_MNEMONIC:                PM          # The mnemonic to be used in the filename storing the housekeeping data
 
 Notify Hub:
+    
     SERVICE_TYPE:            NOTIFY_HUB
     COLLECTOR_PORT:                4245
     PUBLISHER_PORT:                4246
+    REQUESTS_PORT:                 4247
     
 Metrics Hub:
     SERVICE_TYPE:           METRICS_HUB

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -139,6 +139,8 @@ from egse.env import get_site_id
 from egse.exceptions import InternalError
 from egse.listener import EVENT_ID
 from egse.log import logger
+from egse.notifyhub.event import NotificationEvent
+from egse.notifyhub.services import EventPublisher
 from egse.obsid import ObservationIdentifier
 from egse.plugin import entry_points
 from egse.protocol import CommandProtocol
@@ -757,6 +759,16 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
                         EVENT_ID.SETUP, {"event_type": "new_setup", "setup_id": self._setup_id}
                     )
 
+            with EventPublisher() as pub:
+                pub.publish(
+                    NotificationEvent(
+                        event_type="new_setup",
+                        source_service="cm_cs",
+                        data={"setup_id": self._setup_id},
+                        timestamp=time.time(),
+                    )
+                )
+
             return self._setup
         except SettingsError as exc:
             return Failure(f"The Setup file can not be loaded from {setup_file}.", exc)
@@ -940,6 +952,16 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
                     self._control_server.notify_listeners(
                         EVENT_ID.SETUP, {"event_type": "new_setup", "setup_id": setup_id}
                     )
+
+            with EventPublisher() as pub:
+                pub.publish(
+                    NotificationEvent(
+                        event_type="new_setup",
+                        source_service="cm_cs",
+                        data={"setup_id": self._setup_id},
+                        timestamp=time.time(),
+                    )
+                )
 
         return setup
 

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -23,6 +23,7 @@ from egse.confman import ConfigurationManagerProtocol
 from egse.confman import ConfigurationManagerProxy
 from egse.control import ControlServer
 from egse.env import get_conf_data_location
+from egse.logger import remote_logging
 from egse.process import SubProcess
 from egse.registry.client import RegistryClient
 from egse.response import Failure
@@ -136,24 +137,24 @@ def start():
 
     multiprocessing.current_process().name = "cm_cs"
 
-    try:
-        check_prerequisites()
-    except RuntimeError as exc:
-        logger.info(exc)
-        return 0
+    with remote_logging():
+        try:
+            check_prerequisites()
+        except RuntimeError as exc:
+            logger.info(exc)
+            return 0
 
-    try:
-        control_server = ConfigurationManagerControlServer()
-        control_server.serve()
-    except KeyboardInterrupt:
-        print("Shutdown requested...exiting")
-    except SystemExit as exit_code:
-        print(f"System Exit with code {exit_code}.")
-        sys.exit(exit_code.code)
-    except Exception:
-        import traceback
-
-        traceback.print_exc(file=sys.stdout)
+        try:
+            control_server = ConfigurationManagerControlServer()
+            control_server.serve()
+        except KeyboardInterrupt:
+            print("Shutdown requested...exiting")
+        except SystemExit as exit_code:
+            print(f"System Exit with code {exit_code}.")
+            sys.exit(exit_code.code)
+        except Exception:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
 
     return 0
 

--- a/libs/cgse-core/src/egse/notifyhub/__init__.py
+++ b/libs/cgse-core/src/egse/notifyhub/__init__.py
@@ -1,0 +1,59 @@
+__all__ = [
+    "DEFAULT_COLLECTOR_PORT",
+    "DEFAULT_PUBLISHER_PORT",
+    "DEFAULT_REQUESTS_PORT",
+    "is_notify_hub_active",
+    "async_is_notify_hub_active",
+]
+
+from egse.settings import Settings
+
+settings = Settings.load("Notify Hub")
+
+# Default ports that are assigned to PUSH-PULL, PUB-SUB, ROUTER-DEALER protocols of the notification hub.
+# The actual ports are defined in the Settings.yaml, use local settings to change them.
+DEFAULT_COLLECTOR_PORT = settings.get("COLLECTOR_PORT", 0)
+DEFAULT_PUBLISHER_PORT = settings.get("PUBLISHER_PORT", 0)
+DEFAULT_REQUESTS_PORT = settings.get("REQUESTS_PORT", 0)
+
+
+async def async_is_notify_hub_active(timeout: float = 0.5) -> bool:
+    """Check if the notification hub is running and active.
+
+    This function will send a 'health_check' request to the notification hub and
+    waits for the answer. If the hub replies with `healthy` the function returns
+    True, otherwise, False is returned.
+
+    If no reply was received after the given timeout [default=0.5s] the request
+    will time out and return False.
+
+    Use this function in an asynchronous context.
+    """
+
+    from egse.notifyhub.client import AsyncNotificationHubClient  # prevent circular import
+
+    with AsyncNotificationHubClient(request_timeout=timeout) as client:
+        if not await client.health_check():
+            return False
+        else:
+            return True
+
+
+def is_notify_hub_active(timeout: float = 0.5):
+    """Check if the notification hub is running and active.
+
+    This function will send a 'health_check' request to the notification hub and
+    waits for the answer. If the hub replies with `healthy` the function returns
+    True, otherwise, False is returned.
+
+    If no reply was received after the given timeout [default=0.5s] the request
+    will time out and return False.
+    """
+
+    from egse.notifyhub.client import NotificationHubClient  # prevent circular import
+
+    with NotificationHubClient(request_timeout=timeout) as client:
+        if not client.health_check():
+            return False
+        else:
+            return True

--- a/libs/cgse-core/src/egse/notifyhub/client.py
+++ b/libs/cgse-core/src/egse/notifyhub/client.py
@@ -1,0 +1,260 @@
+import asyncio
+import json
+import logging
+import uuid
+from typing import Any
+
+import zmq
+import zmq.asyncio
+
+from egse.notifyhub import DEFAULT_REQUESTS_PORT
+from egse.registry import MessageType
+
+REQUEST_TIMEOUT = 5.0  # seconds
+
+
+class AsyncNotificationHubClient:
+
+    def __init__(
+        self,
+        req_endpoint: str = None,
+        request_timeout: float = REQUEST_TIMEOUT,
+        client_id: str = "async-notify-hub-client",
+    ):
+        """
+        Initialize the async notification hub client.
+
+        Args:
+            req_endpoint: ZeroMQ endpoint for REQ-REP socket, defaults to DEFAULT_RS_REQ_PORT on localhost.
+            request_timeout: Timeout for requests in seconds, defaults to 5.0.
+            client_id: client identification, default='registry-client'
+        """
+        self.req_endpoint = req_endpoint or f"tcp://localhost:{DEFAULT_REQUESTS_PORT}"
+
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("egse.notifyhub.client")
+
+        self._client_id = f"{client_id}-{uuid.uuid4()}".encode()
+
+        self.context = zmq.asyncio.Context.instance()
+        self.req_socket: zmq.asyncio.Socket | None = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def connect(self):
+        self.logger.debug("Connecting to notification hub...")
+
+        # REQ socket for request-reply pattern
+        self.req_socket = self.context.socket(zmq.DEALER)
+        self.req_socket.setsockopt(zmq.LINGER, 0)  # Don't wait for unsent messages on close()
+        self.req_socket.setsockopt(zmq.IDENTITY, self._client_id)
+        self.req_socket.connect(self.req_endpoint)
+
+    def disconnect(self):
+        self.logger.debug("Disconnecting from notification hub...")
+
+        if self.req_socket:
+            self.req_socket.close(linger=0)
+        self.req_socket = None
+
+    async def health_check(self) -> bool:
+        """
+        Check if the registry server is healthy.
+
+        Returns:
+            True if healthy, False otherwise
+        """
+        request = {"action": "health"}
+        response = await self._send_request(MessageType.REQUEST_WITH_REPLY, request)
+        return response.get("success", False)
+
+
+    async def terminate_notification_hub(self):
+        """
+        Send a terminate request to the notification hub. Returns True when successful.
+        """
+        request = {"action": "terminate"}
+        response = await self._send_request(MessageType.REQUEST_WITH_REPLY, request)
+        return response.get("success", False)
+
+    async def _send_request(self, msg_type: MessageType, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Send a request to the registry and get the response.
+
+        Args:
+            msg_type: the type of message and reply
+            request: The request to send to the service registry server.
+
+        Returns:
+            The response from the registry as a dictionary.
+        """
+        self.logger.debug(f"Sending request: {request}")
+
+        try:
+            await self.req_socket.send_multipart([msg_type.value, json.dumps(request).encode()])
+
+            if msg_type == MessageType.REQUEST_NO_REPLY:
+                return {"success": True, }
+
+            try:
+                message_parts = await asyncio.wait_for(self.req_socket.recv_multipart(), timeout=self.request_timeout)
+
+                if len(message_parts) >= 2:
+                    message_type = MessageType(message_parts[0])
+                    message_data = message_parts[1]
+
+                    if message_type == MessageType.RESPONSE:
+                        response = json.loads(message_data)
+                        self.logger.debug(f"Received response: {response}")
+                        return response
+                    else:
+                        return {
+                            "success": False,
+                            "error": f"unexpected MessageType received: {message_type.name}, {message_data = }",
+                        }
+                else:
+                    return {
+                        "success": False,
+                        "error": f"not enough parts received: {len(message_parts)}",
+                        "data": message_parts,
+                    }
+            except asyncio.TimeoutError:
+                self.logger.warning(f"Request timed out after {self.request_timeout:.2f}s")
+                return {"success": False, "error": "Request timed out"}
+        except zmq.ZMQError as exc:
+            self.logger.error(f"ZMQ error: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            self.logger.error(f"Error sending request: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+
+class NotificationHubClient:
+
+    def __init__(
+        self,
+        req_endpoint: str = None,
+        request_timeout: float = REQUEST_TIMEOUT,
+        client_id: str = "notify-hub-client",
+    ):
+        """
+        Initialize the async notification hub client.
+
+        Args:
+            req_endpoint: ZeroMQ endpoint for REQ-REP socket, defaults to DEFAULT_RS_REQ_PORT on localhost.
+            request_timeout: Timeout for requests in seconds, defaults to 5.0.
+            client_id: client identification, default='registry-client'
+        """
+        self.req_endpoint = req_endpoint or f"tcp://localhost:{DEFAULT_REQUESTS_PORT}"
+
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("egse.notifyhub.client")
+
+        self._client_id = f"{client_id}-{uuid.uuid4()}".encode()
+
+        self.context = zmq.Context.instance()
+        self.req_socket: zmq.Socket | None = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def connect(self):
+        self.logger.debug("Connecting to notification hub...")
+
+        # REQ socket for request-reply pattern
+        self.req_socket = self.context.socket(zmq.DEALER)
+        self.req_socket.setsockopt(zmq.LINGER, 0)  # Don't wait for unsent messages on close()
+        self.req_socket.setsockopt(zmq.IDENTITY, self._client_id)
+        self.req_socket.connect(self.req_endpoint)
+
+    def disconnect(self):
+        self.logger.debug("Disconnecting from notification hub...")
+
+        if self.req_socket:
+            self.req_socket.close(linger=0)
+        self.req_socket = None
+
+    def health_check(self) -> bool:
+        """
+        Check if the registry server is healthy.
+
+        Returns:
+            True if healthy, False otherwise
+        """
+        request = {"action": "health"}
+        response = self._send_request(MessageType.REQUEST_WITH_REPLY, request)
+        return response.get("success", False)
+
+
+    def terminate_notification_hub(self) -> bool:
+        """
+        Send a terminate request to the notification hub. Returns True when successful.
+        """
+        request = {"action": "terminate"}
+        response = self._send_request(MessageType.REQUEST_NO_REPLY, request)
+        return response.get("success", False)
+
+    def _send_request(self, msg_type: MessageType, request: dict[str, Any]) -> dict[str, Any]:
+        """
+        Send a request to the registry and get the response.
+
+        Args:
+            msg_type: the type of message and reply
+            request: The request to send to the service registry server.
+            timeout: The number of seconds to wait before timeout
+
+        Returns:
+            The response from the registry as a dictionary.
+        """
+
+        self.logger.debug(f"Sending request: {request}")
+
+        timeout_ms = int(self.request_timeout * 1000)
+        try:
+            self.req_socket.send_multipart([msg_type.value, json.dumps(request).encode()])
+
+            try:
+                if self.req_socket.poll(timeout=timeout_ms):
+                    message_parts = self.req_socket.recv_multipart()
+
+                    if len(message_parts) >= 2:
+                        message_type = MessageType(message_parts[0])
+                        message_data = message_parts[1]
+
+                        if message_type == MessageType.RESPONSE:
+                            response = json.loads(message_data)
+                            self.logger.debug(f"Received response: {response}")
+                            return response
+                        else:
+                            return {
+                                "success": False,
+                                "error": f"unexpected MessageType received: {message_type.name}, {message_data = }",
+                            }
+                    else:
+                        return {
+                            "success": False,
+                            "error": f"not enough parts received: {len(message_parts)}",
+                            "data": message_parts,
+                        }
+                else:
+                    self.logger.error(f"Request timed out after {self.request_timeout:.2f}s")
+                    return {"success": False, "error": "Request timed out"}
+
+            except asyncio.TimeoutError:
+                self.logger.warning(f"Request timed out after {self.request_timeout:.2f}s")
+                return {"success": False, "error": "Request timed out"}
+        except zmq.ZMQError as exc:
+            self.logger.error(f"ZMQ error: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            self.logger.error(f"Error sending request: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}

--- a/libs/cgse-core/src/egse/notifyhub/event.py
+++ b/libs/cgse-core/src/egse/notifyhub/event.py
@@ -1,0 +1,21 @@
+import uuid
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class NotificationEvent:
+    event_type: str
+    source_service: str
+    data: dict
+    timestamp: float
+    correlation_id: Optional[str] = None
+
+    def as_dict(self):
+        return {
+            "event_type": self.event_type,
+            "source_service": self.source_service,
+            "data": self.data,
+            "timestamp": self.timestamp,
+            "correlation_id": self.correlation_id or str(uuid.uuid4()),
+        }

--- a/libs/cgse-core/src/egse/notifyhub/server.py
+++ b/libs/cgse-core/src/egse/notifyhub/server.py
@@ -1,0 +1,349 @@
+import asyncio
+import json
+import logging
+import multiprocessing
+import sys
+import time
+from typing import Any
+from typing import Callable
+
+import typer
+import zmq
+import zmq.asyncio
+
+from egse.log import logger
+from egse.logger import remote_logging
+from egse.notifyhub import DEFAULT_COLLECTOR_PORT
+from egse.notifyhub import DEFAULT_PUBLISHER_PORT
+from egse.notifyhub import DEFAULT_REQUESTS_PORT
+from egse.notifyhub.client import AsyncNotificationHubClient
+from egse.registry import MessageType
+from egse.registry.client import AsyncRegistryClient
+from egse.system import TyperAsyncCommand
+from egse.system import get_host_ip
+from .event import NotificationEvent
+
+app = typer.Typer(name="notify_hub")
+
+class AsyncNotificationHub:
+    def __init__(self):
+
+        self.server_id = "notification-hub-1"
+
+        self.context: zmq.asyncio.Context = zmq.asyncio.Context()
+
+        # Receive events from services (PULL socket for load balancing)
+        self.collector_socket: zmq.asyncio.Socket = self.context.socket(zmq.PULL)
+
+        # Publish events to subscribers (PUB socket for fan-out)
+        self.publisher_socket: zmq.asyncio.Socket = self.context.socket(zmq.PUB)
+
+        # Health check socket (ROUTER - can handle multiple clients)
+        self.requests_socket: zmq.asyncio.Socket = self.context.socket(zmq.ROUTER)
+
+        # Register notification hub to the service registry
+        self.registry_client = AsyncRegistryClient(request_timeout=200)
+        self.service_id = None
+        self.service_name = "Notification Hub"
+        self.service_type = "notification-hub"
+
+        self.stats = {
+            "events_received": 0,
+            "events_published": 0,
+            "last_message_time": 0.0,
+            "start_time": time.time(),
+        }
+
+        self.running = False
+        self._shutdown_event = asyncio.Event()
+
+        # Tasks
+        self._tasks = set()
+
+        self.logger = logging.getLogger("egse.notifyhub")
+
+    async def start(self):
+        """Start the notification hub. This will start the event collector and
+        publisher, the health check, and the stats reporter as asyncio Tasks.
+        """
+        multiprocessing.current_process().name = "notifyhub"
+
+        self.running = True
+        self.logger.info("Starting Async Notification Hub...")
+
+        self.collector_socket.bind(f"tcp://*:{DEFAULT_COLLECTOR_PORT}")
+        self.publisher_socket.bind(f"tcp://*:{DEFAULT_PUBLISHER_PORT}")
+        self.requests_socket.bind(f"tcp://*:{DEFAULT_REQUESTS_PORT}")
+
+        # Start concurrent tasks
+        self._tasks = [
+            asyncio.create_task(self._event_collector()),
+            asyncio.create_task(self._stats_reporter()),
+            asyncio.create_task(self._handle_requests()),
+        ]
+
+        await self._register_service()
+
+        # Wait for shutdown
+        await self._shutdown_event.wait()
+
+        # Clean shutdown
+        await self._shutdown()
+
+
+    async def _shutdown(self):
+        self._running = False
+        self.logger.info("Shutting down async notification hub...")
+
+        # Cancel all tasks
+        for task in self._tasks:
+            task.cancel()
+
+        # Wait for tasks to complete (with timeout)
+        if self._tasks:
+            try:
+                await asyncio.wait(self._tasks, timeout=2.0)
+            except asyncio.CancelledError:
+                pass
+
+        await self._deregister_service()
+
+        self.collector_socket.close()
+        self.publisher_socket.close()
+        self.requests_socket.close()
+
+        self.context.term()
+
+        self.logger.info("Async Notification Hub shutdown complete")
+
+    async def _register_service(self):
+        self.logger.info("Registering service...")
+
+        self.registry_client.connect()
+
+        self.service_id = await self.registry_client.register(
+            name=self.service_name,
+            host=get_host_ip(),
+            port=DEFAULT_REQUESTS_PORT,
+            service_type=self.service_type,
+            metadata={"pub_port": DEFAULT_PUBLISHER_PORT, "collector_port": DEFAULT_COLLECTOR_PORT},
+        )
+
+        if not self.service_id:
+            self.logger.error("Failed to register with the service registry")
+        else:
+            await self.registry_client.start_heartbeat()
+
+    async def _deregister_service(self):
+        self.logger.info("De-registering service...")
+
+        if self.service_id:
+            await self.registry_client.stop_heartbeat()
+            await self.registry_client.deregister()
+
+        self.registry_client.disconnect()
+
+    async def _event_collector(self):
+        """Main event collection loop"""
+        while self.running:
+            try:
+                # Receive event from any service (non-blocking with timeout)
+                message_bytes = await asyncio.wait_for(self.collector_socket.recv(), timeout=0.1)
+
+                message = json.loads(message_bytes.decode())
+
+                event = NotificationEvent(
+                    event_type=message["event_type"],
+                    source_service=message["source_service"],
+                    data=message["data"],
+                    timestamp=message.get("timestamp", time.time()),
+                    correlation_id=message.get("correlation_id"),
+                )
+
+                self.logger.info(f"Received: {event.event_type} from {event.source_service}")
+
+                self.stats["events_received"] += 1
+                self.stats["last_message_time"] = time.time()
+
+                await self._publish_event(event)
+
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                self.running = False
+            except Exception as exc:
+                self.logger.error(f"Error in event collector: {exc}", exc_info=True)
+                # Why waiting 1s here?
+                # - Is this to prevent overloading the logger when there is a serious problem
+                # - Will this improve when we get more experience with the NotifyHub?
+                await asyncio.sleep(1.0)
+
+    async def _publish_event(self, event: NotificationEvent):
+        """Publish event to all subscribers"""
+        try:
+            await self.publisher_socket.send_multipart(
+                [
+                    event.event_type.encode(),  # Topic for filtering
+                    json.dumps(event.as_dict()).encode(),  # Event data
+                ]
+            )
+
+            self.stats["events_published"] += 1
+            self.logger.info(f"Published: {event.event_type}")
+
+        except Exception as exc:
+            self.logger.error(f"Error publishing event: {exc}")
+
+    async def _stats_reporter(self):
+        """Periodically report statistics"""
+        while self.running:
+            try:
+                await asyncio.sleep(30)
+                self.logger.info(f"Stats: {self.stats}")
+            except asyncio.CancelledError:
+                self.running = False
+
+    async def _handle_requests(self):
+        """Simple health check endpoint simulation"""
+        self.logger.info("Started request handler task")
+
+        while self.running:
+            try:
+                try:
+                    message_parts = await asyncio.wait_for(self.requests_socket.recv_multipart(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    # self.logger.debug("waiting for command request...")
+                    continue
+
+                if len(message_parts) >= 3:
+                    client_id = message_parts[0]
+                    message_type = MessageType(message_parts[1])
+                    message_data = message_parts[2]
+
+                    self.logger.info(f"{client_id = }, {message_type = }, {message_data = }")
+                    response = await self._process_request(message_data)
+
+                    await self._send_response(client_id, message_type, response)
+
+            except zmq.ZMQError as exc:
+                self.logger.error(f"ZMQ error: {exc}", exc_info=True)
+            except Exception as exc:
+                self.logger.error(f"Error handling request: {exc}", exc_info=True)
+            except asyncio.CancelledError:
+                self.running = False
+
+    async def _process_request(self, msg_data: bytes):
+        """
+        Process a client request and generate a response.
+
+        Args:
+            msg_data: the actual JSON with the request
+
+        """
+        try:
+            request = json.loads(msg_data.decode())
+            self.logger.info(f"Received request: {request}")
+
+        except json.JSONDecodeError as exc:
+            self.logger.error(f"Invalid JSON received: {exc}")
+            return {"success": False, "error": "Invalid JSON format"}
+
+        action = request.get("action")
+        if not action:
+            return {"success": False, "error": "Missing required field: action"}
+
+        handlers: dict[str, Callable] = {
+            "health": self._handle_health,
+            "terminate": self._handle_terminate,
+        }
+
+        handler = handlers.get(action)
+        if not handler:
+            return {"success": False, "error": f"Unknown action: {action}"}
+
+        return await handler(request)
+
+    async def _send_response(self, client_id: bytes, msg_type: MessageType, response: dict[str, Any]):
+        """
+        If the client expects a reply, send the response.
+
+        Args:
+            client_id: the client identification, part 1 of the multipart message
+            msg_type: the type of the message, e.g. if reply is required
+            response: a dictionary with the status and response
+
+        """
+        if msg_type == MessageType.REQUEST_WITH_REPLY:
+            await self.requests_socket.send_multipart(
+                [client_id, MessageType.RESPONSE.value, json.dumps(response).encode()]
+            )
+
+    async def _handle_health(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a health check request."""
+
+        self.logger.info(f"Handle health request: {request}")
+
+        return {"success": True, "status": "ok", "timestamp": int(time.time())}
+
+    async def _handle_terminate(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Handle a termination request."""
+
+        self.logger.info(f"Handle termination request: {request}")
+
+        await self.stop()
+
+        return {
+            "success": True,
+            "status": "terminating",
+            "timestamp": time.time(),
+        }
+
+    async def _generate_health_response(self, request):
+        """Generate health response data"""
+        health_data = {
+            "status": "healthy" if self.running else "unhealthy",
+            "uptime": time.time() - self.stats["start_time"],
+            "events_received": self.stats["events_received"],
+            "events_published": self.stats['events_published'],
+            "last_message_time": self.stats["last_message_time"],
+            "timestamp": time.time(),
+            "request_id": request.get("request_id"),
+            "server_id": self.server_id,
+        }
+
+        return health_data
+
+    async def stop(self):
+        """Signal the server to stop."""
+        self._shutdown_event.set()
+
+
+@app.command(cls=TyperAsyncCommand)
+# Usage
+async def start():
+    with remote_logging():
+        hub = AsyncNotificationHub()
+        await hub.start()
+
+@app.command(cls=TyperAsyncCommand)
+async def stop():
+    with AsyncNotificationHubClient() as client:
+        await client.terminate_notification_hub()
+
+
+if __name__ == "__main__":
+
+    try:
+        rc = app()
+    except zmq.ZMQError as exc:
+        if "Address already in use" in str(exc):
+            logger.error(f"The Service Registry server is already running: {exc}")
+        else:
+            logger.error("Couldn't start service registry server", exc_info=True)
+        rc = -1
+
+    except KeyboardInterrupt:
+        logging.info("KeyboardInterrupt received for NotifyHub, terminating...")
+        rc = -1
+
+    sys.exit(rc)

--- a/libs/cgse-core/src/egse/notifyhub/services.py
+++ b/libs/cgse-core/src/egse/notifyhub/services.py
@@ -1,0 +1,277 @@
+"""
+Notification Hub
+
+"""
+
+import asyncio
+import json
+import logging
+import time
+from asyncio import CancelledError
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import zmq
+import zmq.asyncio
+
+from . import DEFAULT_COLLECTOR_PORT
+from . import DEFAULT_PUBLISHER_PORT
+from .event import NotificationEvent
+from egse.system import type_name
+
+NOTIFY_HUB_COLLECTOR = f"tcp://localhost:{DEFAULT_COLLECTOR_PORT}"
+NOTIFY_HUB_PUBLISHER = f"tcp://localhost:{DEFAULT_PUBLISHER_PORT}"
+
+
+class AsyncEventPublisher:
+    """Reusable event publisher component"""
+
+    def __init__(self, hub_address: str = NOTIFY_HUB_COLLECTOR):
+        self.hub_address = hub_address
+        self.context = zmq.asyncio.Context()
+        self.publisher = None
+        self._connected = False
+        self.logger = logging.getLogger("egse.event-pub")
+
+    async def connect(self):
+        """Connect to the notification hub"""
+        if not self._connected:
+            self.publisher = self.context.socket(zmq.PUSH)
+            self.publisher.connect(self.hub_address)
+            await asyncio.sleep(0.1)  # Allow connection to establish
+            self._connected = True
+            self.logger.info(f"Connected to hub at {self.hub_address}")
+
+    async def publish(self, event: NotificationEvent):
+        """Publish an event"""
+        if not self._connected:
+            await self.connect()
+
+        await self.publisher.send(json.dumps(event.as_dict()).encode())
+        self.logger.debug(f"Published: {event.event_type}")
+
+    async def close(self):
+        """Clean shutdown"""
+        if self._connected:
+            await self.publisher.close()
+            self._connected = False
+
+
+class AsyncEventSubscriber:
+    """Subscribe to the notification hub and listens to events.
+
+    Args:
+        subscriptions (list): a list of event types to which to subscribe
+        hub_address (str): endpoint of the notification hub [default=NOTIFY_HUB_PUBLISHER]
+    """
+
+    def __init__(self, subscriptions: List[str], hub_address: str = NOTIFY_HUB_PUBLISHER):
+        self.subscriptions = subscriptions
+        self.hub_address = hub_address
+        self.context = zmq.asyncio.Context()
+        self.subscriber = None
+        self.handlers: Dict[str, Callable] = {}
+        self.running = False
+        self.logger = logging.getLogger("egse.event-sub")
+
+    async def connect(self):
+        """Connect to the notification hub."""
+        self.subscriber = self.context.socket(zmq.SUB)
+        self.subscriber.connect(self.hub_address)
+
+        # Subscribe to specific event types
+        for event_type in self.subscriptions:
+            self.subscriber.setsockopt(zmq.SUBSCRIBE, event_type.encode())
+            self.logger.info(f"Subscribed to: {event_type}")
+
+    def register_handler(self, event_type: str, handler: Callable):
+        """Register a handler for an event type."""
+        self.handlers[event_type] = handler
+
+    async def start_listening(self):
+        """Start listening for events"""
+        if not self.subscriber:
+            await self.connect()
+
+        self.running = True
+        self.logger.info("Started listening for events")
+
+        while self.running:
+            try:
+                if await self.subscriber.poll(timeout=1000):
+                    topic, message_bytes = await self.subscriber.recv_multipart()
+
+                    event_type = topic.decode()
+                    event_data = json.loads(message_bytes.decode())
+
+                    await self._handle_event(event_type, event_data)
+
+                await asyncio.sleep(0.001)
+
+            except Exception as exc:
+                self.logger.error(f"Error receiving event: {exc}")
+                await asyncio.sleep(1)
+            except CancelledError:
+                break
+
+    async def _handle_event(self, event_type: str, event_data: Dict):
+        """Handle received event"""
+        handler = self.handlers.get(event_type)
+
+        if handler:
+            try:
+                if asyncio.iscoroutinefunction(handler):
+                    await handler(event_data)
+                else:
+                    await asyncio.get_event_loop().run_in_executor(None, handler, event_data)
+            except Exception as exc:
+                self.logger.error(f"Error handling {event_type}: {exc}")
+        else:
+            self.logger.warning(f"No handler registered for {event_type}")
+
+    async def stop(self):
+        """Stop listening"""
+        self.running = False
+        if self.subscriber:
+            await self.subscriber.close()
+
+
+class ServiceMessaging:
+    """Convenience wrapper that combines publisher and subscriber."""
+
+    def __init__(self, service_name: str, subscriptions: List[str] | None = None):
+        self.service_name = service_name
+        self.publisher = AsyncEventPublisher()
+        self.subscriber = AsyncEventSubscriber(subscriptions or []) if subscriptions else None
+
+    async def publish_event(self, event_type: str, data: Dict[Any, Any], correlation_id: Optional[str] = None):
+        """Publish an event"""
+        event = NotificationEvent(
+            event_type=event_type,
+            source_service=self.service_name,
+            data=data,
+            timestamp=time.time(),
+            correlation_id=correlation_id,
+        )
+        await self.publisher.publish(event)
+
+    def register_handler(self, event_type: str, handler: Callable):
+        """Register event handler"""
+        if self.subscriber:
+            self.subscriber.register_handler(event_type, handler)
+
+    async def start_listening(self):
+        """Start listening for events"""
+        if self.subscriber:
+            await self.subscriber.start_listening()
+
+    async def close(self):
+        """Clean shutdown"""
+        await self.publisher.close()
+        if self.subscriber:
+            await self.subscriber.stop()
+
+
+class EventPublisher:
+    """Reusable event publisher component"""
+
+    def __init__(self, hub_address: str = NOTIFY_HUB_COLLECTOR):
+        self.hub_address = hub_address
+        self.context = zmq.Context().instance()
+        self.publisher = None
+        self._connected = False
+        self.logger = logging.getLogger("egse.event-pub")
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def connect(self):
+        """Connect to the notification hub"""
+        if not self._connected:
+            self.publisher = self.context.socket(zmq.PUSH)
+            self.publisher.connect(self.hub_address)
+            # time.sleep(0.1)  # Allow connection to establish
+            self._connected = True
+            self.logger.info(f"Connected to hub at {self.hub_address}")
+
+    def publish(self, event: NotificationEvent):
+        """Publish an event"""
+        if not self._connected:
+            self.connect()
+
+        self.publisher.send(json.dumps(event.as_dict()).encode())
+        self.logger.debug(f"Published: {event.event_type}")
+
+    def close(self):
+        """Clean shutdown"""
+        if self._connected:
+            self.publisher.close(linger=0)
+            self._connected = False
+
+
+class EventSubscriber:
+    """Reusable event subscriber component"""
+
+    def __init__(self, subscriptions: List[str], hub_address: str = NOTIFY_HUB_PUBLISHER):
+        self.subscriptions = subscriptions
+        self.hub_address = hub_address
+        self.context = zmq.Context().instance()
+        self.subscriber = None
+        self.handlers: Dict[str, Callable] = {}
+        self.logger = logging.getLogger("egse.event-sub")
+
+    def connect(self):
+        """Connect to the notification hub"""
+        self.subscriber = self.context.socket(zmq.SUB)
+        self.subscriber.connect(self.hub_address)
+
+        # Subscribe to specific event types
+        for event_type in self.subscriptions:
+            self.subscriber.setsockopt(zmq.SUBSCRIBE, event_type.encode())
+            self.logger.info(f"Subscribed to: {event_type}")
+
+    def register_handler(self, event_type: str, handler: Callable):
+        """Register a handler for an event type"""
+        self.handlers[event_type] = handler
+
+    @property
+    def socket(self):
+        return self.subscriber
+
+    def poll(self, timeout=1000):
+        if not self.subscriber:
+            self.connect()
+
+        return self.subscriber.poll(timeout=timeout)
+
+    def handle_event(self):
+        topic, message_bytes = self.subscriber.recv_multipart()
+
+        event_type = topic.decode()
+        event_data = json.loads(message_bytes.decode())
+
+        self._handle_event(event_type, event_data)
+
+    def _handle_event(self, event_type: str, event_data: Dict):
+        """Handle received event"""
+        handler = self.handlers.get(event_type)
+
+        if handler:
+            try:
+                handler(event_data)
+            except Exception as exc:
+                self.logger.error(f"Error handling {event_type} by {handler.__name__}: {exc}", exc_info=True)
+        else:
+            self.logger.warning(f"No handler registered for {event_type}")
+
+    def close(self):
+        """Stop listening"""
+        if self.subscriber:
+            self.subscriber.close(linger=0)

--- a/libs/cgse-core/src/egse/procman/procman_cs.py
+++ b/libs/cgse-core/src/egse/procman/procman_cs.py
@@ -17,6 +17,7 @@ import zmq
 from egse.confman import ConfigurationManagerProxy
 from egse.control import ControlServer
 from egse.listener import EVENT_ID
+from egse.logger import remote_logging
 from egse.process import SubProcess
 from egse.procman import ProcessManagerProxy
 from egse.procman.procman_protocol import ProcessManagerProtocol
@@ -127,18 +128,18 @@ def start():
 
     multiprocessing.current_process().name = "pm_cs"
 
-    try:
-        control_server = ProcessManagerControlServer()
-        control_server.serve()
-    except KeyboardInterrupt:
-        print("Shutdown requested...exiting")
-    except SystemExit as exit_code:
-        print(f"System Exit with code {exit_code}.")
-        sys.exit(exit_code.code)
-    except Exception:
-        import traceback
-
-        traceback.print_exc(file=sys.stdout)
+    with remote_logging():
+        try:
+            control_server = ProcessManagerControlServer()
+            control_server.serve()
+        except KeyboardInterrupt:
+            print("Shutdown requested...exiting")
+        except SystemExit as exit_code:
+            print(f"System Exit with code {exit_code}.")
+            sys.exit(exit_code.code)
+        except Exception:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
 
     return 0
 

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import threading
 import time
 import uuid
@@ -231,7 +232,7 @@ class RegistryClient:
             The service ID if successful, None otherwise
         """
         # Prepare service info
-        service_info = {"name": name, "host": host, "port": port}
+        service_info: dict[str, str|int|dict|list] = {"name": name, "host": host, "port": port}
 
         # Add optional fields
         if service_type:
@@ -505,7 +506,7 @@ class AsyncRegistryClient:
         self.registry_hb_endpoint = registry_hb_endpoint or f"tcp://localhost:{DEFAULT_RS_HB_PORT}"
 
         self.request_timeout = request_timeout
-        self.logger = logger
+        self.logger = logging.getLogger("egse.registry.client")
 
         # Service state
         self._service_id = None

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -21,6 +21,7 @@ from pytz import utc
 from egse.control import ControlServer
 from egse.env import get_data_storage_location
 from egse.env import get_site_id
+from egse.logger import remote_logging
 from egse.process import SubProcess
 from egse.registry.client import RegistryClient
 from egse.services import ServiceProxy
@@ -120,24 +121,24 @@ def start():
 
     from egse.storage.storage_cs import StorageControlServer  # noqa
 
-    try:
-        check_prerequisites()
-    except RuntimeError as exc:
-        logger.info(exc)
-        return 0
+    with remote_logging():
+        try:
+            check_prerequisites()
+        except RuntimeError as exc:
+            logger.info(exc)
+            return 0
 
-    try:
-        control_server = StorageControlServer()
-        control_server.serve()
-    except KeyboardInterrupt:
-        print("Shutdown requested...exiting")
-    except SystemExit as exit_code:
-        print(f"System Exit with code {exit_code}.")
-        sys.exit(exit_code.code)
-    except Exception:
-        import traceback
-
-        traceback.print_exc(file=sys.stdout)
+        try:
+            control_server = StorageControlServer()
+            control_server.serve()
+        except KeyboardInterrupt:
+            print("Shutdown requested...exiting")
+        except SystemExit as exit_code:
+            print(f"System Exit with code {exit_code}.")
+            sys.exit(exit_code.code)
+        except Exception:
+            import traceback
+            traceback.print_exc(file=sys.stdout)
 
     return 0
 

--- a/libs/cgse-core/tests/test_notify_hub.py
+++ b/libs/cgse-core/tests/test_notify_hub.py
@@ -1,0 +1,154 @@
+import asyncio
+import contextlib
+import sys
+import threading
+import time
+
+import pytest
+
+from egse.log import logger
+from egse.notifyhub import async_is_notify_hub_active
+from egse.notifyhub import is_notify_hub_active
+from egse.notifyhub.event import NotificationEvent
+from egse.notifyhub.server import AsyncNotificationHub
+from egse.notifyhub.services import AsyncEventPublisher
+from egse.notifyhub.services import AsyncEventSubscriber
+from egse.notifyhub.services import EventPublisher
+from egse.notifyhub.services import EventSubscriber
+from egse.process import SubProcess
+from egse.system import Timer
+from egse.system import waiting_for
+
+
+@contextlib.asynccontextmanager
+async def async_notify_hub():
+    """Asynchronous context manager that starts a notification hub as an asyncio Task."""
+
+    if await async_is_notify_hub_active():
+        pytest.xfail("The notification hub shall not be running for this test.")
+
+    server = AsyncNotificationHub()
+    server_task = asyncio.create_task(server.start())
+
+    with Timer(name="Notify Hub startup timer"):
+        await asyncio.wait_for(async_is_notify_hub_active(), timeout=5.0)
+
+    yield
+
+    await server.stop()
+
+    if not server_task.done():
+        server_task.cancel()
+
+    # Wait for tasks to complete their cancellation
+    try:
+        await asyncio.gather(server_task, return_exceptions=True)
+    except asyncio.CancelledError as exc:
+        logger.error(f"Caught {type(exc).__name__}: {exc}.")
+
+
+@contextlib.contextmanager
+def notify_hub():
+    """Context manager that starts a notification hub as a sub-process."""
+
+    if is_notify_hub_active():
+        pytest.xfail("The notification hub shall not be running for this test.")
+
+    proc = SubProcess("Notification Hub", [sys.executable, "-m", "egse.notifyhub.server"], ["start"])
+    proc.execute()
+
+    with Timer(name="Notify Hub startup timer"):
+        waiting_for(is_notify_hub_active, timeout=5.0)
+
+    yield proc
+
+    proc.quit()
+
+    with Timer(name="Notify Hub shutdown timer"):
+        waiting_for(lambda: not is_notify_hub_active(), timeout=5.0)
+
+
+def single_event_handler(event_data: dict):
+    logger.info(f"{event_data=}")
+    assert event_data["event_type"] == "single-event"
+    assert event_data["source_service"] == "test_notify_hub"
+    assert event_data["data"]["data"] == "Simple string for a single event"
+
+
+@pytest.mark.asyncio
+async def test_server_running_async():
+
+    # This test starts the notification hub and let it running for 30s
+    # In these 30s it should:
+    #
+    # - register as a service to the service registry
+    # - send at least three heartbeats to the registry server
+    # - de-register from the service registry
+
+    async with async_notify_hub():
+
+        await asyncio.sleep(30.0)
+
+
+def test_single_event():
+
+    with notify_hub():
+
+        publisher = EventPublisher()
+        subscriber = EventSubscriber(["single-event"])
+        subscriber.register_handler("single-event", single_event_handler)
+
+        event = NotificationEvent(
+            event_type="single-event",
+            source_service="test_notify_hub",
+            data={"data": "Simple string for a single event"},
+            timestamp=time.time(),
+            correlation_id=None,
+        )
+
+        def poll_next_event():
+            event_received = False
+            while not event_received:
+
+                if subscriber.poll():
+                    subscriber.handle_event()
+                    event_received = True
+
+                logger.info("no event received yet...")
+                time.sleep(1.0)
+
+        thread = threading.Thread(target=poll_next_event)
+        thread.start()
+
+        logger.info(f"Publishing event {event.event_type}")
+        publisher.publish(event)
+
+        time.sleep(1.0)
+
+        publisher.close()
+        subscriber.close()
+
+@pytest.mark.asyncio
+async def test_single_event_async():
+
+    async with async_notify_hub():
+
+        publisher = AsyncEventPublisher()
+
+        subscriber = AsyncEventSubscriber(["single-event"])
+        subscriber.register_handler("single-event", single_event_handler)
+        event_listener = asyncio.create_task(subscriber.start_listening())
+
+        event = NotificationEvent(
+            event_type="single-event",
+            source_service="test_notify_hub",
+            data={"data": "Simple string for a single event"},
+            timestamp=time.time(),
+            correlation_id=None,
+        )
+        await publisher.publish(event)
+
+        await asyncio.sleep(0.2)
+
+        await subscriber.stop()
+        await publisher.close()


### PR DESCRIPTION
The main feature in this pull request is the Notification Hub, but we have made quite some changes also to the logging facility.

- added new service → Notification hub
	- services can publish an event to the notification hub which will (forward) publish it on its known channel
	- services can subscribe to the notification hub for a specific event type
	- the notification hub is added as a core command to the cgse
- updates to the logging:
	- logging messages are now formatted differently → `"{asctime} [{levelname:>8s}] {message} ({processName}[{process}]:{package_name}:{filename}:{lineno:d})"`
	- the `package_name` is added as a new attribute to the LogRecord by the `PackageFilter`. Add that filter to any handler that uses `package_name` in its formatter.
	- use `remote_logging()` context manager for your services/servers
	- use `setup_logging()` and `teardown_logging()` in your REPL / startup script
	- the logger has fixed ports, set them to 0 in the local settings file to use dynamic port assignment (COMMANDER_PORT, RECEIVER_PORT)
- updates to `confman_cs`:
	- the configuration manager now published a `new_setup` event when a new Setup is loaded or submitted