### PR TITLE
Fix typo in docstring for affine_matrix_from_points function

### DIFF
--- a/libs/cgse-coordinates/src/egse/coordinates/transform3d_addon.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/transform3d_addon.py
@@ -73,7 +73,7 @@ def affine_matrix_from_points(
 
     Returns affine transform matrix to register two point sets.
 
-    v0 and v1 are shape (ndims, \*) arrays of at least ndims non-homogeneous
+    v0 and v1 are shape (ndims, \\*) arrays of at least ndims non-homogeneous
     coordinates, where ndims is the dimensionality of the coordinate space.
 
     If shear is False, a similarity transformation matrix is returned.


### PR DESCRIPTION
The pull request fixes a SyntaxWarning in Python 3.12 and higher.