### PR TITLE
ReFactorTheRefactoring Issue #278

### DIFF
--- a/libs/cgse-coordinates/src/egse/coordinates/__init__.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/__init__.py
@@ -78,7 +78,7 @@ def dict_to_ref_model(model_def: Union[Dict, List]) -> navdict:
             deserialize_array(translation),
             deserialize_array(rotation),
             name=name,
-            reference_frame=ref_model[ref_name],
+            ref=ref_model[ref_name],
         )
 
         return ref_frame

--- a/libs/cgse-coordinates/src/egse/coordinates/point.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/point.py
@@ -27,7 +27,7 @@ class Point:
 
     """Representation of a point in 3D space, defined w.r.t. a given reference frame."""
 
-    def __init__(self, coordinates: np.ndarray | list, reference_frame: ReferenceFrame, name: str = None):
+    def __init__(self, coordinates: np.ndarray | list, ref: ReferenceFrame, name: str = None):
         """Initialisation of a point in 3D space, defined w.r.t. a given reference frame.
 
         In order to work with 4x4 transformation matrices, the 3D [x, y, z] coordinates are automatically converted to a
@@ -36,7 +36,7 @@ class Point:
         Args:
             coordinates (np.ndarray, list): 1x3 or 1x4 matrix defining this system in the given reference frame
                                             (1x3 being x, y, z + an additional 1 for the affine operations).
-            reference_frame (ReferenceFrame): Reference system in which this point object will be defined.
+            ref (ReferenceFrame): Reference system in which this point object will be defined.
             name (str): Name of the point. If not given, a random name will be generated. Note that there is no check
                         that the randomly generated name is unique, so two `Point` objects can be different but have
                         the same name.
@@ -56,10 +56,10 @@ class Point:
 
         # Reference frame
 
-        if reference_frame is None:
+        if ref is None:
             raise ValueError("The reference frame must not be None.")
         else:
-            self.reference_frame = reference_frame
+            self.ref = ref
 
         # Name
 
@@ -68,7 +68,7 @@ class Point:
 
         # Definition
 
-        self.definition = [self.coordinates[:-1], self.reference_frame, self.name]
+        self.definition = [self.coordinates[:-1], self.ref, self.name]
 
     def __repr__(self) -> str:
         """Returns a representation the point.
@@ -77,7 +77,7 @@ class Point:
             Representation of the point.
         """
 
-        return f"{self.coordinates[:-1]} (ref {self.reference_frame.name})"
+        return f"{self.coordinates[:-1]} (ref {self.ref.name})"
 
     def __str__(self) -> str:
         """Returns a printable string representation of the point.
@@ -86,7 +86,7 @@ class Point:
             Printable string representation of the point.
         """
 
-        return f"{self.coordinates[:-1]} (ref {self.reference_frame.name}), name {self.name}"
+        return f"{self.coordinates[:-1]} (ref {self.ref.name}), name {self.name}"
 
     def __eq__(self, other) -> bool:
         """Implements the == operator.
@@ -110,7 +110,7 @@ class Point:
         if isinstance(other, Point):
             if not np.array_equal(self.coordinates, other.coordinates):
                 return False
-            if self.reference_frame != other.reference_frame:
+            if self.ref != other.ref:
                 return False
             return True
 
@@ -138,7 +138,7 @@ class Point:
         if isinstance(other, Point):
             if self == other:
                 return True
-            if np.array_equal(self.coordinates, other.express_in(self.reference_frame)):
+            if np.array_equal(self.coordinates, other.express_in(self.ref)):
                 return True
 
         return False
@@ -195,20 +195,20 @@ class Point:
         self.y = self.coordinates[1]
         self.z = self.coordinates[2]
 
-    def get_coordinates(self, reference_frame: ReferenceFrame | None = None) -> np.ndarray:
+    def get_coordinates(self, ref: ReferenceFrame | None = None) -> np.ndarray:
         """Returns the coordinates of the point.
 
         Args:
-            reference_frame (ReferenceFrame | None): Reference frame in which the point coordinates are returned.
+            ref (ReferenceFrame | None): Reference frame in which the point coordinates are returned.
 
         Returns:
             Coordinates of the point in the given reference frame.
         """
 
-        if reference_frame is None:
+        if ref is None:
             return self.coordinates
         else:
-            return self.express_in(reference_frame)
+            return self.express_in(ref)
 
     def distance_to(self, target) -> floating[Any]:
         """Returns the distance from this point to the target.
@@ -226,7 +226,7 @@ class Point:
         from egse.coordinates.reference_frame import ReferenceFrame
 
         if isinstance(target, Point):
-            target_coordinates = target.express_in(self.reference_frame)[:3]
+            target_coordinates = target.express_in(self.ref)[:3]
         elif isinstance(target, ReferenceFrame):
             return np.linalg.norm(self.express_in(target)[:3])
         elif isinstance(target, (np.ndarray, list)):
@@ -257,7 +257,7 @@ class Point:
         from egse.coordinates.reference_frame import ReferenceFrame
 
         if isinstance(target, Point):
-            target_coordinates = target.express_in(self.reference_frame)
+            target_coordinates = target.express_in(self.ref)
         elif isinstance(target, ReferenceFrame):
             target_coordinates = target.get_origin().express_in(self)
         elif isinstance(target, (np.ndarray, list)):
@@ -277,21 +277,21 @@ class Point:
 
         return np.linalg.norm(self.coordinates[plane_selection[plane]] - target_coordinates[plane_selection[plane]])
 
-    def distance_to_plane(self, plane: str = "xy", reference_frame: ReferenceFrame | None = None) -> float:
+    def distance_to_plane(self, plane: str = "xy", ref: ReferenceFrame | None = None) -> float:
         """Calculates the distance from the point to a plane in a given reference frame.
 
         Args:
             plane (str): Target plane, must be in ["xy", "xz", "yz"]
-            reference_frame (ReferenceFrame | None, optional): Reference frame in which the distance is calculated.
+            ref (ReferenceFrame | None, optional): Reference frame in which the distance is calculated.
 
         Returns:
             Distance from the point to the plane.
         """
 
-        if (reference_frame is None) or (self.reference_frame == reference_frame):
+        if (ref is None) or (self.ref == ref):
             coordinates = self.coordinates[:-1]
         else:
-            coordinates = self.express_in(reference_frame)
+            coordinates = self.express_in(ref)
 
         out_of_plane_index = {"xy": 2, "xz": 1, "yz": 0}
 
@@ -308,7 +308,7 @@ class Point:
         """
 
         if isinstance(point, Point):
-            if point.reference_frame != self.reference_frame:
+            if point.ref != self.ref:
                 raise NotImplementedError("The points have different reference frames")
 
             new_coordinates = self.coordinates - point.coordinates
@@ -323,7 +323,7 @@ class Point:
 
         new_coordinates[-1] = 1
 
-        return Point(coordinates=new_coordinates, reference_frame=self.reference_frame)
+        return Point(coordinates=new_coordinates, ref=self.ref)
 
     def __isub__(self, point):
         """Implements the subtraction assignment operator (-=).
@@ -339,7 +339,7 @@ class Point:
         """
 
         if isinstance(point, Point):
-            if point.reference_frame != self.reference_frame:
+            if point.ref != self.ref:
                 raise NotImplementedError("The points have different reference frames")
 
             new_coordinates = self.coordinates - point.coordinates
@@ -371,7 +371,7 @@ class Point:
         """
 
         if isinstance(point, Point):
-            if point.reference_frame != self.reference_frame:
+            if point.ref != self.ref:
                 raise NotImplementedError("The points have different reference frames")
 
             new_coordinates = self.coordinates + point.coordinates
@@ -386,7 +386,7 @@ class Point:
 
         new_coordinates[-1] = 1
 
-        return Point(coordinates=new_coordinates, reference_frame=self.reference_frame)
+        return Point(coordinates=new_coordinates, ref=self.ref)
 
     def __iadd__(self, point):
         """Implements the addition assignment operator (+=).
@@ -402,7 +402,7 @@ class Point:
         """
 
         if isinstance(point, Point):
-            if point.reference_frame != self.reference_frame:
+            if point.ref != self.ref:
                 raise NotImplementedError("The points have different reference frames")
 
             new_coordinates = self.coordinates + point.coordinates
@@ -430,19 +430,21 @@ class Point:
             Coordinates in the target reference frame.
         """
 
-        if target_frame == self.reference_frame:
+        if target_frame == self.ref:
             result = self.coordinates
 
         else:
-            # Apply coordinate transformation of self.coordinates from self.reference_frame to target_frame
-            transform = self.reference_frame.get_passive_transformation_to(target_frame)
+            # We're after the coordinates of self, i.e. the definition of self in targetFrame
+            # We know the coordinates in self.ref
+            # Apply coordinate transformation of self.coordinates from self.ref to target_frame
+            transform = self.ref.get_passive_transformation_to(target_frame)
             result = np.dot(transform, self.coordinates)
 
             LOGGER.debug(f"transform: \n{transform}")
 
         return result
 
-    def change_reference_frame(self, target_frame: ReferenceFrame):
+    def change_ref(self, target_frame: ReferenceFrame):
         """Re-defines `self` as attached to another reference frame.
 
         This is done by:
@@ -457,7 +459,7 @@ class Point:
         new_coordinates = self.express_in(target_frame)
         self.set_coordinates(new_coordinates)
 
-        self.reference_frame = target_frame
+        self.ref = target_frame
 
 
 class Points:
@@ -467,16 +469,18 @@ class Points:
 
     debug = 0
 
-    def __init__(self, coordinates: numpy.ndarray | list, reference_frame: ReferenceFrame, name: str = None):
+    def __init__(self, coordinates: numpy.ndarray | list, ref: ReferenceFrame, name: str = None):
         """Initialisation of a new set of points.
 
         Args:
             coordinates (numpy.ndarray | list): Either a 4xn matrix (3 being x, y, z + an additional 1 for the affine
                                                 operations), defining n coordinates in the given reference frame, or a
                                                 list of Point(s) objects.
-            reference_frame (ReferenceFrame): Reference frame in which the coordinates are defined.
+            ref (ReferenceFrame): Reference frame in which the coordinates are defined.
             name (str | None): Name of the Points object.  When None, a name will be generated automatically, consisting
                                of a capital "P" followed by three lower case letters.
+
+        TODO : TEST. THIS METHOD WAS HEAVILY MODIFIED IN THE REFACTORING FROM PLATO.
         """
 
         # Coordinates
@@ -491,9 +495,10 @@ class Points:
 
             for item in coordinates:
                 if isinstance(item, Point):
-                    coordinate_list.append(item.express_in(reference_frame))
+                    coordinate_list.append(item.express_in(ref))
                 elif isinstance(item, Points):
-                    coordinate_list.extend(item.express_in(reference_frame))
+                    # TODO : TEST. WASN'T IN PLATO CODE. Does it contain all points in the Points object ?
+                    coordinate_list.extend(item.express_in(ref))
                 else:
                     raise ValueError("If the input is a list, all items in it must be Point(s) objects")
             self.set_coordinates(np.array(coordinate_list).T)
@@ -504,10 +509,10 @@ class Points:
 
         # Reference frame
 
-        if reference_frame is None:
+        if ref is None:
             raise ValueError("The reference frame must not be None.")
         else:
-            self.reference_frame = reference_frame
+            self.ref = ref
 
         # Name
 
@@ -521,7 +526,7 @@ class Points:
             Representation of the points.
         """
 
-        return "{0} (ref {1})".format(self.coordinates[:-1], self.reference_frame.name)
+        return "{0} (ref {1})".format(self.coordinates[:-1], self.ref.name)
 
     def __str__(self) -> str:
         """Returns a printable string representation of the point.
@@ -530,7 +535,7 @@ class Points:
             Printable string representation of the point.
         """
 
-        return "{1} (ref {2}), name {0}".format(self.name, self.coordinates[:-1], self.reference_frame.name)
+        return "{1} (ref {2}), name {0}".format(self.name, self.coordinates[:-1], self.ref.name)
 
     @staticmethod
     def __coords__(coordinates):
@@ -589,20 +594,20 @@ class Points:
         self.y = self.coordinates[1, :]
         self.z = self.coordinates[2, :]
 
-    def get_coordinates(self, reference_frame: ReferenceFrame | None = None) -> numpy.ndarray:
+    def get_coordinates(self, ref: ReferenceFrame | None = None) -> numpy.ndarray:
         """Returns the coordinates of the point.
 
         Args:
-            reference_frame (ReferenceFrame | None): Reference frame in which the point coordinates are returned.
+            ref (ReferenceFrame | None): Reference frame in which the point coordinates are returned.
 
         Returns:
             Coordinates of the point in the given reference frame.
         """
 
-        if reference_frame is None:
+        if ref is None:
             return self.coordinates
         else:
-            return self.express_in(reference_frame)
+            return self.express_in(ref)
 
     def express_in(self, target_frame: ReferenceFrame) -> np.ndarray:
         """Expresses the coordinates in another reference frame.
@@ -614,17 +619,17 @@ class Points:
             Coordinates in the target reference frame.
         """
 
-        if target_frame == self.reference_frame:
+        if target_frame == self.ref:
             result = self.coordinates
         else:
-            # Apply coordinate transformation of self.coordinates from self.reference_frame to target_frame
-            transform = self.reference_frame.get_passive_transformation_to(target_frame)
+            # Apply coordinate transformation of self.coordinates from self.ref to target_frame
+            transform = self.ref.get_passive_transformation_to(target_frame)
             if self.debug:
                 print("transform \n{0}".format(transform))
             result = np.dot(transform, self.coordinates)
         return result
 
-    def change_reference_frame(self, target_frame: ReferenceFrame):
+    def change_ref(self, target_frame: ReferenceFrame):
         """Re-defines `self` as attached to another reference frame.
 
         This is done by:
@@ -639,7 +644,7 @@ class Points:
         new_coordinates = self.express_in(target_frame)
         self.set_coordinates(new_coordinates)
 
-        self.reference_frame = target_frame
+        self.ref = target_frame
 
     def get_num_points(self) -> int:
         """Returns the number of points in the set of points.
@@ -661,7 +666,7 @@ class Points:
             Point with the given index.
         """
 
-        return Point(self.coordinates[:, index], reference_frame=self.reference_frame, name=name)
+        return Point(self.coordinates[:, index], ref=self.ref, name=name)
 
     get = get_point
 
@@ -686,7 +691,7 @@ class Points:
 
         a, b, c = self.fit_plane(plane=plane, verbose=verbose)
 
-        unit_axes = Points.from_plane_parameters(a, b, c, reference_frame=self.reference_frame, plane=plane)
+        unit_axes = Points.from_plane_parameters(a, b, c, ref=self.ref, plane=plane)
         # print(f"Unit axes coordinates \n{np.round(unit_axes.coordinates,3)}")
 
         # unit_axes contain 3 unit axes and an origin
@@ -696,11 +701,11 @@ class Points:
         for ax in range(3):
             unit_coordinates[:3, ax] += unit_coordinates[:3, 3]
 
-        new_axes = Points(unit_coordinates, reference_frame=self.reference_frame)
+        new_axes = Points(unit_coordinates, ref=self.ref)
 
         # print(f"new_axes {np.round(new_axes.coordinates,3)}")
 
-        self_axes = Points(np.identity(4), reference_frame=self.reference_frame)
+        self_axes = Points(np.identity(4), ref=self.ref)
 
         transform = t3add.affine_matrix_from_points(
             self_axes.coordinates[:3, :], new_axes.coordinates[:3, :], shear=False, scale=False, use_svd=use_svd
@@ -715,7 +720,7 @@ class Points:
                 print(f"Transform2 \n{np.round(transform2, 3)}")
                 print(f"Both methods consistent ? {np.allclose(transform, transform2)}")
 
-        return ReferenceFrame(transformation=transform, reference_frame=self.reference_frame)
+        return ReferenceFrame(transformation=transform, ref=self.ref)
 
     def fit_plane(self, plane: str = "xy", verbose: bool = True) -> tuple[float, float, float]:
         """Fits the plane best fitting the points.
@@ -754,7 +759,7 @@ class Points:
 
     @classmethod
     def from_plane_parameters(
-        cls, a: float, b: float, c: float, reference_frame: ReferenceFrame, plane: str = "xy", verbose: bool = False
+        cls, a: float, b: float, c: float, ref: ReferenceFrame, plane: str = "xy", verbose: bool = False
     ):
         """Returns the unit axes and the origin of the given reference frame.
 
@@ -762,7 +767,7 @@ class Points:
             a (float): Coefficient `a` in the equation of the target plane (z = ax + by + c)
             b (float): Coefficient `b` in the equation of the target plane (z = ax = by + c)
             c (float): Coefficient `c` in the equation of the target plane (z = ax + by + c)
-            reference_frame (ReferenceFrame): Reference frame.
+            ref (ReferenceFrame): Reference frame.
             plane (str): Plane to fit. Must be in ["xy", "yz", "zx"].
             verbose (bool): If True, print the results on screen.
 
@@ -819,10 +824,10 @@ class Points:
         y_unit_coords = np.cross(z_unit_coords, x_unit_coords)
         y_unit_coords /= np.linalg.norm(y_unit_coords)  # Normalise
 
-        x_unit_point = Point(x_unit_coords, reference_frame=reference_frame)
-        y_unit_point = Point(y_unit_coords, reference_frame=reference_frame)
-        z_unit_point = Point(z_unit_coords, reference_frame=reference_frame)
-        origin = Point(origin_coords, reference_frame=reference_frame)
+        x_unit_point = Point(x_unit_coords, ref=ref)
+        y_unit_point = Point(y_unit_coords, ref=ref)
+        z_unit_point = Point(z_unit_coords, ref=ref)
+        origin = Point(origin_coords, ref=ref)
 
         if verbose:
             print(f"x_unit_coords  {x_unit_coords}")
@@ -830,4 +835,4 @@ class Points:
             print(f"z_unit_coords  {z_unit_coords}")
             print(f"origin_coords {origin_coords}")
 
-        return cls([x_unit_point, y_unit_point, z_unit_point, origin], reference_frame=reference_frame)
+        return cls([x_unit_point, y_unit_point, z_unit_point, origin], ref=ref)

--- a/libs/cgse-coordinates/src/egse/coordinates/reference_frame.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/reference_frame.py
@@ -63,8 +63,8 @@ class ReferenceFrame(object):
     :param transformation: 4x4 affine transformation matrix defining this system in "ref" system
     :type transformation: numpy array
 
-    :param reference_frame: reference system in which this new reference frame is defined
-    :type reference_frame: ReferenceFrame
+    :param ref: reference system in which this new reference frame is defined
+    :type ref: ReferenceFrame
 
     :param name: name the reference frame so it can be referenced, set to 'master' when None
     :type name: str
@@ -108,14 +108,14 @@ class ReferenceFrame(object):
     _ACTIVE_DEFAULT = True
 
     def __init__(
-        self, transformation: np.ndarray | None, reference_frame, name=None, rotation_config=_ROT_CONFIG_DEFAULT
+        self, transformation: np.ndarray | None, ref, name=None, rotation_config=_ROT_CONFIG_DEFAULT
     ):
         """Initialization of a new reference frame.
 
         Args:
             transformation (np.ndarray | None): 4x4 affine transformation matrix defining this system in the given
                                                 reference frame.
-            reference_frame:
+            ref:
             name (str | None): Name of the reference frame.
             rotation_config (str): Order in which the rotation about the three axes are chained.
         """
@@ -123,17 +123,17 @@ class ReferenceFrame(object):
         self.debug = False
 
         DEBUG and LOGGER.debug(
-            f"transformation={transformation_to_string(transformation)}, reference_frame={reference_frame!r}, name={name}, rot_config={rotation_config}"
+            f"transformation={transformation_to_string(transformation)}, ref={ref!r}, name={name}, rot_config={rotation_config}"
         )
 
         # All argument testing is done in the __new__() method and we should be save here.
 
-        self.reference_frame = reference_frame
+        self.ref = ref
         self.name = self.__create_name(name)
         self.transformation = transformation
         self.rotation_config = rotation_config
 
-        self.definition = [self.transformation, self.reference_frame, self.name]
+        self.definition = [self.transformation, self.ref, self.name]
 
         self.x = self.get_axis("x")
         self.y = self.get_axis("y")
@@ -142,7 +142,7 @@ class ReferenceFrame(object):
         self.linked_to = {}
         self.reference_for = []
 
-        reference_frame.reference_for.append(self)
+        ref.reference_for.append(self)
 
         return
 
@@ -204,7 +204,7 @@ class ReferenceFrame(object):
         frame = self
 
         while not frame.is_master():
-            frame = frame.reference_frame
+            frame = frame.ref
 
         return frame
 
@@ -219,7 +219,7 @@ class ReferenceFrame(object):
 
         master_frame = super(ReferenceFrame, cls).__new__(cls)
         master_frame.name = "Master"
-        master_frame.reference_frame = master_frame
+        master_frame.ref = master_frame
         master_frame.transformation = cls._I
         master_frame.rotation_config = cls._ROT_CONFIG_DEFAULT
         master_frame.initialized = True
@@ -228,7 +228,7 @@ class ReferenceFrame(object):
         master_frame.reference_for = []
 
         DEBUG and LOGGER.debug(
-            f"NEW MASTER CREATED: {id(master_frame)}, reference_frame = {id(master_frame.reference_frame)}, name = {master_frame.name}"
+            f"NEW MASTER CREATED: {id(master_frame)}, ref = {id(master_frame.ref)}, name = {master_frame.name}"
         )
 
         return master_frame
@@ -274,7 +274,7 @@ class ReferenceFrame(object):
 
     @classmethod
     def from_translation(
-        cls, translation_x: float, translation_y: float, translation_z: float, reference_frame, name: str = None
+        cls, translation_x: float, translation_y: float, translation_z: float, ref, name: str = None
     ):
         """Creates a reference frame from a translation w.r.t. the given reference frame.
 
@@ -282,7 +282,7 @@ class ReferenceFrame(object):
              translation_x (float): Translation along the x-axis.
              translation_y (float): Translation along the y-axis.
              translation_z (float): Translation along the z-axis.
-             reference_frame (ReferenceFrame): Reference frame w.r.t. which the translation is performed.
+             ref (ReferenceFrame): Reference frame w.r.t. which the translation is performed.
              name (str): Simple, convenient name to identify the reference frame. If no name is provided, a random name
                          of  four characters starting with 'F' will be generated.
 
@@ -293,12 +293,12 @@ class ReferenceFrame(object):
         affine_matrix = np.identity(4)
         affine_matrix[:3, 3] = [translation_x, translation_y, translation_z]
 
-        if reference_frame is None:
+        if ref is None:
             raise ValueError(
-                "The reference_frame argument can not be None, provide a master or another reference frame."
+                "The ref argument can not be None, provide a master or another reference frame."
             )
 
-        return cls(transformation=affine_matrix, reference_frame=reference_frame, name=name)
+        return cls(transformation=affine_matrix, ref=ref, name=name)
 
     @classmethod
     def from_rotation(
@@ -306,7 +306,7 @@ class ReferenceFrame(object):
         rotation_x: float,
         rotation_y: float,
         rotation_z: float,
-        reference_frame,
+        ref,
         name: str = None,
         rotation_config: str = _ROT_CONFIG_DEFAULT,
         active: bool = _ACTIVE_DEFAULT,
@@ -318,7 +318,7 @@ class ReferenceFrame(object):
             rotation_x (float): Rotation angle about the x-axis.
             rotation_y (float): Rotation angle about the y-axis.
             rotation_z (float): Rotation angle about the z-axis.
-            reference_frame (ReferenceFrame): Reference frame w.r.t. which the rotation is performed.
+            ref (ReferenceFrame): Reference frame w.r.t. which the rotation is performed.
             name (str): Simple, convenient name to identify the reference frame. If no name is provided, a random name
                         of  four characters starting with 'F' will be generated.
             rotation_config (str): Order in which the rotation about the three axes are chained.
@@ -341,13 +341,13 @@ class ReferenceFrame(object):
 
         transformation = t3.affines.compose(T=translation, R=rotation_matrix.rotation_matrix, Z=zoom, S=shear)
 
-        if reference_frame is None:
+        if ref is None:
             raise ValueError(
-                "The reference_frame argument can not be None, provide a master or another reference frame."
+                "The ref argument can not be None, provide a master or another reference frame."
             )
 
         return cls(
-            transformation=transformation, reference_frame=reference_frame, name=name, rotation_config=rotation_config
+            transformation=transformation, ref=ref, name=name, rotation_config=rotation_config
         )
 
     @staticmethod
@@ -371,7 +371,7 @@ class ReferenceFrame(object):
         cls,
         translation: np.ndarray,
         rotation: np.ndarray,
-        reference_frame,
+        ref,
         name: str = None,
         rotation_config: str = _ROT_CONFIG_DEFAULT,
         active: bool = _ACTIVE_DEFAULT,
@@ -384,7 +384,7 @@ class ReferenceFrame(object):
             rotation (np.ndarray): Rotation vector: 3x1: rx, ry, rz.
 
 
-            reference_frame (ReferenceFrame): Reference frame w.r.t. which the rotation is performed.
+            ref (ReferenceFrame): Reference frame w.r.t. which the rotation is performed.
             name (str): Simple, convenient name to identify the reference frame. If no name is provided, a random name
                         of  four characters starting with 'F' will be generated.
             rotation_config (str): Order in which the rotation about the three axes are chained.
@@ -404,14 +404,14 @@ class ReferenceFrame(object):
             rotation_x, rotation_y, rotation_z, rotation_config=rotation_config, active=active
         )
 
-        if reference_frame is None:
+        if ref is None:
             raise ValueError(
-                "The reference_frame argument can not be None, provide a master or another reference frame."
+                "The ref argument can not be None, provide a master or another reference frame."
             )
 
         return cls(
             transformation=t3.affines.compose(translation, rotation_matrix.rotation_matrix, Z=zoom, S=shear),
-            reference_frame=reference_frame,
+            ref = ref,
             name=name,
             rotation_config=rotation_config,
         )
@@ -479,7 +479,7 @@ class ReferenceFrame(object):
 
         return (
             f"ReferenceFrame(transformation={transformation_to_string(self.transformation)}, "
-            f"reference_frame={self.reference_frame.name}, name={self.name}, rotation_config={self.rotation_config})"
+            f"ref={self.ref.name}, name={self.name}, rotation_config={self.rotation_config})"
         )
 
     def __str__(self) -> str:
@@ -493,7 +493,7 @@ class ReferenceFrame(object):
             f"""\
                 ReferenceFrame
                 name          : {self.name}
-                reference     : {self.reference_frame.name}
+                reference     : {self.ref.name}
                 rotation_config    : {self.rotation_config}
                 links         : {[key.name for key in self.linked_to.keys()]}
                 transformation:
@@ -539,7 +539,7 @@ class ReferenceFrame(object):
         # TODO:
         #   remove the _stop keyword
 
-        # TODO: deprecate transformation as an input variable
+        # (TODO) / DONE: deprecate transformation as an input variable
         #       linkedTo can become a list of reference frames, with no transformation
         #       associated to the link. The tfo associated to a link is already
         #       checked in real time whenever the link is addressed
@@ -549,7 +549,7 @@ class ReferenceFrame(object):
             if DEBUG:
                 LOGGER.info(
                     "Deprecation warning: transformation will be automatically set to "
-                    "the current relation between {self.name} and {ref.name}"
+                    f"the current relation between {self.name} and {reference_frame.name}"
                 )
                 LOGGER.debug("Requested:")
                 LOGGER.debug(np.round(transformation, decimals=3))
@@ -562,7 +562,7 @@ class ReferenceFrame(object):
         self.linked_to[reference_frame] = transformation
 
         # TODO simplify this when transformation is deprecated
-        #      it becomes ref.linked_to[self] = ref.get_active_transformation_to(self)
+        #      it becomes reference_frame.linked_to[self] = reference_frame.get_active_transformation_to(self)
         reference_frame.linked_to[self] = t3add.affine_inverse(transformation)
 
     def remove_link(self, reference_frame) -> None:
@@ -603,27 +603,27 @@ class ReferenceFrame(object):
             DEBUG and LOGGER.debug("case 1")
             result = np.identity(4)
 
-        elif target_frame.reference_frame is self:
+        elif target_frame.ref is self:
             # The target frame is defined in self -> The requested transformation is the target frame definition
             DEBUG and LOGGER.debug("=== 2 start ===")
             result = t3add.affine_inverse(target_frame.transformation)
             DEBUG and LOGGER.debug("=== 2 end   ===")
-        elif target_frame.reference_frame is self.reference_frame:
+        elif target_frame.ref is self.ref:
             # target_frame and self are defined wrt the same reference frame
             # We want
             #   self --> target_frame
             # We know
-            #   target_frame.reference_frame --> target_frame (= target_frame.transformation)
-            #   self.reference_frame   --> self   (= self.transformation)
+            #   target_frame.ref --> target_frame (= target_frame.transformation)
+            #   self.ref   --> self   (= self.transformation)
             # That is
-            #   self --> self.reference_frame is target_frame.reference_frame --> target_frame
+            #   self --> self.ref is target_frame.ref --> target_frame
             #   inverse(definition)    target_frame definition
 
             # Both reference frames are defined w.r.t. the same reference frame
 
             if DEBUG:
                 LOGGER.debug("=== 3 start ===")
-                LOGGER.debug(" ref   \n{0}".format(self.reference_frame))
+                LOGGER.debug(" ref   \n{0}".format(self.ref))
                 LOGGER.debug("===")
                 LOGGER.debug("self   \n{0}".format(self))
                 LOGGER.debug("===")
@@ -642,19 +642,19 @@ class ReferenceFrame(object):
         else:
             # We are after the transformation from
             #   self --> target_frame
-            #   self --> self.reference_frame --> target_frame.reference_frame --> target_frame
+            #   self --> self.ref --> target_frame.ref --> target_frame
             #
             # We know
-            #   target_frame.reference_frame --> target_frame (target_frame.transformation)
-            #   self.reference_frame        --> self (self.transformation)
+            #   target_frame.ref --> target_frame (target_frame.transformation)
+            #   self.ref        --> self (self.transformation)
             # but
-            #   target_frame.reference_frame != self.reference_frame
+            #   target_frame.ref != self.ref
             # so we need
-            #   self.reference_frame --> target_frame.reference_frame
+            #   self.ref --> target_frame.ref
             # then we can compose
-            # self --> self.reference_frame --> target_frame.reference_frame --> target_frame
+            # self --> self.ref --> target_frame.ref --> target_frame
             #
-            # Note: the transformation self.reference_frame --> target_frame.reference_frame is acquired recursively
+            # Note: the transformation self.ref --> target_frame.ref is acquired recursively
             #       This relies on the underlying assumption that there exists
             #       one unique reference frame that source and self can be linked to
             #       (without constraints on the number of links necessary), i.e.
@@ -665,7 +665,7 @@ class ReferenceFrame(object):
 
             DEBUG and LOGGER.debug("=== 4 start ===")
             self_to_ref = self.transformation
-            self_ref_to_target_ref = self.reference_frame.get_passive_transformation_to(target_frame.reference_frame)
+            self_ref_to_target_ref = self.ref.get_passive_transformation_to(target_frame.ref)
             ref_to_target = t3add.affine_inverse(target_frame.transformation)
             result = np.dot(ref_to_target, np.dot(self_ref_to_target_ref, self_to_ref))
             DEBUG and LOGGER.debug("=== 4 end   ===")
@@ -927,7 +927,7 @@ class ReferenceFrame(object):
             if verbose and level:
                 level += 1
 
-            if frame.reference_frame not in frame.linked_to:
+            if frame.ref not in frame.linked_to:
                 ends.append(frame)
                 DEBUG and LOGGER.debug(f"{(10 + 2 * level) * ' '}{frame.name}: new end")
                 # if verbose: LOGGER.info(f"{(10+2*level)*' '}{frame.name}: new end")
@@ -935,11 +935,11 @@ class ReferenceFrame(object):
             for linked_frame in frame.linked_to:
                 ends, visited = self._find_ends(linked_frame, visited=visited, ends=ends, verbose=verbose, level=level)
 
-        # If frame.reference_frame was linked to frame via an indirect route, reject it
+        # If frame.ref was linked to frame via an indirect route, reject it
 
         final_ends = []
         for aframe in ends:
-            if aframe.reference_frame not in ends:
+            if aframe.ref not in ends:
                 final_ends.append(aframe)
 
         return final_ends, visited
@@ -1013,12 +1013,8 @@ class ReferenceFrame(object):
         if not relative:
             # virtual = what self should become after the (absolute) movement
             # it allows to compute the relative transformation to be applied and work in relative further down
-            virtual = ReferenceFrame(
-                transformation,
-                reference_frame=self.reference_frame,
-                name="virtual",
-                rotation_config=self.rotation_config,
-            )
+            virtual = ReferenceFrame(transformation, ref=self.ref, name="virtual",
+                                     rotation_config=self.rotation_config)
             request = self.get_active_transformation_to(virtual)
             del virtual
         else:
@@ -1060,29 +1056,21 @@ class ReferenceFrame(object):
         to_restore = {}
 
         for frame in impacted:
-            to_restore[frame] = ReferenceFrame(
-                frame.get_active_transformation_from(temp_master),
-                reference_frame=temp_master,
-                name=frame.name + "to_restore",
-                rotation_config=frame.rotation_config,
-            )
+            to_restore[frame] = ReferenceFrame(frame.get_active_transformation_from(temp_master), ref=temp_master,
+                                               name=frame.name + "to_restore", rotation_config=frame.rotation_config)
 
         # BLOCK A. apply the right transformation to all "endFrames"
 
         # Ensure that `untouched` remains unaffected regardless of the update order of the end_frames
         # self_untouched = ReferenceFrame(
         #     transformation = self.get_active_transformation_from(temp_master),
-        #     reference_frame=temp_master,
+        #     ref=temp_master,
         #     name=self.name + "_fixed",
         #     rotation_config=self.rotation_config,
         # )
 
-        self_untouched = ReferenceFrame(
-            transformation=self.transformation,
-            reference_frame=self.reference_frame,
-            name=self.name + "_fixed",
-            rotation_config=self.rotation_config,
-        )
+        self_untouched = ReferenceFrame(transformation=self.transformation, ref=self.ref,
+                                        name=self.name + "_fixed", rotation_config=self.rotation_config)
 
         for bottom in end_frames:
             up = bottom.get_active_transformation_to(self_untouched)
@@ -1123,7 +1111,7 @@ class ReferenceFrame(object):
         # Direct restoration or the impacted frames at their original location
 
         for frame in to_restore:
-            frame.transformation = frame.reference_frame.get_active_transformation_to(to_restore[frame])
+            frame.transformation = frame.ref.get_active_transformation_to(to_restore[frame])
 
         del to_restore
 
@@ -1249,7 +1237,7 @@ class ReferenceFrame(object):
             name = self.name + axis
         from egse.coordinates.point import Point
 
-        return Point(unit_vectors[axis], reference_frame=self, name=name)
+        return Point(unit_vectors[axis], ref=self, name=name)
 
     def get_normal(self, name: str | None = None):
         """Returns a unit vector, normal to the xy-plane.
@@ -1266,7 +1254,7 @@ class ReferenceFrame(object):
         """
         from egse.coordinates.point import Point
 
-        return Point([0, 0, 1], reference_frame=self, name=name)
+        return Point([0, 0, 1], ref=self, name=name)
 
     def get_origin(self, name: str | None = None):
         """Returns the origin in `self`.
@@ -1282,7 +1270,7 @@ class ReferenceFrame(object):
 
         from egse.coordinates.point import Point
 
-        return Point([0, 0, 0], reference_frame=self, name=name)
+        return Point([0, 0, 0], ref=self, name=name)
 
     def is_master(self) -> bool:
         """Checks whether this reference frame is a master reference frame.
@@ -1293,7 +1281,7 @@ class ReferenceFrame(object):
         transformation = self.transformation
 
         return (
-            (self.name == self.reference_frame.name)
+            (self.name == self.ref.name)
             and (transformation.shape[0] == transformation.shape[1])
             and np.allclose(transformation, np.eye(transformation.shape[0]))
         )
@@ -1330,13 +1318,13 @@ class ReferenceFrame(object):
                 return False
             # The following tests are here to prevent recursion to go infinite when self and other
             # point to itself
-            if self.reference_frame is self and other.reference_frame is other:
-                DEBUG and LOGGER.debug("both self.reference_frame and other.reference_frame point to themselves")
+            if self.ref is self and other.ref is other:
+                DEBUG and LOGGER.debug("both self.ref and other.ref point to themselves")
                 pass
             else:
-                DEBUG and LOGGER.debug("one of self.reference_frame or other.ref doesn't points to itself")
-                if self.reference_frame != other.reference_frame:
-                    DEBUG and LOGGER.debug("self.reference_frame not equals other.reference_frame")
+                DEBUG and LOGGER.debug("one of self.ref or other.ref doesn't points to itself")
+                if self.ref != other.ref:
+                    DEBUG and LOGGER.debug("self.ref not equals other.ref")
                     return False
             if self.name is not other.name:
                 DEBUG and LOGGER.debug(
@@ -1379,13 +1367,13 @@ class ReferenceFrame(object):
                 return False
             # The following tests are here to prevent recursion to go infinite when self and other
             # point to itself
-            if self.reference_frame is self and other.reference_frame is other:
-                DEBUG and LOGGER.debug("both self.reference_frame and other.reference_frame point to themselves")
+            if self.ref is self and other.ref is other:
+                DEBUG and LOGGER.debug("both self.ref and other.ref point to themselves")
                 pass
             else:
-                DEBUG and LOGGER.debug("one of self.reference_frame or other.ref doesn't points to itself")
-                if self.reference_frame != other.reference_frame:
-                    DEBUG and LOGGER.debug("self.ref not equals other.reference_frame")
+                DEBUG and LOGGER.debug("one of self.ref or other.ref doesn't points to itself")
+                if self.ref != other.ref:
+                    DEBUG and LOGGER.debug("self.ref not equals other.ref")
                     return False
             if self.name is not other.name:
                 DEBUG and LOGGER.debug(
@@ -1400,7 +1388,7 @@ class ReferenceFrame(object):
     def __hash__(self):
         """Overrides the default implementation."""
 
-        hash_number = (id(self.rotation_config) + id(self.reference_frame) + id(self.name)) // 16
+        hash_number = (id(self.rotation_config) + id(self.ref) + id(self.name)) // 16
         return hash_number
 
     def __copy__(self):
@@ -1414,4 +1402,4 @@ class ReferenceFrame(object):
             DEBUG and LOGGER.debug(f"Returning Master itself instead of a copy.")
             return self
 
-        return ReferenceFrame(self.transformation, self.reference_frame, self.name, self.rotation_config)
+        return ReferenceFrame(self.transformation, self.ref, self.name, self.rotation_config)

--- a/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
@@ -142,7 +142,7 @@ class ReferenceFrameModel:
         result = f"Number of frames: {len(self)}\n"
 
         for reference_frame in self:
-            result += f"{reference_frame.name:>10}[{reference_frame.reference_frame.name}]  ---  {[link.name for link in reference_frame.linked_to]}\n"
+            result += f"{reference_frame.name:>10}[{reference_frame.ref.name}]  ---  {[link.name for link in reference_frame.linked_to]}\n"
 
         return result
 
@@ -191,7 +191,7 @@ class ReferenceFrameModel:
         translation: np.ndarray = None,
         rotation: np.ndarray = None,
         transformation: np.ndarray = None,
-        reference: str,
+        ref: str,
     ) -> None:
         """Adds a reference frame to the model.
 
@@ -201,7 +201,7 @@ class ReferenceFrameModel:
             translation (np.ndarray): Translation vector. Ignored when `transformation` is given.
             rotation (np.ndarray: Rotation vector. Ignored when `transformation` is given.
             transformation (np.ndarray): Transformation matrix.
-            reference (str): Name of the reference frame that is a reference for the new reference frame, i.e. the new
+            ref (str): Name of the reference frame that is a reference for the new reference frame, i.e. the new
                              reference frame is defined w.r.t. this one.
         """
 
@@ -210,21 +210,17 @@ class ReferenceFrameModel:
         if name in self._model:
             raise KeyError("A reference frame with the name '{name} already exists in the model.")
 
-        reference = self._model[reference]
+        ref = self._model[ref]
 
         if transformation:
-            self._model[name] = ReferenceFrame(
-                transformation,
-                reference_frame=reference,
-                name=name,
-                rotation_config=self._rot_config,
-            )
+            self._model[name] = ReferenceFrame(transformation, ref=ref, name=name,
+                                               rotation_config=self._rot_config)
         else:
             self._model[name] = ReferenceFrame.from_translation_rotation(
                 translation,
                 rotation,
                 name=name,
-                reference_frame=reference,
+                ref=ref,
                 rotation_config=self._rot_config,
                 degrees=self._use_degrees,
                 active=self._use_active_movements,
@@ -369,9 +365,8 @@ class ReferenceFrameModel:
 
         from egse.coordinates.reference_frame import ReferenceFrame
 
-        moving_in_other = ReferenceFrame(
-            transformation, rotation_config=self._rot_config, reference_frame=other, name="moving_in_other"
-        )
+        moving_in_other = ReferenceFrame(transformation, ref=other, name="moving_in_other",
+                                         rotation_config=self._rot_config)
 
         moving_in_other.add_link(frame)
 
@@ -443,9 +438,8 @@ class ReferenceFrameModel:
 
         from egse.coordinates.reference_frame import ReferenceFrame
 
-        moving_in_other = ReferenceFrame(
-            transformation, rotation_config=self._rot_config, reference_frame=other, name="moving_in_other"
-        )
+        moving_in_other = ReferenceFrame(transformation, ref=other, name="moving_in_other",
+                                         rotation_config=self._rot_config)
 
         moving_in_other.add_link(frame)
 
@@ -736,10 +730,10 @@ def define_the_initial_setup() -> ReferenceFrameModel:
     model = ReferenceFrameModel()
 
     model.add_master_frame()
-    model.add_frame("A", translation=[2, 2, 2], rotation=[0, 0, 0], reference="Master")
-    model.add_frame("B", translation=[-2, 2, 2], rotation=[0, 0, 0], reference="Master")
-    model.add_frame("C", translation=[2, 2, 5], rotation=[0, 0, 0], reference="A")
-    model.add_frame("D", translation=[2, 2, 2], rotation=[0, 0, 0], reference="B")
+    model.add_frame("A", translation=[2, 2, 2], rotation=[0, 0, 0], ref="Master")
+    model.add_frame("B", translation=[-2, 2, 2], rotation=[0, 0, 0], ref="Master")
+    model.add_frame("C", translation=[2, 2, 5], rotation=[0, 0, 0], ref="A")
+    model.add_frame("D", translation=[2, 2, 2], rotation=[0, 0, 0], ref="B")
 
     model.add_link("A", "B")
     model.add_link("B", "C")


### PR DESCRIPTION
Attempt of solving #278

Re-introduce the concept of _ref_ == "parent reference_frame" as a distinct type of reference_frame troughout the code
+ correct for some inconsistencies where the names _ref_ and/or _reference_frame_ had been wrongly used wrt method signatures

	modified:   libs/cgse-coordinates/src/egse/coordinates/__init__.py
	modified:   libs/cgse-coordinates/src/egse/coordinates/point.py
	modified:   libs/cgse-coordinates/src/egse/coordinates/reference_frame.py
	modified:   libs/cgse-coordinates/src/egse/coordinates/refmodel.py