### PR TITLE
use get endpoint

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.16.0"
+version = "0.16.1"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.16.0"
+version = "0.16.1"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.16.0"
+version = "0.16.1"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -3,7 +3,12 @@ PACKAGES:
 
 Service Registry:
     
-    CLEANUP_INTERVAL:               30
+    CLEANUP_INTERVAL:                30
+    REQUESTER_PORT:                6100
+    PUBLISHER_PORT:                6101
+    HEARTBEAT_PORT:                6102
+    DATABASE_PATH:  service_registry.db
+
 
 Logging Control Server:                          # LOG_CS
 
@@ -11,8 +16,8 @@ Logging Control Server:                          # LOG_CS
     PROCESS_NAME:                log_cs
     MAX_NR_LOG_FILES:                20          # The maximum number of log files that will be maintained in a roll-over
     MAX_SIZE_LOG_FILES:              20          # The maximum size one log file can become
-    RECEIVER_PORT:                 4248
-    COMMANDER_PORT:                4249
+    RECEIVER_PORT:                 6105
+    COMMANDER_PORT:                6106
     TEXTUALOG_IP_ADDRESS:     127.0.0.1          # The IP address of the textualog listening server
     TEXTUALOG_LISTENING_PORT:     19996          # The port number on which the textualog server is listening
 
@@ -20,9 +25,9 @@ Configuration Manager Control Server:            # CM_CS
 
     SERVICE_TYPE:                 CM_CS
     PROCESS_NAME:                 cm_cs
-    COMMANDING_PORT:               6000          # The port on which the controller listens to commands - REQ-REP
-    MONITORING_PORT:               6001          # The port on which the controller sends periodic status information of the device - PUB-SUB
-    SERVICE_PORT:                  6002          # The port on which the controller listens for configuration and administration - REQ-REP
+    COMMANDING_PORT:               6110          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6111          # The port on which the controller sends periodic status information of the device - PUB-SUB
+    SERVICE_PORT:                  6112          # The port on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
     STORAGE_MNEMONIC:                CM          # The mnemonic to be used in the filename storing the housekeeping data
 
@@ -30,30 +35,35 @@ Storage Manager Control Server:                  # SM_CS
 
     SERVICE_TYPE:                 SM_CS
     PROCESS_NAME:                 sm_cs
-    COMMANDING_PORT:               6010          # The port on which the controller listens to commands - REQ-REP
-    MONITORING_PORT:               6011          # The port on which the controller sends periodic status information of the device - PUB-SUB
-    SERVICE_PORT:                  6012          # The port on which the controller listens for configuration and administration - REQ-REP
+    COMMANDING_PORT:               6115          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6116          # The port on which the controller sends periodic status information of the device - PUB-SUB
+    SERVICE_PORT:                  6117          # The port on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
 
 Process Manager Control Server:                  # PM_CS
 
     SERVICE_TYPE:                 PM_CS
     PROCESS_NAME:                 pm_cs
-    COMMANDING_PORT:               6020          # The port on which the controller listens to commands - REQ-REP
-    MONITORING_PORT:               6021          # The port on which the controller sends periodic status information of the devide - PUB-SUB
-    SERVICE_PORT:                  6022          # The port number on which the controller listens for configuration and administration - REQ-REP
+    COMMANDING_PORT:               6120          # The port on which the controller listens to commands - REQ-REP
+    MONITORING_PORT:               6121          # The port on which the controller sends periodic status information of the devide - PUB-SUB
+    SERVICE_PORT:                  6122          # The port number on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
     STORAGE_MNEMONIC:                PM          # The mnemonic to be used in the filename storing the housekeeping data
 
 Notify Hub:
     
     SERVICE_TYPE:            NOTIFY_HUB
+    SERVICE_ID:                 nh_cs_1
     PROCESS_NAME:                 nh_cs
-    COLLECTOR_PORT:                4245
-    PUBLISHER_PORT:                4246
-    REQUESTS_PORT:                 4247
+    COLLECTOR_PORT:                6125
+    PUBLISHER_PORT:                6126
+    REQUESTS_PORT:                 6167
     
 Metrics Hub:
     
     SERVICE_TYPE:           METRICS_HUB
+    SERVICE_ID:                 mh_cs_1
     PROCESS_NAME:                 mh_cs
+    COLLECTOR_PORT:                6130
+    PUBLISHER_PORT:                6131
+    REQUESTS_PORT:                 6132

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -128,6 +128,7 @@ from egse.command import ClientServerCommand
 from egse.command import stringify_function_call
 from egse.config import find_file
 from egse.config import find_files
+from egse.connect import get_endpoint
 from egse.control import ControlServer
 from egse.control import is_control_server_active
 from egse.decorators import dynamic_interface
@@ -992,27 +993,22 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
     """
     The Configuration Manager Proxy class is used to connect to the Configuration Manager
     Control Server and send commands and requests for the configuration manager.
+
+    When the port number passed is 0 (zero), the endpoint is requested from the
+    service registry.
+
+    Args:
+        protocol: the transport protocol [default is taken from settings file]
+        hostname: location of the control server (IP address) [default is taken
+            from settings file]
+        port: TCP port on which the control server is listening for commands
+            [default is taken from settings file]
     """
 
     def __init__(
         self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=PROXY_TIMEOUT
     ):
-        """
-        Args:
-            protocol: the transport protocol [default is taken from settings file]
-            hostname: location of the control server (IP address) [default is taken
-                from settings file]
-            port: TCP port on which the control server is listening for commands
-                [default is taken from settings file]
-        """
-        if port == 0:
-            with RegistryClient() as reg:
-                endpoint = reg.get_endpoint(settings.SERVICE_TYPE)
-
-            if not endpoint:
-                raise RuntimeError(f"No service registered as {settings.SERVICE_TYPE}")
-        else:
-            endpoint = connect_address(protocol, hostname, port)
+        endpoint = get_endpoint(settings.SERVICE_TYPE, protocol, hostname, port)
 
         super().__init__(endpoint, timeout=timeout)
 

--- a/libs/cgse-core/src/egse/dummy.py
+++ b/libs/cgse-core/src/egse/dummy.py
@@ -1,6 +1,13 @@
 """
 This module provides a dummy implementation for classes of the commanding chain.
 
+This is only a simplified implementation that is used for testing purposes.
+
+If you need a more elaborate example of a device and commanding chain implementation,
+check out the `cgse-dummy` project in PyPI. That project is a full implementation of
+all aspects in device access, commanding, and services. It also handles both
+synchronous and asynchronous implementations.
+
 Start the control server with:
 
     py -m egse.dummy start-cs

--- a/libs/cgse-core/src/egse/notifyhub/__init__.py
+++ b/libs/cgse-core/src/egse/notifyhub/__init__.py
@@ -11,6 +11,10 @@ from egse.settings import Settings
 
 settings = Settings.load("Notify Hub")
 
+PROCESS_NAME = settings.get("PROCESS_NAME", "nh_cs")
+SERVICE_ID = settings.get("SERVICE_ID", "nh_cs_1")
+SERVICE_TYPE = settings.get("SERVICE_TYPE", "NOTIFY_HUB")
+
 # Default ports that are assigned to PUSH-PULL, PUB-SUB, ROUTER-DEALER protocols of the notification hub.
 # The actual ports are defined in the Settings.yaml, use local settings to change them.
 DEFAULT_COLLECTOR_PORT = settings.get("COLLECTOR_PORT", 0)

--- a/libs/cgse-core/src/egse/notifyhub/server.py
+++ b/libs/cgse-core/src/egse/notifyhub/server.py
@@ -18,6 +18,8 @@ from egse.logger import remote_logging
 from egse.notifyhub import DEFAULT_COLLECTOR_PORT
 from egse.notifyhub import DEFAULT_PUBLISHER_PORT
 from egse.notifyhub import DEFAULT_REQUESTS_PORT
+from egse.notifyhub import PROCESS_NAME
+from egse.notifyhub import SERVICE_TYPE
 from egse.notifyhub import STATS_INTERVAL
 from egse.notifyhub.client import AsyncNotificationHubClient
 from egse.registry import MessageType
@@ -30,12 +32,13 @@ from .event import NotificationEvent
 REQUEST_POLL_TIMEOUT = 1.0
 """time to wait for while listening for requests [seconds]."""
 
-app = typer.Typer(name="notify_hub")
+
+app = typer.Typer(name=PROCESS_NAME)
 
 
 class AsyncNotificationHub:
     def __init__(self):
-        self.server_id = "notification-hub-1"
+        self.server_id = PROCESS_NAME
 
         self.context: zmq.asyncio.Context = zmq.asyncio.Context()
 
@@ -51,8 +54,8 @@ class AsyncNotificationHub:
         # Register notification hub to the service registry
         self.registry_client = AsyncRegistryClient(timeout=REQUEST_TIMEOUT)
         self.service_id = None
-        self.service_name = "Notification Hub"
-        self.service_type = "notification-hub"
+        self.service_name = PROCESS_NAME
+        self.service_type = SERVICE_TYPE
         self.is_service_registered: bool = False
         """True if the service is registered to the service registry."""
 
@@ -123,7 +126,7 @@ class AsyncNotificationHub:
 
         self.service_id = await self.registry_client.register(
             name=self.service_name,
-            host=get_host_ip(),
+            host=get_host_ip() or "127.0.0.1",
             port=DEFAULT_REQUESTS_PORT,
             service_type=self.service_type,
             metadata={"pub_port": DEFAULT_PUBLISHER_PORT, "collector_port": DEFAULT_COLLECTOR_PORT},

--- a/libs/cgse-core/src/egse/registry/__init__.py
+++ b/libs/cgse-core/src/egse/registry/__init__.py
@@ -1,5 +1,8 @@
-import logging
 from enum import Enum
+
+from egse.log import logging
+
+logger = logging.getLogger("egse.registry")
 
 # Default ports that are assigned to REQ-REP and PUB-SUB protocols of the registry services
 DEFAULT_RS_REQ_PORT = 4242  # Handle requests
@@ -17,9 +20,6 @@ class MessageType(Enum):
     RESPONSE = b"RESPONSE"  # Response to a request
     NOTIFICATION = b"NOTIF"  # Server-initiated notification
     HEARTBEAT = b"HB"  # Heartbeat/health check
-
-
-logger = logging.getLogger("egse.registry")
 
 
 def is_service_registry_active(timeout: float = 0.5):

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -121,6 +121,7 @@ from typing import Union
 from egse.bits import humanize_bytes
 from egse.command import ClientServerCommand
 from egse.config import find_files
+from egse.connect import get_endpoint
 from egse.control import ControlServer
 from egse.control import is_control_server_active
 from egse.decorators import dynamic_interface
@@ -1071,28 +1072,25 @@ class StorageCommand(ClientServerCommand):
 
 
 class StorageProxy(Proxy, StorageInterface, EventInterface):
-    """The StorageProxy class is used to connect to the Storage Manager (control server) and
-    send commands remotely."""
+    """
+    The StorageProxy class is used to connect to the Storage Manager (control server) and
+    send commands remotely.
+
+    When the port number is 0 (zero), the endpoint will be retrieved from the service registry.
+
+    Args:
+        protocol: the transport protocol [default is taken from settings file]
+        hostname: location of the control server (IP address)
+            [default is taken from settings file]
+        port: TCP port on which the control server is listening for commands
+            [default is taken from settings file]
+
+    """
 
     def __init__(
         self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=REQUEST_TIMEOUT
     ):
-        """
-        Args:
-            protocol: the transport protocol [default is taken from settings file]
-            hostname: location of the control server (IP address)
-                [default is taken from settings file]
-            port: TCP port on which the control server is listening for commands
-                [default is taken from settings file]
-        """
-        if port == 0:
-            with RegistryClient() as reg:
-                endpoint = reg.get_endpoint(settings.SERVICE_TYPE)
-
-            if not endpoint:
-                raise RuntimeError(f"No service registered as {settings.SERVICE_TYPE}")
-        else:
-            endpoint = connect_address(protocol, hostname, port)
+        endpoint = get_endpoint(settings.SERVICE_TYPE, protocol, hostname, port)
 
         super().__init__(endpoint, timeout=timeout)
 

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.16.0"
+version = "0.16.1"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.16.0"
+version = "0.16.1"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.16.0"
+version = "0.16.1"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.16.0"
+version = "0.16.1"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.16.0"
+version = "0.16.1"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.16.0"
+version = "0.16.1"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.16.0"
+version = "0.16.1"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.16.0"
+version = "0.16.1"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.16.0"
+version = "0.16.1"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
This is a maintenance pull request that adds consistency to the Proxy subclasses.

- use get_endpoint() function
- define constants from settings with proper defaults
- when port = 0 use service registry
- the settings file for the core services has been cleaned up and all core services now have fixed port numbers.

Version bump to 0.16.1.