### PR TITLE
Replace StrEnum with Enum (Python 3.10 compatibility)

### DIFF
--- a/projects/ariel/ariel-tcu/src/egse/ariel/tcu/tcu_cmd_utils.py
+++ b/projects/ariel/ariel-tcu/src/egse/ariel/tcu/tcu_cmd_utils.py
@@ -20,11 +20,13 @@ import crcmod
 try:
     from enum import StrEnum
 except ImportError:
+
     class StrEnum(str, Enum):
         """Python 3.10-compatible fallback for enum.StrEnum."""
 
         def __str__(self) -> str:
             return str(self.value)
+
 
 from egse.ariel.tcu import TcuMode
 from egse.decorators import static_vars


### PR DESCRIPTION
This PR fixes #282 by replacing a few Python 3.11 bindings (`typing.Self` and `enum.StrEnum`) with Python 3.10 compatible ones.