### PR TITLE
cgse commands now load `.env`

### DIFF
--- a/libs/cgse-common/src/cgse_common/cgse.py
+++ b/libs/cgse-common/src/cgse_common/cgse.py
@@ -24,6 +24,7 @@ import textwrap
 
 import rich
 import typer
+from dotenv import load_dotenv
 from rich.console import Console
 from rich.traceback import Traceback
 from typer.core import TyperGroup
@@ -34,6 +35,7 @@ from egse.plugin import entry_points
 from egse.system import get_package_description
 from egse.system import snake_to_title
 
+load_dotenv()
 
 def broken_command(name: str, module: str, exc: Exception):
     """

--- a/libs/cgse-common/src/egse/env.py
+++ b/libs/cgse-common/src/egse/env.py
@@ -244,7 +244,7 @@ def set_data_storage_location(location: str | Path | None):
         _env.set("DATA_STORAGE_LOCATION", None)
         return
 
-    if not Path(location).exists():
+    if not Path(location).expanduser().exists():
         warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist: {location}.")
 
     os.environ[env_name] = str(location)
@@ -312,7 +312,7 @@ def set_conf_data_location(location: str | Path | None):
         _env.set("CONF_DATA_LOCATION", None)
         return
 
-    if not Path(location).exists():
+    if not Path(location).expanduser().exists():
         warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist: {location}.")
 
     os.environ[env_name] = location
@@ -378,7 +378,7 @@ def set_log_file_location(location: str | Path | None):
         _env.set("LOG_FILE_LOCATION", None)
         return
 
-    if not Path(location).exists():
+    if not Path(location).expanduser().exists():
         warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist: {location}.")
 
     os.environ[env_name] = location
@@ -423,7 +423,7 @@ def get_log_file_location(site_id: str = None, check_exists: bool = False) -> st
         log_data_root = f"{data_root}/log"
 
     if check_exists:
-        if not Path(log_data_root).is_dir():
+        if not Path(log_data_root).expanduser().is_dir():
             raise ValueError(f"The location that was constructed doesn't exist: {log_data_root}")
 
     return log_data_root
@@ -453,8 +453,9 @@ def set_local_settings(path: str | Path | None):
         _env.set("LOCAL_SETTINGS", None)
         return
 
-    if not Path(path).exists():
-        warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist: {path}.")
+    if not Path(path).expanduser().is_file():
+        warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist or is not a "
+                      f"regular file: {path}.")
 
     os.environ[env_name] = path
     _env.set("LOCAL_SETTINGS", path)
@@ -481,9 +482,9 @@ def get_local_settings_path() -> str | None:
         )
         return None
 
-    if not Path(local_settings).exists():
+    if not Path(local_settings).expanduser().is_file():
         warnings.warn(
-            f"The local settings path '{local_settings}' doesn't exist. As a result, "
+            f"The local settings path '{local_settings}' doesn't exist or is not a regular file. As a result, "
             f"the local settings for your project will not be loaded."
         )
 
@@ -519,7 +520,7 @@ def get_conf_repo_location() -> str | None:
         )
         return None
 
-    if not Path(location).exists():
+    if not Path(location).expanduser().exists():
         warnings.warn(f"The location of the configuration data repository doesn't exist: {location}.")
         return None
 
@@ -545,7 +546,7 @@ def set_conf_repo_location(location: str | Path | None):
         _env.set("CONF_REPO_LOCATION", None)
         return
 
-    if not Path(location).exists():
+    if not Path(location).expanduser().exists():
         warnings.warn(f"The location you provided for the environment variable {env_name} doesn't exist: {location}.")
 
     os.environ[env_name] = location
@@ -660,11 +661,11 @@ def main(args: list | None = None):  # pragma: no cover
 
         if value == NoValue():
             value = "[bold red]not set"
-        elif not value.startswith("/"):
+        elif not Path(value).expanduser().is_absolute():
             value = f"[default]{value} [bold orange3](this is a relative path!)"
-        elif not os.path.exists(value):
+        elif not Path(value).expanduser().exists():
             value = f"[default]{value} [bold red](location doesn't exist!)"
-        elif not os.path.isdir(value):
+        elif not Path(value).expanduser().is_dir():
             value = f"[default]{value} [bold red](location is not a directory!)"
         else:
             value = f"[default]{value}"
@@ -675,7 +676,7 @@ def main(args: list | None = None):  # pragma: no cover
 
         if not value:
             value = "[bold red]not set"
-        elif not os.path.exists(value):
+        elif not Path(value).expanduser().exists():
             value = f"[default]{value} [bold red](location doesn't exist!)"
         else:
             value = f"[default]{value}"
@@ -701,7 +702,7 @@ def main(args: list | None = None):  # pragma: no cover
         try:
             rich.print(f"    {get_data_storage_location() = }", flush=True, end="")
             location = get_data_storage_location()
-            if not Path(location).exists():
+            if not Path(location).expanduser().exists():
                 if args.mkdir:
                     rich.print(f"  [green]⟶ Creating data storage location: {location} (+ daily + obs)[/]")
                     Path(location).mkdir(parents=True)
@@ -717,7 +718,7 @@ def main(args: list | None = None):  # pragma: no cover
         try:
             rich.print(f"    {get_conf_data_location() = }", flush=True, end="")
             location = get_conf_data_location()
-            if not Path(location).exists():
+            if not Path(location).expanduser().exists():
                 if args.mkdir:
                     rich.print(f"  [green]⟶ Creating configuration data location: {location}[/]")
                     Path(location).mkdir(parents=True)
@@ -731,7 +732,7 @@ def main(args: list | None = None):  # pragma: no cover
         try:
             rich.print(f"    {get_conf_repo_location() = }", flush=True, end="")
             location = get_conf_repo_location()
-            if location is None or not Path(location).exists():
+            if location is None or not Path(location).expanduser().exists():
                 rich.print("  [red]⟶ ERROR: The configuration repository location doesn't exist![/]")
             else:
                 rich.print()
@@ -741,7 +742,7 @@ def main(args: list | None = None):  # pragma: no cover
         try:
             rich.print(f"    {get_log_file_location() = }", flush=True, end="")
             location = get_log_file_location()
-            if not Path(location).exists():
+            if not Path(location).expanduser().exists():
                 if args.mkdir:
                     rich.print(f"  [green]⟶ Creating log files location: {location}[/]")
                     Path(location).mkdir(parents=True)
@@ -755,7 +756,7 @@ def main(args: list | None = None):  # pragma: no cover
         try:
             rich.print(f"    {get_local_settings_path() = }", flush=True, end="")
             location = get_local_settings_path()
-            if location is None or not Path(location).exists():
+            if location is None or not Path(location).expanduser().exists():
                 rich.print("  [red]⟶ ERROR: The local settings file is not defined or doesn't exist![/]")
             else:
                 rich.print()

--- a/libs/cgse-common/src/egse/settings.py
+++ b/libs/cgse-common/src/egse/settings.py
@@ -197,7 +197,7 @@ def load_local_settings(force: bool = False) -> attrdict:
     local_settings_path = get_local_settings_path()
 
     if local_settings_path:
-        path = Path(local_settings_path)
+        path = Path(local_settings_path).expanduser()
         local_settings = load_settings_file(path.parent, path.name, force)
 
     return local_settings

--- a/libs/cgse-common/tests/test_env.py
+++ b/libs/cgse-common/tests/test_env.py
@@ -69,10 +69,16 @@ def test_get_data_storage_location():
     print_env()
 
 
-@pytest.mark.skip()
+# @pytest.mark.skip()
 def test_set_data_storage_location():
-    with env_var(PROJECT="PLATO"):
+    orig_location = get_data_storage_location()
+
+    with (
+        env_var(PROJECT="PLATO"),
+        env_var(PLATO_DATA_STORAGE_LOCATION="~/data/PLATO")
+    ):
         saved_location = get_data_storage_location()
+        assert saved_location.startswith("~/data/PLATO")
 
         with pytest.warns(UserWarning, match="PLATO_DATA_STORAGE_LOCATION"):
             set_data_storage_location("/tmp/data")
@@ -82,6 +88,11 @@ def test_set_data_storage_location():
         # Cleanup data storage location
 
         set_data_storage_location(saved_location)
+
+        saved_location = get_data_storage_location()
+        assert saved_location.startswith("~/data/PLATO")
+
+    assert get_data_storage_location() == orig_location
 
 
 def test_get_conf_data_location():

--- a/libs/cgse-core/.envrc.disabled
+++ b/libs/cgse-core/.envrc.disabled
@@ -1,9 +1,0 @@
-SITE=CSL2
-
-export PLATO_CONF_DATA_LOCATION=~/Documents/PyCharmProjects/plato-cgse-conf/data/${SITE}/conf
-export PLATO_CONF_REPO_LOCATION=~/Documents/PyCharmProjects/plato-cgse-conf
-export PLATO_DATA_STORAGE_LOCATION=~/data
-export PLATO_LOCAL_SETTINGS=~/cgse/local_settings.yaml
-
-export PYTHONSTARTUP=~/Documents/PyCharmProjects/plato-common-egse/startup.py
-


### PR DESCRIPTION
This pull request fixes two things:

1. the cgse commands and subcommands now use dotenv
2. the Path() that is read from environment variables now expands the `~` character to the users home directory