### PR TITLE
Fix re-registration problem

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.16.6"
+version = "0.16.7"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.16.6"
+version = "0.16.7"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.16.6"
+version = "0.16.7"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/src/egse/logger/log_cs.py
+++ b/libs/cgse-core/src/egse/logger/log_cs.py
@@ -254,7 +254,7 @@ def start():
     commander.close(linger=0)
     receiver.close(linger=0)
 
-    if not is_service_registered:
+    if is_service_registered:
         client.stop_heartbeat()
         client.deregister(service_id)
 

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -316,8 +316,9 @@ class RegistryClient:
             return None
 
         if not self._service_info:
-            self.logger.warning("Cannot reregister: no service info was saved by this registry client or service "
-                                "already deregistered.")
+            self.logger.warning(
+                "Cannot reregister: no service info was saved by this registry client or service already deregistered."
+            )
             return None
 
         return self.register(
@@ -327,7 +328,6 @@ class RegistryClient:
             service_type=self._service_info["type"],
             metadata=self._service_info["metadata"],
         )
-
 
     def discover_service(self, service_type: str, use_cache: bool = False) -> dict[str, Any] | None:
         """

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.16.6"
+version = "0.16.7"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.16.6"
+version = "0.16.7"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.16.6"
+version = "0.16.7"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.16.6"
+version = "0.16.7"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.16.6"
+version = "0.16.7"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.16.6"
+version = "0.16.7"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.16.6"
+version = "0.16.7"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.16.6"
+version = "0.16.7"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.16.6"
+version = "0.16.7"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
This pull request fixes the re-registration problem.

- When a control server goes to sleep or is stopped (not killed) it will automatically re-register to the service registry when is returns from sleep or continues after being stopped.
- The periodic heartbeat is stopped and restarted
- The registration gets another service_id.

This was tested by 

- bringing the macBook laptop to sleep by closing its lid and reopening after one minute
- using the `kill -STOP <PID>` and `kill -CONT <PID>` commands on the control server
- also bringing back up the process before it was registered restored the registration properly
