### PR TITLE
redirect output to log location

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.16.1"
+version = "0.16.2"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/src/egse/env.py
+++ b/libs/cgse-common/src/egse/env.py
@@ -384,7 +384,7 @@ def set_log_file_location(location: str | Path | None):
     _env.set("LOG_FILE_LOCATION", location)
 
 
-def get_log_file_location(site_id: str = None) -> str:
+def get_log_file_location(site_id: str = None, check_exists: bool = False) -> str:
     """
     Returns the full path of the location of the log files. The log file location is read from the environment
     variable `${PROJECT}_LOG_FILE_LOCATION`. The location shall be independent of any setting that is subject to change.
@@ -392,8 +392,12 @@ def get_log_file_location(site_id: str = None) -> str:
     If the environment variable is not set, a default log file location is created from the data storage location as
     follows: `<PROJECT>_DATA_STORAGE_LOCATION/<SITE_ID>/log`.
 
+    There is no check for the existence of the returned location. The caller function shall check if the
+    returned value is a directory and if it exists.
+
     Args:
         site_id: the site identifier
+        check_exists: check if the location that will be returned is a directory and exists
 
     Returns:
         The full path of location of the log files as a string.
@@ -416,6 +420,10 @@ def get_log_file_location(site_id: str = None) -> str:
             )
         data_root = data_root.rstrip("/")
         log_data_root = f"{data_root}/log"
+
+    if check_exists:
+        if not Path(log_data_root).is_dir():
+            raise ValueError(f"The location that was constructed doesn't exist: {log_data_root}")
 
     return log_data_root
 

--- a/libs/cgse-common/src/egse/system.py
+++ b/libs/cgse-common/src/egse/system.py
@@ -48,6 +48,7 @@ from typing import Callable
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import TextIO
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -60,6 +61,7 @@ from rich.tree import Tree
 from typer.core import TyperCommand
 
 import signal
+from egse.env import get_log_file_location
 from egse.log import logger
 
 EPOCH_1958_1970 = 378691200
@@ -2305,6 +2307,28 @@ def caffeinate(pid: int = None):
     if get_os_name() == "macos":
         logger.warning(f"Running 'caffeinate -i -w {pid}' on macOS to prevent the system from idle sleeping.")
         subprocess.Popen([shutil.which("caffeinate"), "-i", "-w", str(pid)])
+
+
+def redirect_output_to_log(output_fn: str, append: bool = False) -> TextIO:
+    """
+    Open file in the log folder where process output will be redirected.
+
+    When no location can be determined, the user's home directory will be used.
+
+    The file is opened in text mode at the given location and the stream (file descriptor) will be returned.
+    """
+
+    try:
+        location = get_log_file_location()
+        output_path = Path(location, output_fn).expanduser()
+    except ValueError:
+        output_path = Path.home() / output_fn
+
+    out = open(output_path, "a" if append else "w")
+
+    logger.info(f"Output will be redirected to {output_path!s}")
+
+    return out
 
 
 ignore_m_warning("egse.system")

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.16.1"
+version = "0.16.2"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.16.1"
+version = "0.16.2"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -1,14 +1,15 @@
 import subprocess
 import sys
-from pathlib import Path
 
 import rich
+
+from egse.system import redirect_output_to_log
 
 
 def start_rm_cs(log_level: str):
     rich.print("Starting the service registry manager core service...")
 
-    out = open(Path("~/.rm_cs.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".rm_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.registry.server", "start", "--log-level", log_level],
@@ -22,7 +23,7 @@ def start_rm_cs(log_level: str):
 def start_log_cs():
     rich.print("Starting the logging core service...")
 
-    out = open(Path("~/.log_cs.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".log_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.logger.log_cs", "start"],
@@ -36,7 +37,7 @@ def start_log_cs():
 def start_sm_cs():
     rich.print("Starting the storage manager core service...")
 
-    out = open(Path("~/.sm_cs.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".sm_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.storage.storage_cs", "start"],
@@ -50,7 +51,7 @@ def start_sm_cs():
 def start_cm_cs():
     rich.print("Starting the configuration manager core service...")
 
-    out = open(Path("~/.cm_cs.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".cm_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.confman.confman_cs", "start"],
@@ -64,7 +65,7 @@ def start_cm_cs():
 def start_pm_cs():
     rich.print("Starting the process manager core service...")
 
-    out = open(Path("~/.pm_cs.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".pm_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.procman.procman_cs", "start"],
@@ -78,7 +79,7 @@ def start_pm_cs():
 def start_notifyhub():
     rich.print("Starting the notification hub core service...")
 
-    out = open(Path("~/.notifyhub.start.out").expanduser(), "w")
+    out = redirect_output_to_log(".nh_cs.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.notifyhub.server", "start"],

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -8,13 +8,14 @@ import rich
 from egse.log import logger
 from egse.process import is_process_running
 from egse.system import Timer
+from egse.system import redirect_output_to_log
 from egse.system import waiting_for
 
 
 def stop_rm_cs():
     rich.print("Terminating the service registry manager core service...")
 
-    out = open(Path("~/.rm_cs.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".rm_cs.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.registry.server", "stop"],
@@ -34,7 +35,7 @@ def stop_rm_cs():
 def stop_log_cs():
     rich.print("Terminating the logging core service...")
 
-    out = open(Path("~/.log_cs.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".log_cs.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.logger.log_cs", "stop"],
@@ -48,7 +49,7 @@ def stop_log_cs():
 def stop_sm_cs():
     rich.print("Terminating the storage manager core service...")
 
-    out = open(Path("~/.sm_cs.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".sm_cs.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.storage.storage_cs", "stop"],
@@ -68,7 +69,7 @@ def stop_sm_cs():
 def stop_cm_cs():
     rich.print("Terminating the configuration manager core service...")
 
-    out = open(Path("~/.cm_cs.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".cm_cs.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.confman.confman_cs", "stop"],
@@ -88,7 +89,8 @@ def stop_cm_cs():
 def stop_pm_cs():
     rich.print("Terminating the process manager core service...")
 
-    out = open(Path("~/.pm_cs.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".pm_cs.stop.log")
+
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.procman.procman_cs", "stop"],
@@ -108,7 +110,7 @@ def stop_pm_cs():
 def stop_notifyhub():
     rich.print("Terminating the notification hub core service...")
 
-    out = open(Path("~/.notifyhub.stop.out").expanduser(), "w")
+    out = redirect_output_to_log(".nh_cs.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.notifyhub.server", "stop"],

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -91,7 +91,6 @@ def stop_pm_cs():
 
     out = redirect_output_to_log(".pm_cs.stop.log")
 
-
     subprocess.Popen(
         [sys.executable, "-m", "egse.procman.procman_cs", "stop"],
         stdout=out,

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.16.1"
+version = "0.16.2"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.16.1"
+version = "0.16.2"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.16.1"
+version = "0.16.2"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.16.1"
+version = "0.16.2"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
+++ b/projects/generic/lakeshore-tempcontrol/src/lakeshore_tempcontrol/cgse_services.py
@@ -37,7 +37,7 @@ def start_lakeshore336(
 
     if background:
         location = get_log_file_location()
-        output_filename = "lakeshore336_cs.start.out"
+        output_filename = ".lakeshore336_cs.start.log"
         output_path = Path(location, output_filename).expanduser()
 
         rich.print(f"Starting the LakeShore336 Control Server ({device_id}) – {simulator = }")

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.16.1"
+version = "0.16.2"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
+++ b/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
@@ -1,15 +1,13 @@
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
 from typing import Annotated
-from typing import TextIO
 
 import rich
 import typer
 
-from egse.env import get_log_file_location
 from egse.system import all_logging_disabled
+from egse.system import redirect_output_to_log
 
 puna = typer.Typer(name="puna", help="PUNA Positioning Hexapod, Symétrie")
 
@@ -18,25 +16,12 @@ zonda = typer.Typer(name="zonda", help="ZONDA Positioning Hexapod, Symétrie")
 joran = typer.Typer(name="joran", help="JORAN Positioning Hexapod, Symétrie")
 
 
-def redirect_output_to(output_fn: str) -> TextIO:
-    """Open file in the log folder where process output will be redirected."""
-
-    location = get_log_file_location()
-    output_path = Path(location, output_fn).expanduser()
-
-    rich.print(f"Output will be redirected to {output_path!s}")
-
-    out = open(output_path, "w")
-
-    return out
-
-
 def start_hexapod_cs_process(device_name, device_id, simulator):
     """Generic function to start the hexapod control server in the background."""
 
     rich.print(f"Starting the {device_name} hexapod control server for {device_id} – {simulator = }")
 
-    out = redirect_output_to(f"{device_name.lower()}_cs.{device_id.lower()}.start.out")
+    out = redirect_output_to_log(f".{device_name.lower()}_cs.{device_id.lower()}.start.log")
 
     cmd = [sys.executable, "-m", f"egse.hexapod.symetrie.{device_name.lower()}_cs", "start", device_id]
     if simulator:
@@ -50,7 +35,7 @@ def stop_hexapod_cs_process(device_name, device_id):
 
     rich.print(f"Terminating hexapod {device_name} control server for {device_id}...")
 
-    out = redirect_output_to(f"{device_name.lower()}_cs.{device_id.lower()}.stop.out")
+    out = redirect_output_to_log(f".{device_name.lower()}_cs.{device_id.lower()}.stop.log")
 
     cmd = [sys.executable, "-m", f"egse.hexapod.symetrie.{device_name.lower()}_cs", "stop", device_id]
 
@@ -114,7 +99,7 @@ def start_puna_sim(device_id: str):
 
     rich.print("Starting service PUNA Simulator")
 
-    out = redirect_output_to(f"puna_sim.{device_id.lower()}.start.out")
+    out = redirect_output_to_log(f".puna_sim.{device_id.lower()}.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.hexapod.symetrie.puna_sim", "start", device_id],
@@ -130,7 +115,7 @@ def stop_puna_sim(device_id: str):
     """Stop the PUNA Hexapod Simulator."""
     rich.print("Terminating the PUNA simulator.")
 
-    out = redirect_output_to(f"puna_sim.{device_id.lower()}.stop.out")
+    out = redirect_output_to_log(f".puna_sim.{device_id.lower()}.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.hexapod.symetrie.puna_sim", "stop", device_id],

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.16.1"
+version = "0.16.2"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.16.1"
+version = "0.16.2"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.16.1"
+version = "0.16.2"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.16.1"
+version = "0.16.2"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
The start and stop scripts of core services and control servers now redirect their output no longer to the users home folder, but to the log location.