### PR TITLE
fix: change service discovery failure log to debug level when verbose debug is enabled

### DIFF
--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -363,7 +363,8 @@ class RegistryClient:
             service = response.get("service")
             return service
         else:
-            self.logger.warning(f"Service discovery failed: {response.get('error')}")
+            if VERBOSE_DEBUG:
+                self.logger.debug(f"Service discovery failed: {response.get('error')}")
             return None
 
     def get_service(self, service_id: str | None = None) -> dict[str, Any] | None:


### PR DESCRIPTION
The warning about a discovery when the service is not available is flooding the logs. The log message is put under VERBOSEDEBUG.