### PR TITLE
fixed port numbers core services

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.15.1"
+version = "0.16.0"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/src/cgse_common/cgse.py
+++ b/libs/cgse-common/src/cgse_common/cgse.py
@@ -72,7 +72,7 @@ class SortedCommandGroup(TyperGroup):
         commands = super().list_commands(ctx)
 
         # Define priority commands in specific order
-        priority_commands = ["init", "version", "show", "top", "core", "registry", "log", "cm", "sm", "pm"]
+        priority_commands = ["init", "version", "show", "top", "core", "reg", "not", "log", "cm", "sm", "pm"]
 
         # Custom sort:
         # First the priority commands in the given order (their index)

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.15.1"
+version = "0.16.0"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -45,12 +45,12 @@ cgse-core = "cgse_core:settings.yaml"
 
 [project.entry-points."cgse.service.core_command"]
 core = 'cgse_core.services:core'
-registry = 'cgse_core.services:rm_cs'
+reg = 'cgse_core.services:rm_cs'
 log = 'cgse_core.services:log_cs'
 cm = 'cgse_core.services:cm_cs'
 sm = 'cgse_core.services:sm_cs'
 pm = 'cgse_core.services:pm_cs'
-notify = 'cgse_core.services:notifyhub'
+not = 'cgse_core.services:notifyhub'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.15.1"
+version = "0.16.0"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -184,11 +184,11 @@ async def log_cs_status(suppress_errors: bool = True):
 def log_cs_reregister(force: bool = False):
     """Command the Logger to re-register as a service."""
 
-    from egse.logger.log_cs import app_name
+    from egse.logger.log_cs import PROCESS_NAME
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),
-        app_name,
+        PROCESS_NAME,
         {"action": "reregister", "params": {"force": force}},
     )
 
@@ -221,11 +221,11 @@ async def cm_cs_status(suppress_errors: bool = True):
 def cm_cs_reregister(force: bool = False):
     """Command the Configuration Manager to re-register as a service."""
 
-    from egse.confman.confman_cs import app_name
+    from egse.confman import PROCESS_NAME
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),
-        app_name,
+        PROCESS_NAME,
         {"action": "reregister", "params": {"force": force}},
     )
 
@@ -265,11 +265,11 @@ async def sm_cs_status(suppress_errors: bool = True):
 def sm_cs_reregister(force: bool = False):
     """Command the Storage Manager to re-register as a service."""
 
-    from egse.storage.storage_cs import app_name
+    from egse.storage.storage_cs import PROCESS_NAME
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),
-        app_name,
+        PROCESS_NAME,
         {"action": "reregister", "params": {"force": force}},
     )
 
@@ -302,11 +302,11 @@ async def pm_cs_status(suppress_errors: bool = True):
 def pm_cs_reregister(force: bool = False):
     """Command the Storage Manager to re-register as a service."""
 
-    from egse.procman.procman_cs import app_name
+    from egse.procman.procman_cs import PROCESS_NAME
 
     create_signal_command_file(
         Path(DEFAULT_SIGNAL_DIR),
-        app_name,
+        PROCESS_NAME,
         {"action": "reregister", "params": {"force": force}},
     )
 

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -8,6 +8,7 @@ Service Registry:
 Logging Control Server:                          # LOG_CS
 
     SERVICE_TYPE:                LOG_CS
+    PROCESS_NAME:                log_cs
     MAX_NR_LOG_FILES:                20          # The maximum number of log files that will be maintained in a roll-over
     MAX_SIZE_LOG_FILES:              20          # The maximum size one log file can become
     RECEIVER_PORT:                 4248
@@ -18,26 +19,41 @@ Logging Control Server:                          # LOG_CS
 Configuration Manager Control Server:            # CM_CS
 
     SERVICE_TYPE:                 CM_CS
+    PROCESS_NAME:                 cm_cs
+    COMMANDING_PORT:               6000          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6001          # The port on which the controller sends periodic status information of the device - PUB-SUB
+    SERVICE_PORT:                  6002          # The port on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
     STORAGE_MNEMONIC:                CM          # The mnemonic to be used in the filename storing the housekeeping data
 
-Storage Control Server:                          # SM_CS
+Storage Manager Control Server:                  # SM_CS
 
     SERVICE_TYPE:                 SM_CS
+    PROCESS_NAME:                 sm_cs
+    COMMANDING_PORT:               6010          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6011          # The port on which the controller sends periodic status information of the device - PUB-SUB
+    SERVICE_PORT:                  6012          # The port on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
 
 Process Manager Control Server:                  # PM_CS
 
     SERVICE_TYPE:                 PM_CS
+    PROCESS_NAME:                 pm_cs
+    COMMANDING_PORT:               6020          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6021          # The port on which the controller sends periodic status information of the devide - PUB-SUB
+    SERVICE_PORT:                  6022          # The port number on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
     STORAGE_MNEMONIC:                PM          # The mnemonic to be used in the filename storing the housekeeping data
 
 Notify Hub:
     
     SERVICE_TYPE:            NOTIFY_HUB
+    PROCESS_NAME:                 nh_cs
     COLLECTOR_PORT:                4245
     PUBLISHER_PORT:                4246
     REQUESTS_PORT:                 4247
     
 Metrics Hub:
+    
     SERVICE_TYPE:           METRICS_HUB
+    PROCESS_NAME:                 mh_cs

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -166,9 +166,17 @@ from egse.zmq_ser import connect_address
 
 HERE = Path(__file__).parent
 
-CTRL_SETTINGS = Settings.load("Configuration Manager Control Server")
+settings = Settings.load("Configuration Manager Control Server")
+
 SITE_ID = get_site_id()
 COMMAND_SETTINGS = Settings.load(location=HERE, filename="confman.yaml")
+
+PROCESS_NAME = settings.get("PROCESS_NAME", "cm_cs")
+PROTOCOL = settings.get("PROTOCOL", "tcp")
+HOSTNAME = settings.get("HOSTNAME", "localhost")
+COMMANDING_PORT = settings.get("COMMANDING_PORT", 0)
+SERVICE_PORT = settings.get("SERVICE_PORT", 0)
+MONITORING_PORT = settings.get("MONITORING_PORT", 0)
 
 # CM_SETUP_ID = Gauge("CM_SETUP_ID", 'Setup ID')
 # CM_TEST_ID = Gauge("CM_TEST_ID", 'Test ID')
@@ -378,12 +386,14 @@ def is_configuration_manager_active(timeout: float = 0.5):
         True if the Configuration Manager is running and replied with the expected answer.
     """
 
-    with RegistryClient() as client:
-        endpoint = client.get_endpoint(CTRL_SETTINGS.SERVICE_TYPE)
-
-    if endpoint is None:
-        logger.debug(f"No endpoint for {CTRL_SETTINGS.SERVICE_TYPE}")
-        return False
+    if COMMANDING_PORT == 0:
+        with RegistryClient() as client:
+            endpoint = client.get_endpoint(settings.SERVICE_TYPE)
+            if endpoint is None:
+                logger.debug(f"No endpoint for {settings.SERVICE_TYPE}")
+                return False
+    else:
+        endpoint = connect_address(PROTOCOL, HOSTNAME, COMMANDING_PORT)
 
     return is_control_server_active(endpoint, timeout)
 
@@ -474,7 +484,7 @@ class ConfigurationManagerInterface:
         """Starts a new observation or test. The following actions will be taken:
 
         * create an observation identifier, aka `obsid`
-        * notify the Storage Control Server that a new observation is started
+        * notify the Storage Manager Control Server that a new observation is started
         * return the generated `obsid`
 
         Args:
@@ -487,7 +497,7 @@ class ConfigurationManagerInterface:
 
     @dynamic_interface
     def end_observation(self) -> Response:
-        """Ends the current observation and notifies the Storage Control Server.
+        """Ends the current observation and notifies the Storage Manager Control Server.
 
         Returns:
             `Success` when the observation could be closed properly and the Storage CS was notified
@@ -619,7 +629,7 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
         if not response.successful:
             self._obsid = None
             return Failure(
-                "Sending a start_observation to the Storage Control Server failed",
+                "Sending a start_observation to the Storage Manager Control Server failed",
                 response,
             )
 
@@ -658,7 +668,7 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
 
         if not response.successful:
             return Failure(
-                "Sending an end_observation to the Storage Control Server failed.",
+                "Sending an end_observation to the Storage Manager Control Server failed.",
                 response,
             )
 
@@ -984,7 +994,13 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
     Control Server and send commands and requests for the configuration manager.
     """
 
-    def __init__(self, protocol: str = None, hostname: str = None, port: int = -1, timeout=PROXY_TIMEOUT):
+    def __init__(
+            self,
+            protocol: str = PROTOCOL,
+            hostname: str = HOSTNAME,
+            port: int = COMMANDING_PORT,
+            timeout=PROXY_TIMEOUT
+    ):
         """
         Args:
             protocol: the transport protocol [default is taken from settings file]
@@ -993,12 +1009,12 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
             port: TCP port on which the control server is listening for commands
                 [default is taken from settings file]
         """
-        if hostname is None:
+        if port == 0:
             with RegistryClient() as reg:
-                endpoint = reg.get_endpoint(CTRL_SETTINGS.SERVICE_TYPE)
+                endpoint = reg.get_endpoint(settings.SERVICE_TYPE)
 
             if not endpoint:
-                raise RuntimeError(f"No service registered as {CTRL_SETTINGS.SERVICE_TYPE}")
+                raise RuntimeError(f"No service registered as {settings.SERVICE_TYPE}")
         else:
             endpoint = connect_address(protocol, hostname, port)
 
@@ -1076,7 +1092,8 @@ def is_not_in(a, b):
 
 
 def get_status():
-    if is_configuration_manager_active():
+
+    try:
         with ConfigurationManagerProxy() as cm:
             obsid = cm.get_obsid()
             obsid = obsid.return_code
@@ -1098,7 +1115,7 @@ def get_status():
                 else:
                     setup_id = "[red]No Setup loaded[/]"
             except Exception as exc:
-                setup_id = "An Exception was caught: {exc}"
+                setup_id = f"An Exception was caught: {exc}"
 
             return textwrap.dedent(
                 f"""\
@@ -1114,5 +1131,5 @@ def get_status():
                     Listeners: {", ".join(cm.get_listener_names())}
                 """
             )
-    else:
-        return "Configuration Manager Status: [red]not active"
+    except ConnectionError as exc:
+        return f"Configuration Manager Status: [red]not active[/] ({exc})"

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -995,11 +995,7 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
     """
 
     def __init__(
-            self,
-            protocol: str = PROTOCOL,
-            hostname: str = HOSTNAME,
-            port: int = COMMANDING_PORT,
-            timeout=PROXY_TIMEOUT
+        self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=PROXY_TIMEOUT
     ):
         """
         Args:
@@ -1092,7 +1088,6 @@ def is_not_in(a, b):
 
 
 def get_status():
-
     try:
         with ConfigurationManagerProxy() as cm:
             obsid = cm.get_obsid()

--- a/libs/cgse-core/src/egse/confman/confman_cs.py
+++ b/libs/cgse-core/src/egse/confman/confman_cs.py
@@ -134,6 +134,7 @@ app = typer.Typer(name=PROCESS_NAME)
 
 console = Console(width=120)
 
+
 @app.command()
 def start():
     """
@@ -188,8 +189,7 @@ def stop():
                 port = service["metadata"]["service_port"]
             else:
                 rich.print(
-                    "[red]ERROR: Couldn't determine how to connect to the configuration manager. "
-                    "No service defined.[/]"
+                    "[red]ERROR: Couldn't determine how to connect to the configuration manager. No service defined.[/]"
                 )
                 return
     else:
@@ -202,6 +202,7 @@ def stop():
             proxy.quit_server()
     except ConnectionError as exc:
         console.print(f"[red]ERROR: Couldn't connect to configuration manager: {exc}[/]")
+
 
 @app.command()
 def status():

--- a/libs/cgse-core/src/egse/control.py
+++ b/libs/cgse-core/src/egse/control.py
@@ -633,7 +633,7 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         # FIXME: not sure if the stop heartbeat is necessary here, but I see that after
         #        a re-registration signal, the heartbeat socket is None.
-        self.registry.stop_heartbeat()
+        # self.registry.stop_heartbeat()
         self.register_service(self.service_type)
 
     def register_service(self, service_type: str):

--- a/libs/cgse-core/src/egse/control.py
+++ b/libs/cgse-core/src/egse/control.py
@@ -626,11 +626,14 @@ class ControlServer(metaclass=abc.ABCMeta):
         self.logger.info(f"Re-registration of service: {self.service_name} ({force=})")
 
         if self.registry.get_service(self.service_id):
-            if force is True:
+            if force:
                 self.deregister_service()
             else:
                 return
 
+        # FIXME: not sure if the stop heartbeat is necessary here, but I see that after
+        #        a re-registration signal, the heartbeat socket is None.
+        self.registry.stop_heartbeat()
         self.register_service(self.service_type)
 
     def register_service(self, service_type: str):

--- a/libs/cgse-core/src/egse/logger/log_cs.py
+++ b/libs/cgse-core/src/egse/logger/log_cs.py
@@ -80,6 +80,7 @@ LOGGER_NAME = "egse.logger"
 
 settings = Settings.load("Logging Control Server")
 
+PROCESS_NAME = settings.get("PROCESS_NAME", "log_cs")
 PROTOCOL = settings.get("PROTOCOL", "tcp")
 HOSTNAME = settings.get("HOSTNAME", "localhost")
 RECEIVER_PORT = settings.get("RECEIVER_PORT", 0)  # dynamically assigned by the system if 0
@@ -101,8 +102,7 @@ class DateTimeFormatter(logging.Formatter):
 
 file_formatter = DateTimeFormatter(fmt=LOG_FORMAT_FILE, style=LOG_FORMAT_FILE_STYLE, datefmt=None)
 
-app_name = "log_cs"
-app = typer.Typer(name=app_name)
+app = typer.Typer(name=PROCESS_NAME)
 
 
 def _log_record(message: str, level: int = logging.WARNING):
@@ -116,7 +116,7 @@ def start():
 
     global file_handler, stream_handler, socket_handler
 
-    multiprocessing.current_process().name = app_name
+    multiprocessing.current_process().name = PROCESS_NAME
 
     log_file_location = Path(get_log_file_location())
     log_file_name = get_log_file_name()
@@ -216,7 +216,7 @@ def start():
         else:
             is_service_registered = True
 
-    signaling = FileBasedSignaling(app_name)
+    signaling = FileBasedSignaling(PROCESS_NAME)
     signaling.start_monitoring()
     signaling.register_handler("reregister", reregister_service)
 

--- a/libs/cgse-core/src/egse/monitoring.py
+++ b/libs/cgse-core/src/egse/monitoring.py
@@ -222,7 +222,7 @@ PROCESS_NAMES = {
     "DPU_PROCESSOR_HEARTBEAT": ("DPU Processor", "HEARTBEAT_PORT"),
     "DPU_CS": ("DPU Control Server", "MONITORING_PORT"),
     "CM_CS": ("Configuration Manager Control Server", "MONITORING_PORT"),
-    "SM_CS": ("Storage Control Server", "MONITORING_PORT"),
+    "SM_CS": ("Storage Manager Control Server", "MONITORING_PORT"),
     "PM_CS": ("Process Manager Control Server", "MONITORING_PORT"),
     "SYN_CS": ("Synoptics Manager Control Server", "MONITORING_PORT"),
     "DATA_DISTRIBUTION": ("DPU Processor", "DATA_DISTRIBUTION_PORT"),

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -53,7 +53,7 @@ def get_status() -> str:
     Returns: String representation of the status of the Process Manager.
     """
 
-    if is_process_manager_active():
+    try:
         with ProcessManagerProxy() as sm:
             text = textwrap.dedent(
                 f"""\
@@ -67,8 +67,8 @@ def get_status() -> str:
             )
         return text
 
-    else:
-        return "Process Manager Status: [red]not active"
+    except ConnectionError as exc:
+        return f"Process Manager Status: [red]not active[/] ({exc})"
 
 
 class StartCommand:

--- a/libs/cgse-core/src/egse/procman/procman_cs.py
+++ b/libs/cgse-core/src/egse/procman/procman_cs.py
@@ -127,6 +127,7 @@ app = typer.Typer(name=PROCESS_NAME)
 
 console = Console(width=120)
 
+
 @app.command()
 def start():
     """Starts the Process Manager (pm_cs).
@@ -174,8 +175,7 @@ def stop():
                 port = service["metadata"]["service_port"]
             else:
                 rich.print(
-                    "[red]ERROR: Couldn't determine how to connect to the process manager. "
-                    "No service defined.[/]"
+                    "[red]ERROR: Couldn't determine how to connect to the process manager. No service defined.[/]"
                 )
                 return
     else:

--- a/libs/cgse-core/src/egse/protocol.py
+++ b/libs/cgse-core/src/egse/protocol.py
@@ -35,6 +35,7 @@ from egse.device import DeviceConnectionObserver
 from egse.log import logger
 from egse.response import Failure
 from egse.system import format_datetime
+from egse.system import type_name
 
 # Define some metrics for Prometheus
 
@@ -119,7 +120,7 @@ class BaseCommandProtocol(DeviceConnectionObserver):
         self.__socket = socket
 
         endpoint = self.get_bind_address()
-        logger.info(f"Binding {type(self).__name__} to {endpoint}")
+        logger.info(f"Binding {type_name(self)} to {endpoint}")
 
         self.__socket.bind(endpoint)
 

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -158,6 +158,7 @@ PROTOCOL = settings.get("PROTOCOL", "tcp")
 HOSTNAME = settings.get("HOSTNAME", "localhost")
 COMMANDING_PORT = settings.get("COMMANDING_PORT", 0)
 
+
 def is_storage_manager_active(timeout: float = 0.5):
     """Check if the Storage Manager is running.
 
@@ -1074,11 +1075,7 @@ class StorageProxy(Proxy, StorageInterface, EventInterface):
     send commands remotely."""
 
     def __init__(
-            self,
-            protocol: str = PROTOCOL,
-            hostname: str = HOSTNAME,
-            port: int = COMMANDING_PORT,
-            timeout=REQUEST_TIMEOUT
+        self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=REQUEST_TIMEOUT
     ):
         """
         Args:
@@ -1127,7 +1124,6 @@ class StorageProtocol(CommandProtocol):
 
 
 def get_status(full: bool = False):
-
     try:
         with StorageProxy() as sm:
             text = textwrap.dedent(

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -150,10 +150,13 @@ from egse.zmq_ser import connect_address
 
 HERE = Path(__file__).parent
 
-CS_SETTINGS = Settings.load("Storage Control Server")
+settings = Settings.load("Storage Manager Control Server")
 SITE_ID = get_site_id()
 DEVICE_SETTINGS = COMMAND_SETTINGS = Settings.load(location=HERE, filename="storage.yaml")
 
+PROTOCOL = settings.get("PROTOCOL", "tcp")
+HOSTNAME = settings.get("HOSTNAME", "localhost")
+COMMANDING_PORT = settings.get("COMMANDING_PORT", 0)
 
 def is_storage_manager_active(timeout: float = 0.5):
     """Check if the Storage Manager is running.
@@ -162,11 +165,15 @@ def is_storage_manager_active(timeout: float = 0.5):
         True if the Storage Manager is running and replied with the expected answer.
     """
 
-    with RegistryClient() as client:
-        endpoint = client.get_endpoint(CS_SETTINGS.SERVICE_TYPE)
+    if COMMANDING_PORT == 0:
+        with RegistryClient() as client:
+            endpoint = client.get_endpoint(settings.SERVICE_TYPE)
+            if endpoint is None:
+                logger.debug(f"No endpoint for {settings.SERVICE_TYPE}")
+                return False
 
-    if endpoint is None:
-        return False
+    else:
+        endpoint = connect_address(PROTOCOL, HOSTNAME, COMMANDING_PORT)
 
     return is_control_server_active(endpoint, timeout)
 
@@ -1066,7 +1073,13 @@ class StorageProxy(Proxy, StorageInterface, EventInterface):
     """The StorageProxy class is used to connect to the Storage Manager (control server) and
     send commands remotely."""
 
-    def __init__(self, protocol: str = None, hostname: str = None, port: int = -1, timeout=REQUEST_TIMEOUT):
+    def __init__(
+            self,
+            protocol: str = PROTOCOL,
+            hostname: str = HOSTNAME,
+            port: int = COMMANDING_PORT,
+            timeout=REQUEST_TIMEOUT
+    ):
         """
         Args:
             protocol: the transport protocol [default is taken from settings file]
@@ -1075,12 +1088,12 @@ class StorageProxy(Proxy, StorageInterface, EventInterface):
             port: TCP port on which the control server is listening for commands
                 [default is taken from settings file]
         """
-        if hostname is None:
+        if port == 0:
             with RegistryClient() as reg:
-                endpoint = reg.get_endpoint(CS_SETTINGS.SERVICE_TYPE)
+                endpoint = reg.get_endpoint(settings.SERVICE_TYPE)
 
             if not endpoint:
-                raise RuntimeError(f"No service registered as {CS_SETTINGS.SERVICE_TYPE}")
+                raise RuntimeError(f"No service registered as {settings.SERVICE_TYPE}")
         else:
             endpoint = connect_address(protocol, hostname, port)
 
@@ -1114,7 +1127,8 @@ class StorageProtocol(CommandProtocol):
 
 
 def get_status(full: bool = False):
-    if is_storage_manager_active():
+
+    try:
         with StorageProxy() as sm:
             text = textwrap.dedent(
                 f"""\
@@ -1146,5 +1160,5 @@ def get_status(full: bool = False):
 
         return text
 
-    else:
-        return "Storage Manager Status: [red]not active"
+    except ConnectionError as exc:
+        return f"Storage Manager Status: [red]not active[/] ({exc})"

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -1,5 +1,5 @@
 """
-The Storage Control Server, aka Storage Manager, is the service which saves all data coming
+The Storage Manager Control Server, aka Storage Manager, is the service which saves all data coming
 from any component in the Common-EGSE.
 
 The Storage manager is implemented as a standard control server.
@@ -18,6 +18,7 @@ import typer
 import zmq
 from apscheduler.schedulers.background import BackgroundScheduler
 from pytz import utc
+from rich.console import Console
 
 from egse.control import ControlServer
 from egse.env import get_data_storage_location
@@ -36,23 +37,31 @@ from egse.zmq_ser import get_port_number
 
 logger = logging.getLogger("egse.storage")
 
-CTRL_SETTINGS = Settings.load("Storage Control Server")
+settings = Settings.load("Storage Manager Control Server")
+
+PROCESS_NAME = settings.get("PROCESS_NAME", "cm_cs")
+PROTOCOL = settings.get("PROTOCOL", "tcp")
+HOSTNAME = settings.get("HOSTNAME", "localhost")
+COMMANDING_PORT = settings.get("COMMANDING_PORT", 0)
+SERVICE_PORT = settings.get("SERVICE_PORT", 0)
+MONITORING_PORT = settings.get("MONITORING_PORT", 0)
+
 SITE_ID = get_site_id()
 
 
 class StorageControlServer(ControlServer):
     """
-    The Storage Control Server (aka Storage Manager) saves information from registered components.
+    The Storage Manager Control Server (aka Storage Manager) saves information from registered components.
     """
 
     def __init__(self):
         super().__init__()
 
-        multiprocessing.current_process().name = app_name
+        multiprocessing.current_process().name = PROCESS_NAME
 
         self.logger = logger
-        self.service_name = app_name
-        self.service_type = CTRL_SETTINGS.SERVICE_TYPE
+        self.service_name = PROCESS_NAME
+        self.service_type = settings.SERVICE_TYPE
 
         self.device_protocol = StorageProtocol(self)
 
@@ -62,7 +71,7 @@ class StorageControlServer(ControlServer):
 
         self.poller.register(self.dev_ctrl_cmd_sock, zmq.POLLIN)
 
-        self.register_service(service_type=CTRL_SETTINGS.SERVICE_TYPE)
+        self.register_service(service_type=settings.SERVICE_TYPE)
 
         from egse.confman import ConfigurationManagerProxy, is_configuration_manager_active
         from egse.listener import EVENT_ID
@@ -92,16 +101,16 @@ class StorageControlServer(ControlServer):
         self.deregister_service()
 
     def get_communication_protocol(self):
-        return "tcp"
+        return PROTOCOL
 
     def get_commanding_port(self):
-        return get_port_number(self.dev_ctrl_cmd_sock) or 0
+        return get_port_number(self.dev_ctrl_cmd_sock) or COMMANDING_PORT
 
     def get_service_port(self):
-        return get_port_number(self.dev_ctrl_service_sock) or 0
+        return get_port_number(self.dev_ctrl_service_sock) or SERVICE_PORT
 
     def get_monitoring_port(self):
-        return get_port_number(self.dev_ctrl_mon_sock) or 0
+        return get_port_number(self.dev_ctrl_mon_sock) or MONITORING_PORT
 
     def get_event_subscriptions(self) -> list[str]:
         return ["new_setup"]
@@ -121,15 +130,16 @@ class StorageControlServer(ControlServer):
             self.logger.debug(f"{event_data=}")
 
 
-app_name = "sm_cs"
-app = typer.Typer(name=app_name)
+app = typer.Typer(name=PROCESS_NAME)
+
+console = Console(width=120)
 
 
 @app.command()
 def start():
     """Start the Storage Manager."""
 
-    multiprocessing.current_process().name = "sm_cs"
+    multiprocessing.current_process().name = PROCESS_NAME
 
     # We import this class such that the class name is
     # 'egse.storage.storage_cs.StorageControlServer' and we
@@ -173,15 +183,30 @@ def start_bg():
 def stop():
     """Send a 'quit_server' command to the Storage Manager."""
 
-    with RegistryClient() as reg:
-        service = reg.discover_service(CTRL_SETTINGS.SERVICE_TYPE)
-        # rich.print("service = ", service)
+    if COMMANDING_PORT == 0:
+        with RegistryClient() as reg:
+            service = reg.discover_service(settings.SERVICE_TYPE)
+            rich.print("service = ", service)
+            if service:
+                hostname = service["host"]
+                port = service["metadata"]["service_port"]
+            else:
+                rich.print(
+                    "[red]ERROR: Couldn't determine how to connect to the storage manager. "
+                    "No service defined.[/]"
+                )
+                return
 
-        if service:
-            with ServiceProxy(hostname=service["host"], port=service["metadata"]["service_port"]) as proxy:
-                proxy.quit_server()
-        else:
-            rich.print("[red]ERROR: Couldn't connect to 'sm_cs', process probably not running.")
+    else:
+        hostname = HOSTNAME
+        port = SERVICE_PORT
+
+    rich.print("[green]Sending 'quit' command to storage manager..[/]")
+    try:
+        with ServiceProxy(hostname=hostname, port=port) as proxy:
+            proxy.quit_server()
+    except ConnectionError as exc:
+        console.print(f"[red]ERROR: Couldn't connect to storage manager: {exc}[/]")
 
 
 @app.command()

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -192,8 +192,7 @@ def stop():
                 port = service["metadata"]["service_port"]
             else:
                 rich.print(
-                    "[red]ERROR: Couldn't determine how to connect to the storage manager. "
-                    "No service defined.[/]"
+                    "[red]ERROR: Couldn't determine how to connect to the storage manager. No service defined.[/]"
                 )
                 return
 

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.15.1"
+version = "0.16.0"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.15.1"
+version = "0.16.0"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.15.1"
+version = "0.16.0"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.15.1"
+version = "0.16.0"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.15.1"
+version = "0.16.0"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.15.1"
+version = "0.16.0"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.15.1"
+version = "0.16.0"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.15.1"
+version = "0.16.0"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.15.1"
+version = "0.16.0"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
This is a maintenance pull request which handles a numbers of hanging issues:

- fixed port numbers for core services until the registration problem is resolved
- proxies now handle fixed port numbers of the core services properly
- renamed cgse commands 
  - registry → reg
  - notify → not
- proper sorting of the `reg` and `not` commands
- bumped minor version → 0.16.0