### PR TITLE
Fix timeouts in proxy

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.16.5"
+version = "0.16.6"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-common/src/egse/signal.py
+++ b/libs/cgse-common/src/egse/signal.py
@@ -158,7 +158,7 @@ class FileBasedSignaling:
         """Terminate the monitoring loop thread."""
         self.running = False
         if self.thread.is_alive():
-            self.thread.join(timeout=1)
+            self.thread.join(timeout=1.0)
 
 
 def create_signal_command_file(signal_dir: Path, service_id: str, command: dict) -> None:

--- a/libs/cgse-common/tests/test_influxdb_plugin.py
+++ b/libs/cgse-common/tests/test_influxdb_plugin.py
@@ -20,7 +20,7 @@ def test_influxdb_access():
     influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
     influxdb.connect()
 
-    result = influxdb.query("SELECT * FROM cm ORDER BY TIME DESC LIMIT 20", mode="pandas")
+    result = influxdb.query("SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20", mode="pandas")
     print(result)
     assert isinstance(result, pd.DataFrame)
 

--- a/libs/cgse-common/tests/test_influxdb_plugin.py
+++ b/libs/cgse-common/tests/test_influxdb_plugin.py
@@ -20,7 +20,9 @@ def test_influxdb_access():
     influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
     influxdb.connect()
 
-    result = influxdb.query("SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20", mode="pandas")
+    result = influxdb.query(
+        "SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20", mode="pandas"
+    )
     print(result)
     assert isinstance(result, pd.DataFrame)
 

--- a/libs/cgse-common/tests/test_metrics.py
+++ b/libs/cgse-common/tests/test_metrics.py
@@ -11,8 +11,9 @@ def test_get_metrics_repo():
 
     # Don't use a too large time interval here, or you will get an error like:
     # 'External error: Query would exceed file limit of 432 parquet files'
-    result = influxdb.query("SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20",
-                            mode="pandas")
+    result = influxdb.query(
+        "SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20", mode="pandas"
+    )
     print(result)
 
     # result = influxdb.query("SHOW TABLES;")

--- a/libs/cgse-common/tests/test_metrics.py
+++ b/libs/cgse-common/tests/test_metrics.py
@@ -9,7 +9,10 @@ def test_get_metrics_repo():
     influxdb = get_metrics_repo("influxdb", {"host": "http://localhost:8181", "database": "ARIEL", "token": token})
     influxdb.connect()
 
-    result = influxdb.query("SELECT * FROM cm ORDER BY TIME DESC LIMIT 20", mode="pandas")
+    # Don't use a too large time interval here, or you will get an error like:
+    # 'External error: Query would exceed file limit of 432 parquet files'
+    result = influxdb.query("SELECT * FROM cm WHERE time >= now() - INTERVAL '2 days' ORDER BY TIME DESC LIMIT 20",
+                            mode="pandas")
     print(result)
 
     # result = influxdb.query("SHOW TABLES;")

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.16.5"
+version = "0.16.6"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.16.5"
+version = "0.16.6"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -181,7 +181,7 @@ MONITORING_PORT = settings.get("MONITORING_PORT", 0)
 # CM_SETUP_ID = Gauge("CM_SETUP_ID", 'Setup ID')
 # CM_TEST_ID = Gauge("CM_TEST_ID", 'Test ID')
 
-PROXY_TIMEOUT = 10_000  # don't wait longer than 10s by default
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s by default
 
 
 def _push_setup_to_repo(filename: str, commit_msg: str) -> Failure | Success:
@@ -982,6 +982,7 @@ class ConfigurationManagerProxy(Proxy, ConfigurationManagerInterface):
             from settings file]
         port: TCP port on which the control server is listening for commands
             [default is taken from settings file]
+        timeout: number of fractional seconds before a timeout is triggered
     """
 
     def __init__(

--- a/libs/cgse-core/src/egse/dummy.py
+++ b/libs/cgse-core/src/egse/dummy.py
@@ -35,15 +35,11 @@ and stopped with:
 
 from __future__ import annotations
 
-import contextlib
 import multiprocessing
 import random
 import select
 import socket
 import sys
-import threading
-import time
-from functools import partial
 
 import typer
 import zmq
@@ -62,7 +58,6 @@ from egse.proxy import Proxy
 from egse.system import SignalCatcher
 from egse.system import attrdict
 from egse.system import format_datetime
-from egse.system import type_name
 from egse.zmq_ser import bind_address
 from egse.zmq_ser import connect_address
 
@@ -96,7 +91,7 @@ ctrl_settings = attrdict(
         "SERVICE_PORT": 4444,
         "MONITORING_PORT": 4445,
         "PROTOCOL": "tcp",
-        "TIMEOUT": 10_000,  # milliseconds
+        "TIMEOUT": 10.0,
         "HK_DELAY": 1.0,
     }
 )

--- a/libs/cgse-core/src/egse/dummy.py
+++ b/libs/cgse-core/src/egse/dummy.py
@@ -172,7 +172,7 @@ class DummyProxy(Proxy, DummyInterface):
         protocol: the transport protocol [default is taken from settings file]
         hostname: location of the control server (IP address) [default is taken from settings file]
         port: TCP port on which the control server is listening for commands [default is taken from settings file]
-        timeout: a socket timeout in milliseconds
+        timeout: a socket timeout in seconds
     """
 
     def __init__(
@@ -180,7 +180,7 @@ class DummyProxy(Proxy, DummyInterface):
         protocol: str = ctrl_settings.PROTOCOL,
         hostname: str = ctrl_settings.HOSTNAME,
         port: int = ctrl_settings.COMMANDING_PORT,
-        timeout: int = ctrl_settings.TIMEOUT,
+        timeout: float = ctrl_settings.TIMEOUT,
     ):
         super().__init__(connect_address(protocol, hostname, port), timeout=timeout)
 

--- a/libs/cgse-core/src/egse/notifyhub/services.py
+++ b/libs/cgse-core/src/egse/notifyhub/services.py
@@ -111,7 +111,7 @@ class AsyncEventSubscriber:
 
         while self.running:
             try:
-                if await self.subscriber.poll(timeout=1000):
+                if await self.subscriber.poll(timeout=1000):  # timeout in milliseconds
                     topic, message_bytes = await self.subscriber.recv_multipart()
 
                     event_type = topic.decode()
@@ -269,7 +269,7 @@ class EventSubscriber:
         return self.subscriber
 
     def poll(self, timeout=1000):
-        return self.subscriber.poll(timeout=timeout)
+        return self.subscriber.poll(timeout=timeout)  # timeout in milliseconds
 
     def handle_event(self, return_event_data: bool = False) -> dict:
         topic, message_bytes = self.subscriber.recv_multipart()

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -395,11 +395,11 @@ class ProcessManagerProxy(Proxy, ProcessManagerInterface):
     """Proxy for process management, used to connect to the Process Manager Control Server and send commands remotely."""
 
     def __init__(
-            self,
-            protocol: str = PROTOCOL,
-            hostname: str = HOSTNAME,
-            port: int = COMMANDING_PORT,
-            timeout: float = PROXY_TIMEOUT
+        self,
+        protocol: str = PROTOCOL,
+        hostname: str = HOSTNAME,
+        port: int = COMMANDING_PORT,
+        timeout: float = PROXY_TIMEOUT,
     ):
         """
         Initialisation of a new Proxy for Process Management.

--- a/libs/cgse-core/src/egse/procman/__init__.py
+++ b/libs/cgse-core/src/egse/procman/__init__.py
@@ -22,7 +22,8 @@ LOGGER = logging.getLogger("egse.procman")
 
 settings = Settings.load("Process Manager Control Server")
 COMMAND_SETTINGS = Settings.load(location=HERE, filename="procman.yaml")
-PROXY_TIMEOUT = 10_000
+
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s
 
 SERVICE_TYPE = settings.get("SERVICE_TYPE", "pm_cs")
 PROTOCOL = settings.get("PROTOCOL", "tcp")
@@ -394,7 +395,11 @@ class ProcessManagerProxy(Proxy, ProcessManagerInterface):
     """Proxy for process management, used to connect to the Process Manager Control Server and send commands remotely."""
 
     def __init__(
-        self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=PROXY_TIMEOUT
+            self,
+            protocol: str = PROTOCOL,
+            hostname: str = HOSTNAME,
+            port: int = COMMANDING_PORT,
+            timeout: float = PROXY_TIMEOUT
     ):
         """
         Initialisation of a new Proxy for Process Management.
@@ -406,6 +411,7 @@ class ProcessManagerProxy(Proxy, ProcessManagerInterface):
             protocol (str): Transport protocol
             hostname (str): Location of the control server (IP address)
             port (int): TCP port on which the Control Server is listening for commands
+            timeout (float): number of fractional seconds before a timeout occurs
         """
 
         endpoint = get_endpoint(settings.SERVICE_TYPE, protocol, hostname, port)

--- a/libs/cgse-core/src/egse/services.py
+++ b/libs/cgse-core/src/egse/services.py
@@ -227,7 +227,7 @@ class ServiceProxy(Proxy, ServiceInterface):
         protocol: str = "tcp",
         hostname: str = None,
         port: int = None,
-        timeout: int = REQUEST_TIMEOUT,
+        timeout: float = REQUEST_TIMEOUT,
     ):
         """
         The Service Proxy class is used to send service commands to the control server.
@@ -237,7 +237,7 @@ class ServiceProxy(Proxy, ServiceInterface):
             protocol: the transport protocol [default: tcp]
             hostname: the IP address of the control server
             port: the port on which the control server is listening for service commands
-            timeout: number of milliseconds before a timeout is triggered
+            timeout: number of fractional seconds before a timeout is triggered
         """
 
         if hostname is None or port is None:

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -1067,11 +1067,15 @@ class StorageProxy(Proxy, StorageInterface):
             [default is taken from settings file]
         port: TCP port on which the control server is listening for commands
             [default is taken from settings file]
-
+        timeout (float): number of fractional seconds before a timeout occurs
     """
 
     def __init__(
-        self, protocol: str = PROTOCOL, hostname: str = HOSTNAME, port: int = COMMANDING_PORT, timeout=REQUEST_TIMEOUT
+            self,
+            protocol: str = PROTOCOL,
+            hostname: str = HOSTNAME,
+            port: int = COMMANDING_PORT,
+            timeout: float = REQUEST_TIMEOUT,
     ):
         endpoint = get_endpoint(settings.SERVICE_TYPE, protocol, hostname, port)
 

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -1071,11 +1071,11 @@ class StorageProxy(Proxy, StorageInterface):
     """
 
     def __init__(
-            self,
-            protocol: str = PROTOCOL,
-            hostname: str = HOSTNAME,
-            port: int = COMMANDING_PORT,
-            timeout: float = REQUEST_TIMEOUT,
+        self,
+        protocol: str = PROTOCOL,
+        hostname: str = HOSTNAME,
+        port: int = COMMANDING_PORT,
+        timeout: float = REQUEST_TIMEOUT,
     ):
         endpoint = get_endpoint(settings.SERVICE_TYPE, protocol, hostname, port)
 

--- a/libs/cgse-core/tests/script_test_registry_client_server.py
+++ b/libs/cgse-core/tests/script_test_registry_client_server.py
@@ -62,7 +62,7 @@ def test_proper_termination_of_tasks_sync(
         registry_req_endpoint=f"tcp://{host}:{req_port}",
         registry_sub_endpoint=f"tcp://{host}:{pub_port}",
         registry_hb_endpoint=f"tcp://{host}:{hb_port}",
-        request_timeout=5000,  # 5 second timeout
+        timeout=5.0,
     )
     client.connect()
 
@@ -106,7 +106,7 @@ async def test_proper_termination_of_tasks_async(
         registry_req_endpoint=f"tcp://{host}:{req_port}",
         registry_sub_endpoint=f"tcp://{host}:{pub_port}",
         registry_hb_endpoint=f"tcp://{host}:{hb_port}",
-        request_timeout=5000,  # 5 second timeout
+        timeout=5.0,
     )
     client.connect()
 

--- a/libs/cgse-core/tests/script_test_service_registry_server.py
+++ b/libs/cgse-core/tests/script_test_service_registry_server.py
@@ -187,7 +187,7 @@ async def send_request(request, timeout=5.0):
         logger.debug("Request sent, waiting for response")
 
         # Wait for response with poll and timeout
-        if await socket.poll(timeout=timeout * 1000) == 0:
+        if await socket.poll(timeout=int(timeout * 1000)) == 0:
             logger.error(f"Timeout polling for response to {request.get('action')}")
             raise TimeoutError(f"Timeout waiting for response to {request.get('action')}")
 

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.16.5"
+version = "0.16.6"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.16.5"
+version = "0.16.6"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.16.5"
+version = "0.16.6"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.16.5"
+version = "0.16.6"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.16.5"
+version = "0.16.6"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.16.5"
+version = "0.16.6"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.16.5"
+version = "0.16.6"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.16.5"
+version = "0.16.6"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.16.5"
+version = "0.16.6"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
This pull request fixes the timeout argument for Proxy subclasses. The timeout should be in seconds instead of milliseconds.

Closes #171 