### PR TITLE
[#254] Query InfluxDB3 database name and authentication token in `cgse init`

### DIFF
--- a/docs/user_guide/env.md
+++ b/docs/user_guide/env.md
@@ -34,11 +34,25 @@ these variables are not set, they will be determined from defaults.
     By default, this directory is also located in the overall data storage folder, such
     that log files are kept per project and site id.
 
-**`{PROJECT}_LOCAL_SETTINGS`**: 
+**`{PROJECT}_LOCAL_SETTINGS`**:
 
 :   This file is used for local site-specific settings. When the environment
-    variable is not set, no local settings will be loaded. By default, the name 
+    variable is not set, no local settings will be loaded. By default, the name
     of this file is assumed to be 'local_settings.yaml'.
+
+**`INFLUXDB3_DATABASE_NAME`**:
+
+:   The name of the InfluxDB3 database to which metrics and monitoring data are written.
+    This variable is used by device control servers and monitoring components to route
+    time-series data to the correct database. When not set, metrics will not be
+    propagated to InfluxDB. This variable is set during `cgse init` and defaults to
+    `{project}_{site_id}` (lowercased), e.g. `ariel_vacuum_lab`.
+
+**`INFLUXDB3_AUTH_TOKEN`**:
+
+:   The authentication token for the InfluxDB3 instance. Both `INFLUXDB3_DATABASE_NAME`
+    and `INFLUXDB3_AUTH_TOKEN` must be set for metrics to be sent to InfluxDB. When either
+    is missing, a warning is logged and metrics collection is disabled.
 
 You can inspect your current environment with the command given below. The example is for 
 a project called ARIEL and a test setup in the vacuum lab.

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_commands.py
@@ -79,6 +79,16 @@ def init(project: str = ""):
     if answer:
         local_settings_path = answer
 
+    influxdb_database_name = f"{project.lower()}_{site_id.lower()}"
+    answer = Prompt.ask(f"What is the InfluxDB3 database name [{influxdb_database_name}] ?")
+    if answer:
+        influxdb_database_name = answer
+
+    influxdb_auth_token = ""
+    answer = Prompt.ask("What is the InfluxDB3 authentication token (leave empty to skip) ?", default="")
+    if answer:
+        influxdb_auth_token = answer
+
     Path(data_storage_location).expanduser().mkdir(exist_ok=True, parents=True)
     (Path(data_storage_location).expanduser() / "daily").mkdir(exist_ok=True, parents=True)
     (Path(data_storage_location).expanduser() / "obs").mkdir(exist_ok=True, parents=True)
@@ -109,9 +119,13 @@ def init(project: str = ""):
                     export {project}_CONF_DATA_LOCATION={conf_data_location}
                     export {project}_LOG_FILE_LOCATION={log_file_location}
                     export {project}_LOCAL_SETTINGS={local_settings_path}
+                    export INFLUXDB3_DATABASE_NAME={influxdb_database_name}
                     """
                 )
             )
+        if influxdb_auth_token:
+            with open(Path("~/.bash_profile").expanduser(), "a") as fd:
+                fd.write(f"export INFLUXDB3_AUTH_TOKEN={influxdb_auth_token}\n")
     else:
         rich.print(
             textwrap.dedent(
@@ -124,9 +138,12 @@ def init(project: str = ""):
                 export {project}_CONF_DATA_LOCATION={conf_data_location}
                 export {project}_LOG_FILE_LOCATION={log_file_location}
                 export {project}_LOCAL_SETTINGS={local_settings_path}
+                export INFLUXDB3_DATABASE_NAME={influxdb_database_name}
             """
             )
         )
+        if influxdb_auth_token:
+            rich.print(f"export INFLUXDB3_AUTH_TOKEN={influxdb_auth_token}")
 
 
 show = typer.Typer(help="Show information about settings, environment, setup, ...")


### PR DESCRIPTION
Fixes #254. When running `cgse init`, the user will be queried for the InfluxDB3 database name (defaults to `{project.lower()}_{site_id.lower()}`) and an optional InfluxDB3 authentication token.