### PR TITLE
Add Async Control Server and Async Control Client + their Dummy subclass implementations

### DIFF
--- a/docs/dev_guide/async_control_authoring_checklist.md
+++ b/docs/dev_guide/async_control_authoring_checklist.md
@@ -1,0 +1,93 @@
+# Async Control Authoring Checklist
+
+Use this checklist when adding a new async control server/client pair in `cgse-core` or downstream projects.
+
+## 1. Define the server subclass
+
+- Subclass `AsyncControlServer`.
+- Set a unique `service_type` string.
+- Implement `register_custom_handlers()`.
+- Register device commands with `add_device_command_handler(...)`.
+- Register service commands with `add_service_command_handler(...)`.
+- Optionally override `get_service_info()` to expose server-specific metadata.
+
+## 2. Define the client subclass
+
+- Subclass `TypedAsyncControlClient`.
+- Set the same `service_type` as the server.
+- Add one method per command (for example `health()`, `move()`, `configure()`).
+- Use:
+  - `_success_message_as_str(...)` for string responses.
+  - `_success_message_as_dict(...)` for JSON/object responses.
+- Keep transport details out of business methods; call `send_device_command(...)` or `send_service_command(...)`.
+
+## 3. Keep command contracts aligned
+
+- Command names in client wrappers match server handler registration.
+- Request payload fields are documented and validated.
+- Response shape is stable and documented (`success` + `message`).
+- Error responses are predictable and actionable.
+
+## 4. Prefer explicit command channels
+
+- Device actions: `send_device_command(...)`.
+- Service/lifecycle actions: `send_service_command(...)`.
+- Avoid using private client methods from application code.
+
+## 5. Add tests for the pair
+
+- Start the server subclass in an async test.
+- Connect with the client subclass (using default class `service_type`).
+- Test at least:
+  - one happy-path device command,
+  - one happy-path service command,
+  - one failure path (unknown command or bad payload).
+
+## 6. Validate quality gates
+
+- Run focused tests for changed files.
+- Run lint/type checks for touched files.
+- Ensure no line-length/import-order regressions.
+
+## 7. Migration notes (legacy -> async)
+
+- Server-side "handler registration" belongs in server subclasses.
+- Client-side extension is done with typed wrapper methods, not handler maps.
+- If an old client called private methods directly, migrate to public wrappers.
+
+## Minimal skeleton
+
+```python
+from typing import Any
+
+from egse.async_control import AsyncControlServer
+from egse.async_control import TypedAsyncControlClient
+from egse.zmq_ser import zmq_json_response
+
+
+class MyAsyncControlServer(AsyncControlServer):
+    service_type = "my-async-control-server"
+
+    def register_custom_handlers(self):
+        self.add_device_command_handler("set-mode", self._set_mode)
+        self.add_service_command_handler("health", self._health)
+
+    async def _set_mode(self, cmd: dict[str, Any]) -> list:
+        mode = cmd.get("mode", "default")
+        return zmq_json_response({"success": True, "message": {"mode": mode}})
+
+    async def _health(self, cmd: dict[str, Any]) -> list:
+        return zmq_json_response({"success": True, "message": {"status": "ok"}})
+
+
+class MyAsyncControlClient(TypedAsyncControlClient):
+    service_type = MyAsyncControlServer.service_type
+
+    async def set_mode(self, mode: str) -> dict[str, Any] | None:
+        response = await self.send_device_command({"command": "set-mode", "mode": mode})
+        return self._success_message_as_dict(response, "set-mode")
+
+    async def health(self) -> dict[str, Any] | None:
+        response = await self.send_service_command("health")
+        return self._success_message_as_dict(response, "health")
+```

--- a/docs/dev_guide/async_control_authoring_checklist.md
+++ b/docs/dev_guide/async_control_authoring_checklist.md
@@ -60,7 +60,8 @@ Use this checklist when adding a new async control server/client pair in `cgse-c
 ```python
 from typing import Any
 
-from egse.async_control import AsyncControlServer
+from egse.async_control import AcquisitionAsyncControlServer
+from egse.zmq_ser import zmq_json_response
 from egse.async_control import TypedAsyncControlClient
 from egse.zmq_ser import zmq_json_response
 
@@ -91,3 +92,125 @@ class MyAsyncControlClient(TypedAsyncControlClient):
         response = await self.send_service_command("health")
         return self._success_message_as_dict(response, "health")
 ```
+
+## Handle-based acquisition callback pattern
+
+If your device driver invokes a callback with a single argument such as `callback(handle)`, do not try to force the
+driver to call `on_acquisition_data(...)` directly. Instead, add a small adapter method in your server subclass that
+matches the driver callback signature exactly.
+
+The intended execution path is:
+
+1. `start_acquisition()` registers a driver-facing callback such as `self._driver_callback`.
+2. The driver calls `self._driver_callback(handle)` on its own thread.
+3. `_driver_callback(handle)` extracts the data you need from `handle` and calls `self.on_acquisition_data(...)`.
+4. `AsyncControlServer.on_acquisition_data(...)` performs the thread-safe handoff into the asyncio queue.
+5. `AsyncControlServer.process_acquisition_data()` drains the queue.
+6. Your subclass hook `handle_acquisition_record(...)` receives the normalized record and stores, logs, or forwards it.
+
+In other words: the device callback belongs to the subclass, the queueing belongs to `AsyncControlServer`, and the
+storage/logging belongs to `handle_acquisition_record(...)`.
+
+```python
+from typing import Any
+
+from egse.async_control import AsyncControlServer
+
+
+class MyHandleBasedServer(AcquisitionAsyncControlServer):
+    service_type = "my-handle-based-server"
+
+    def __init__(self, driver):
+        self._driver = driver
+        self._acquisition_running = False
+        super().__init__()
+
+    def register_custom_handlers(self):
+        self.add_device_command_handler("start-acquisition", self._do_start_acquisition)
+        self.add_device_command_handler("stop-acquisition", self._do_stop_acquisition)
+
+    async def _do_start_acquisition(self, cmd: dict[str, Any]) -> list:
+        self._driver.start_acquisition(callback=self._driver_callback)
+        self._acquisition_running = True
+        return zmq_json_response({"success": True, "message": {"running": True}})
+
+    async def _do_stop_acquisition(self, cmd: dict[str, Any]) -> list:
+        self._driver.stop_acquisition()
+        self._acquisition_running = False
+        return zmq_json_response({"success": True, "message": {"running": False}})
+
+    def _driver_callback(self, handle):
+        """Adapter that matches the driver callback signature exactly."""
+        payload = self._extract_payload_from_handle(handle)
+        self.on_acquisition_data(
+            payload,
+            source="my-device",
+            metadata={"handle_type": type(handle).__name__},
+        )
+
+    def _extract_payload_from_handle(self, handle) -> dict[str, Any]:
+        """Read the data immediately if the handle is only valid during the callback."""
+        return {
+            "timestamp": handle.timestamp,
+            "value": handle.value,
+            "status": handle.status,
+        }
+
+    async def handle_acquisition_record(self, record: dict[str, Any]):
+        self.logger.info("Received acquisition record: %s", record["data"])
+```
+
+Notes:
+
+- Prefer extracting plain Python data from the driver handle inside `_driver_callback(...)`. Many drivers only keep the
+  handle or buffer valid during the callback.
+- You usually do not need to override `get_acquisition_callback()` for this pattern.
+- Keep `_driver_callback(...)` short. Do not do DB writes, network calls, or other slow work there.
+- If you need batch storage, override `handle_acquisition_batch(...)`; otherwise only override
+  `handle_acquisition_record(...)`.
+
+## Sequential execution across clients and timers
+
+If both external clients and internal tasks (timers/background jobs) touch the same device,
+route those operations through `AsyncControlServer._execute_sequential(...)`.
+
+This creates one serialized hardware lane across all call sites.
+
+```python
+import asyncio
+from typing import Any
+
+from egse.async_control import AsyncControlServer
+from egse.zmq_ser import zmq_json_response
+
+
+class MySequentialServer(AsyncControlServer):
+    service_type = "my-sequential-server"
+
+    def __init__(self, driver):
+        self._driver = driver
+        super().__init__()
+
+    def register_custom_handlers(self):
+        self.add_device_command_handler("fetch", self._do_fetch)
+
+    async def _do_fetch(self, cmd: dict[str, Any]) -> list:
+        # External client request goes through the same serialized lane.
+        value = await self._execute_sequential(
+            asyncio.to_thread(self._driver.fetch_reading)
+        )
+        return zmq_json_response({"success": True, "message": {"value": value}})
+
+    async def poll_timer_tick(self):
+        # Internal timer work uses the same lane, preventing command/timer races.
+        value = await self._execute_sequential(
+            asyncio.to_thread(self._driver.fetch_reading)
+        )
+        self.logger.info("Polled device reading: %s", value)
+```
+
+Notes:
+
+- Device command handlers are already processed one-by-one, but `_execute_sequential(...)`
+  is still useful to serialize device access across *multiple sources*.
+- Use `asyncio.to_thread(...)` inside `_execute_sequential(...)` for blocking driver APIs.

--- a/docs/dev_guide/index.md
+++ b/docs/dev_guide/index.md
@@ -17,3 +17,7 @@ Don't confuse a monorepo with microservices either. A microservice architecture 
 run independently and are developed, scaled and deployed without affecting the other units or
 services. You can set up a monorepo containing all of your microservices with ease, one does not
 need the other, but they can perfectly go together.
+
+## See also
+
+- [Async Control Authoring Checklist](async_control_authoring_checklist.md)

--- a/libs/cgse-coordinates/src/egse/coordinates/reference_frame.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/reference_frame.py
@@ -107,9 +107,7 @@ class ReferenceFrame(object):
     _strict_naming = False
     _ACTIVE_DEFAULT = True
 
-    def __init__(
-        self, transformation: np.ndarray | None, ref, name=None, rotation_config=_ROT_CONFIG_DEFAULT
-    ):
+    def __init__(self, transformation: np.ndarray | None, ref, name=None, rotation_config=_ROT_CONFIG_DEFAULT):
         """Initialization of a new reference frame.
 
         Args:
@@ -273,9 +271,7 @@ class ReferenceFrame(object):
         return name
 
     @classmethod
-    def from_translation(
-        cls, translation_x: float, translation_y: float, translation_z: float, ref, name: str = None
-    ):
+    def from_translation(cls, translation_x: float, translation_y: float, translation_z: float, ref, name: str = None):
         """Creates a reference frame from a translation w.r.t. the given reference frame.
 
          Args:
@@ -294,9 +290,7 @@ class ReferenceFrame(object):
         affine_matrix[:3, 3] = [translation_x, translation_y, translation_z]
 
         if ref is None:
-            raise ValueError(
-                "The ref argument can not be None, provide a master or another reference frame."
-            )
+            raise ValueError("The ref argument can not be None, provide a master or another reference frame.")
 
         return cls(transformation=affine_matrix, ref=ref, name=name)
 
@@ -342,13 +336,9 @@ class ReferenceFrame(object):
         transformation = t3.affines.compose(T=translation, R=rotation_matrix.rotation_matrix, Z=zoom, S=shear)
 
         if ref is None:
-            raise ValueError(
-                "The ref argument can not be None, provide a master or another reference frame."
-            )
+            raise ValueError("The ref argument can not be None, provide a master or another reference frame.")
 
-        return cls(
-            transformation=transformation, ref=ref, name=name, rotation_config=rotation_config
-        )
+        return cls(transformation=transformation, ref=ref, name=name, rotation_config=rotation_config)
 
     @staticmethod
     def from_points(points, plane: str = "xy", use_svd: bool = True, verbose: bool = True):
@@ -405,13 +395,11 @@ class ReferenceFrame(object):
         )
 
         if ref is None:
-            raise ValueError(
-                "The ref argument can not be None, provide a master or another reference frame."
-            )
+            raise ValueError("The ref argument can not be None, provide a master or another reference frame.")
 
         return cls(
             transformation=t3.affines.compose(translation, rotation_matrix.rotation_matrix, Z=zoom, S=shear),
-            ref = ref,
+            ref=ref,
             name=name,
             rotation_config=rotation_config,
         )
@@ -1013,8 +1001,7 @@ class ReferenceFrame(object):
         if not relative:
             # virtual = what self should become after the (absolute) movement
             # it allows to compute the relative transformation to be applied and work in relative further down
-            virtual = ReferenceFrame(transformation, ref=self.ref, name="virtual",
-                                     rotation_config=self.rotation_config)
+            virtual = ReferenceFrame(transformation, ref=self.ref, name="virtual", rotation_config=self.rotation_config)
             request = self.get_active_transformation_to(virtual)
             del virtual
         else:
@@ -1056,8 +1043,12 @@ class ReferenceFrame(object):
         to_restore = {}
 
         for frame in impacted:
-            to_restore[frame] = ReferenceFrame(frame.get_active_transformation_from(temp_master), ref=temp_master,
-                                               name=frame.name + "to_restore", rotation_config=frame.rotation_config)
+            to_restore[frame] = ReferenceFrame(
+                frame.get_active_transformation_from(temp_master),
+                ref=temp_master,
+                name=frame.name + "to_restore",
+                rotation_config=frame.rotation_config,
+            )
 
         # BLOCK A. apply the right transformation to all "endFrames"
 
@@ -1069,8 +1060,12 @@ class ReferenceFrame(object):
         #     rotation_config=self.rotation_config,
         # )
 
-        self_untouched = ReferenceFrame(transformation=self.transformation, ref=self.ref,
-                                        name=self.name + "_fixed", rotation_config=self.rotation_config)
+        self_untouched = ReferenceFrame(
+            transformation=self.transformation,
+            ref=self.ref,
+            name=self.name + "_fixed",
+            rotation_config=self.rotation_config,
+        )
 
         for bottom in end_frames:
             up = bottom.get_active_transformation_to(self_untouched)

--- a/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
@@ -213,8 +213,7 @@ class ReferenceFrameModel:
         ref = self._model[ref]
 
         if transformation:
-            self._model[name] = ReferenceFrame(transformation, ref=ref, name=name,
-                                               rotation_config=self._rot_config)
+            self._model[name] = ReferenceFrame(transformation, ref=ref, name=name, rotation_config=self._rot_config)
         else:
             self._model[name] = ReferenceFrame.from_translation_rotation(
                 translation,
@@ -365,8 +364,9 @@ class ReferenceFrameModel:
 
         from egse.coordinates.reference_frame import ReferenceFrame
 
-        moving_in_other = ReferenceFrame(transformation, ref=other, name="moving_in_other",
-                                         rotation_config=self._rot_config)
+        moving_in_other = ReferenceFrame(
+            transformation, ref=other, name="moving_in_other", rotation_config=self._rot_config
+        )
 
         moving_in_other.add_link(frame)
 
@@ -438,8 +438,9 @@ class ReferenceFrameModel:
 
         from egse.coordinates.reference_frame import ReferenceFrame
 
-        moving_in_other = ReferenceFrame(transformation, ref=other, name="moving_in_other",
-                                         rotation_config=self._rot_config)
+        moving_in_other = ReferenceFrame(
+            transformation, ref=other, name="moving_in_other", rotation_config=self._rot_config
+        )
 
         moving_in_other.add_link(frame)
 

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -70,7 +70,7 @@ setup_provider = "egse._setup_core:CoreSetupProvider"
 "Logger" = "LOG_CS"
 
 [tool.pytest.ini_options]
-pythonpath = "src"
+pythonpath = ["tests", "src"]
 testpaths = ["tests"]
 addopts = "-rA --cov --cov-branch --cov-report html"
 log_cli = true

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -11,6 +11,7 @@ from enum import Enum
 from enum import auto
 from typing import Any
 from typing import Callable
+from typing import Coroutine
 
 import zmq.asyncio
 from rich.traceback import Traceback
@@ -94,6 +95,7 @@ class AsyncControlServer:
     def __init__(self):
         self.interrupted: Event = asyncio.Event()
         self.logger = logging.getLogger("egse.async_control.server")
+        self._loop: asyncio.AbstractEventLoop | None = None
 
         self.mon_delay = 1000
         """Delay between publish status information [ms]."""
@@ -104,7 +106,7 @@ class AsyncControlServer:
 
         self._service_id = None
 
-        self._sequential_queue = asyncio.Queue()
+        self._sequential_queue: asyncio.Queue[Coroutine[Any, Any, Any]] = asyncio.Queue()
         """Queue for sequential operations that must preserve order of execution."""
 
         self.device_command_port = CONTROL_SERVER_DEVICE_COMMANDING_PORT
@@ -184,17 +186,14 @@ class AsyncControlServer:
         self.interrupted.set()
 
     async def start(self):
+        self._loop = asyncio.get_running_loop()
+
         self.connect_device_command_socket()
         self.connect_service_command_socket()
 
         await self.register_service()
 
-        self._tasks = [
-            asyncio.create_task(self.process_device_command(), name="process-device-commands"),
-            asyncio.create_task(self.process_service_command(), name="process-service-commands"),
-            asyncio.create_task(self.send_status_updates(), name="send-status-updates"),
-            asyncio.create_task(self.process_sequential_queue(), name="process-sequential-queue"),
-        ]
+        self._tasks = self._create_background_tasks()
 
         try:
             while not self.interrupted.is_set():
@@ -209,6 +208,19 @@ class AsyncControlServer:
 
         self.disconnect_device_command_socket()
         self.disconnect_service_command_socket()
+
+    def _create_background_tasks(self) -> list[Task]:
+        """Create top-level server tasks.
+
+        Subclasses can override this method and append extra tasks while keeping
+        the base command/service lifecycle unchanged.
+        """
+        return [
+            asyncio.create_task(self.process_device_command(), name="process-device-commands"),
+            asyncio.create_task(self.process_service_command(), name="process-service-commands"),
+            asyncio.create_task(self.send_status_updates(), name="send-status-updates"),
+            asyncio.create_task(self.process_sequential_queue(), name="process-sequential-queue"),
+        ]
 
     async def register_service(self):
         self.logger.info(f"Registering service {type(self).__name__} as type {self.service_type}")
@@ -505,16 +517,192 @@ class AsyncControlServer:
         except asyncio.CancelledError:
             self.logger.debug("Caught CancelledError on status updates keep-alive loop.")
 
-    async def enqueue_sequential_operation(self, coroutine_func):
+    async def enqueue_sequential_operation(self, operation: Coroutine[Any, Any, Any]):
         """
         Add an operation to the sequential queue.
 
         Args:
-            coroutine_func: A coroutine function (async function) to be executed sequentially
+            operation: A coroutine object to be executed sequentially.
         """
 
         if self._sequential_queue is not None:  # sanity check
-            self._sequential_queue.put_nowait(coroutine_func)
+            self._sequential_queue.put_nowait(operation)
+
+    async def _execute_sequential(self, operation: Coroutine[Any, Any, Any]) -> Any:
+        """Execute one coroutine through the sequential queue and await its result.
+
+        Use this helper from command handlers, service handlers, and internal tasks
+        when all hardware-facing work must be serialized through one lane.
+        """
+
+        loop = asyncio.get_running_loop()
+        result_future: asyncio.Future[Any] = loop.create_future()
+
+        async def wrapped_operation():
+            try:
+                result = await operation
+            except Exception as exc:
+                if not result_future.done():
+                    result_future.set_exception(exc)
+                return
+
+            if not result_future.done():
+                result_future.set_result(result)
+
+        try:
+            await self.enqueue_sequential_operation(wrapped_operation())
+        except Exception:
+            operation.close()
+            raise
+
+        return await result_future
+
+
+class AcquisitionAsyncControlServer(AsyncControlServer):
+    """Async control server variant with callback-based acquisition queueing support."""
+
+    def __init__(self):
+        super().__init__()
+
+        self.acquisition_queue_maxsize = 10_000
+        """Maximum number of acquisition records buffered in memory."""
+
+        self._acquisition_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self.acquisition_queue_maxsize)
+        """Queue for acquisition records received through callback ingestion."""
+
+        self.acquisition_dropped_count = 0
+        """Number of acquisition records dropped because the queue was full."""
+
+        self.acquisition_batch_enabled = False
+        """Enable grouped acquisition processing for higher-rate producers."""
+
+        self.acquisition_batch_max_size = 100
+        """Maximum number of records grouped into one batch before sink dispatch."""
+
+        self.acquisition_batch_max_wait_s = 0.05
+        """Maximum wait time [s] to collect records into a batch."""
+
+    def get_service_info(self) -> dict[str, Any]:
+        """Service info payload including acquisition queue statistics."""
+        info = super().get_service_info()
+        info.update(
+            {
+                "acquisition queue size": self._acquisition_queue.qsize(),
+                "acquisition dropped": self.acquisition_dropped_count,
+                "acquisition batch enabled": self.acquisition_batch_enabled,
+                "acquisition batch size": self.acquisition_batch_max_size,
+            }
+        )
+        return info
+
+    def _create_background_tasks(self) -> list[Task]:
+        tasks = super()._create_background_tasks()
+        tasks.append(asyncio.create_task(self.process_acquisition_data(), name="process-acquisition-data"))
+        return tasks
+
+    def get_acquisition_callback(self) -> Callable[[Any], None]:
+        """Return a callback that device drivers can call to ingest acquisition samples."""
+        return self.on_acquisition_data
+
+    def on_acquisition_data(
+        self,
+        data: Any,
+        *,
+        source: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """Ingest one acquisition record from any thread.
+
+        This function is intentionally sync/thread-safe so it can be used as a
+        device-driver callback.
+        """
+
+        record = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "source": source,
+            "data": data,
+            "metadata": metadata or {},
+        }
+
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            self.logger.warning("Dropping acquisition record because event loop is not running yet.")
+            self.acquisition_dropped_count += 1
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+
+        if running_loop is loop:
+            self._enqueue_acquisition_record(record)
+        else:
+            loop.call_soon_threadsafe(self._enqueue_acquisition_record, record)
+
+    def _enqueue_acquisition_record(self, record: dict[str, Any]):
+        try:
+            self._acquisition_queue.put_nowait(record)
+        except asyncio.QueueFull:
+            self.acquisition_dropped_count += 1
+            if self.acquisition_dropped_count % 1000 == 1:
+                self.logger.warning(
+                    "Acquisition queue full, dropping records "
+                    f"(dropped={self.acquisition_dropped_count}, maxsize={self.acquisition_queue_maxsize})."
+                )
+
+    async def process_acquisition_data(self):
+        """Drain acquisition records from the queue and dispatch them to sink hooks."""
+
+        self.logger.info("Starting acquisition data processing ...")
+
+        while not self.interrupted.is_set():
+            try:
+                if not self.acquisition_batch_enabled:
+                    try:
+                        record = await asyncio.wait_for(self._acquisition_queue.get(), timeout=0.1)
+                    except asyncio.TimeoutError:
+                        continue
+                    batch = [record]
+                else:
+                    try:
+                        first_record = await asyncio.wait_for(
+                            self._acquisition_queue.get(), timeout=self.acquisition_batch_max_wait_s
+                        )
+                    except asyncio.TimeoutError:
+                        continue
+
+                    batch = [first_record]
+
+                    # Drain additional records without blocking to create a compact, ordered batch.
+                    while len(batch) < self.acquisition_batch_max_size:
+                        try:
+                            batch.append(self._acquisition_queue.get_nowait())
+                        except asyncio.QueueEmpty:
+                            break
+
+                try:
+                    await self.handle_acquisition_batch(batch)
+                finally:
+                    for _ in batch:
+                        self._acquisition_queue.task_done()
+
+            except asyncio.CancelledError:
+                self.logger.debug("Acquisition data task cancelled.")
+                break
+            except Exception as exc:
+                self.logger.error(f"Error processing acquisition record: {exc}", exc_info=True)
+
+    async def handle_acquisition_batch(self, records: list[dict[str, Any]]):
+        """Hook for batch sinks; default keeps strict sequential per-record processing."""
+        for record in records:
+            await self.handle_acquisition_record(record)
+
+    async def handle_acquisition_record(self, record: dict[str, Any]):
+        """Hook for subclasses to forward acquisition data to DB, storage manager, or other services."""
+        self.logger.debug(
+            f"Acquisition record received (source={record.get('source')}, queue={self._acquisition_queue.qsize()})."
+        )
 
 
 DEFAULT_CLIENT_REQUEST_TIMEOUT = 5.0  # seconds

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -19,6 +19,8 @@ from rich.traceback import Traceback
 from egse.env import bool_env
 from egse.exceptions import InitializationError
 from egse.log import logging
+
+# from egse.process import ProcessStatus
 from egse.registry.client import AsyncRegistryClient
 from egse.system import Periodic
 from egse.system import get_current_location
@@ -84,9 +86,12 @@ async def is_control_server_active(service_type: str, timeout: float = 0.5) -> b
 
     # 2. I can connect to the control server (by first contacting the service registry) and send a ping.
 
-    # async with AsyncControlClient(service_type=service_type) as client:
-    #     response = await client.ping()
-    # return response == 'pong'
+    # try:
+    #     async with AsyncControlClient(service_type=service_type) as client:
+    #         response = await client.ping()
+    #     return response == "pong"
+    # except InitializationError:
+    #     return False
 
 
 class AsyncControlServer:
@@ -759,7 +764,8 @@ class AsyncControlClient:
 
         """
         if self._post_init_is_done:
-            self.logger.warning("The post_init function is already called, returning.")
+            if VERBOSE_DEBUG:
+                self.logger.debug("The post_init function is already called, returning.")
             return True
 
         self._post_init_is_done = True

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -22,7 +22,7 @@ from egse.log import logging
 
 # from egse.process import ProcessStatus
 from egse.registry.client import AsyncRegistryClient
-from egse.system import Periodic
+from egse.system import Periodic, humanize_seconds
 from egse.system import get_current_location
 from egse.system import get_host_ip
 from egse.system import log_rich_output
@@ -101,6 +101,7 @@ class AsyncControlServer:
         self.interrupted: Event = asyncio.Event()
         self.logger = logging.getLogger("egse.async_control.server")
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._start_time = datetime.datetime.now()
 
         self.mon_delay = 1000
         """Delay between publish status information [ms]."""
@@ -171,6 +172,9 @@ class AsyncControlServer:
             "device commanding port": self.device_command_port,
             "service commanding port": self.service_command_port,
             "service type": self.service_type,
+            "uptime": humanize_seconds(
+                (datetime.datetime.now() - self._start_time).total_seconds(), include_micro_seconds=False
+            ),
         }
 
     @staticmethod

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -22,9 +22,10 @@ from egse.log import logging
 
 # from egse.process import ProcessStatus
 from egse.registry.client import AsyncRegistryClient
-from egse.system import Periodic, humanize_seconds
+from egse.system import Periodic
 from egse.system import get_current_location
 from egse.system import get_host_ip
+from egse.system import humanize_seconds
 from egse.system import log_rich_output
 from egse.system import type_name
 from egse.zmq_ser import get_port_number

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -1,0 +1,1159 @@
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import pickle
+import uuid
+from asyncio import Event
+from asyncio import Task
+from enum import Enum
+from enum import auto
+from typing import Any
+from typing import Callable
+
+import zmq.asyncio
+from rich.traceback import Traceback
+
+from egse.env import bool_env
+from egse.exceptions import InitializationError
+from egse.log import logging
+from egse.registry.client import AsyncRegistryClient
+from egse.system import Periodic
+from egse.system import get_current_location
+from egse.system import get_host_ip
+from egse.system import log_rich_output
+from egse.system import type_name
+from egse.zmq_ser import get_port_number
+from egse.zmq_ser import set_address_port
+from egse.zmq_ser import zmq_error_response
+from egse.zmq_ser import zmq_json_request
+from egse.zmq_ser import zmq_json_response
+from egse.zmq_ser import zmq_string_request
+from egse.zmq_ser import zmq_string_response
+
+logger = logging.getLogger("egse.async_control")
+
+# When zero (0) ports will be dynamically allocated by the system
+CONTROL_SERVER_DEVICE_COMMANDING_PORT = 0
+CONTROL_SERVER_SERVICE_COMMANDING_PORT = 0
+
+CONTROL_SERVER_SERVICE_TYPE = "async-control-server"
+CONTROL_CLIENT_ID = "async-control-client"
+
+VERBOSE_DEBUG: bool = bool_env("VERBOSE_DEBUG")
+
+RECREATE_SOCKET = False
+"""Recreate ZeroMQ socket after a timeout. Set to True when experiencing problems
+with corrupted socket states. This is mainly used for REQ-REP protocols."""
+
+
+class SocketType(Enum):
+    """The socket type defines which socket to use for the intended communication."""
+
+    DEVICE = auto()
+    SERVICE = auto()
+
+
+async def is_control_server_active(service_type: str, timeout: float = 0.5) -> bool:
+    """
+    Checks if the Control Server is running.
+
+    This function sends a *Ping* message to the Control Server and expects a *Pong* answer back within the timeout
+    period.
+
+    Args:
+        service_type (str): the service type of the control server to check
+        timeout (float): Timeout when waiting for a reply [s, default=0.5]
+
+    Returns:
+        True if the Control Server is running and replied with the expected answer; False otherwise.
+    """
+
+    # I have a choice here to check if the control server is active/healthy.
+    #
+    # 1. I can connect to the ServiceRegistry, and analyse the 'health' field if it is 'passing', or
+
+    with AsyncRegistryClient() as registry:
+        service = await registry.discover_service(service_type)
+    if service:
+        return True if service["health"] == "passing" else False
+    else:
+        return False
+
+    # 2. I can connect to the control server (by first contacting the service registry) and send a ping.
+
+    # async with AsyncControlClient(service_type=service_type) as client:
+    #     response = await client.ping()
+    # return response == 'pong'
+
+
+class AsyncControlServer:
+    service_type = CONTROL_SERVER_SERVICE_TYPE
+
+    def __init__(self):
+        self.interrupted: Event = asyncio.Event()
+        self.logger = logging.getLogger("egse.async_control.server")
+
+        self.mon_delay = 1000
+        """Delay between publish status information [ms]."""
+        self.hk_delay = 1000
+        """Delay between saving housekeeping information [ms]."""
+
+        # self._process_status = ProcessStatus()
+
+        self._service_id = None
+
+        self._sequential_queue = asyncio.Queue()
+        """Queue for sequential operations that must preserve order of execution."""
+
+        self.device_command_port = CONTROL_SERVER_DEVICE_COMMANDING_PORT
+        """The device commanding port for the control server. This will be 0 at start and dynamically assigned by the
+        system."""
+
+        self.service_command_port = CONTROL_SERVER_SERVICE_COMMANDING_PORT
+        """The service commanding port for the control server. This will be 0 at start and dynamically assigned by the
+        system."""
+
+        self.device_command_handlers: dict[str, Callable] = {}
+        """Dictionary mapping device command names to their handler functions."""
+
+        self.service_command_handlers: dict[str, Callable] = {}
+        """Dictionary mapping service command names to their handler functions."""
+
+        self._tasks: list[Task] = []
+        """The background top-level tasks that are performed by the control server."""
+
+        self._ctx = zmq.asyncio.Context.instance()
+
+        # Socket to handle device commanding pattern - ROUTER-DEALER
+        self.device_command_socket: zmq.asyncio.Socket = self._ctx.socket(zmq.ROUTER)
+
+        # Socket to handle service commanding pattern - ROUTER-DEALER
+        self.service_command_socket: zmq.asyncio.Socket = self._ctx.socket(zmq.ROUTER)
+
+        self.register_default_device_command_handlers()
+        self.register_default_service_command_handlers()
+
+        # Call the hook for registering custom handlers, so that they are registered before the server
+        # starts accepting commands.
+        self.register_custom_handlers()
+
+        self.registry = AsyncRegistryClient()
+
+    def register_default_device_command_handlers(self):
+        """Register baseline device handlers that are useful for diagnostics and examples."""
+        self.add_device_command_handler("block", self._do_block)
+        self.add_device_command_handler("say", self._do_say)
+
+    def register_default_service_command_handlers(self):
+        """Register baseline service handlers for lifecycle and health checks."""
+        self.add_service_command_handler("terminate", self._handle_terminate)
+        self.add_service_command_handler("info", self._handle_info)
+        self.add_service_command_handler("ping", self._handle_ping)
+        self.add_service_command_handler("block", self._handle_block)
+
+    def register_custom_handlers(self):
+        """Hook for subclasses to register device-specific command handlers."""
+
+    def get_service_info(self) -> dict[str, Any]:
+        """Service info payload returned by the `info` service command."""
+        return {
+            "name": type(self).__name__,
+            "hostname": self.get_ip_address(),
+            "device commanding port": self.device_command_port,
+            "service commanding port": self.service_command_port,
+            "service type": self.service_type,
+        }
+
+    @staticmethod
+    def get_ip_address() -> str:
+        """Returns the IP address of the current host or localhost."""
+        return get_host_ip() or "localhost"
+
+    def connect_device_command_socket(self):
+        self.device_command_socket.bind(f"tcp://*:{self.device_command_port}")
+        self.device_command_port = get_port_number(self.device_command_socket)
+
+    def connect_service_command_socket(self):
+        self.service_command_socket.bind(f"tcp://*:{self.service_command_port}")
+        self.service_command_port = get_port_number(self.service_command_socket)
+
+    def stop(self):
+        self.logger.warning(f"Stopping the async control server {type(self).__name__}.")
+        self.interrupted.set()
+
+    async def start(self):
+        self.connect_device_command_socket()
+        self.connect_service_command_socket()
+
+        await self.register_service()
+
+        self._tasks = [
+            asyncio.create_task(self.process_device_command(), name="process-device-commands"),
+            asyncio.create_task(self.process_service_command(), name="process-service-commands"),
+            asyncio.create_task(self.send_status_updates(), name="send-status-updates"),
+            asyncio.create_task(self.process_sequential_queue(), name="process-sequential-queue"),
+        ]
+
+        try:
+            while not self.interrupted.is_set():
+                await self._check_tasks_health()
+                await asyncio.sleep(1.0)
+        except asyncio.CancelledError:
+            self.logger.debug(f"Caught CancelledError on server keep-alive loop, terminating {type(self).__name__}.")
+        finally:
+            await self._cleanup_running_tasks()
+
+        await self.deregister_service()
+
+        self.disconnect_device_command_socket()
+        self.disconnect_service_command_socket()
+
+    async def register_service(self):
+        self.logger.info(f"Registering service {type(self).__name__} as type {self.service_type}")
+
+        self.registry.connect()
+
+        self._service_id = await self.registry.register(
+            name=type_name(self),
+            host=get_host_ip() or "127.0.0.1",
+            port=get_port_number(self.device_command_socket),
+            service_type=self.service_type,
+            metadata={"service_port": get_port_number(self.service_command_socket)},
+        )
+        await self.registry.start_heartbeat()
+
+    async def deregister_service(self):
+        await self.registry.stop_heartbeat()
+        await self.registry.deregister()
+
+        self.registry.disconnect()
+
+    async def _check_tasks_health(self):
+        """Check if any tasks unexpectedly terminated."""
+        for task in self._tasks:
+            if task.done() and not task.cancelled():
+                try:
+                    # This will raise any exception that occurred in the task
+                    task.result()
+                except Exception as exc:
+                    self.logger.error(f"Task {task.get_name()} failed: {exc}", exc_info=True)
+                    # Potentially restart the task or shut down service
+
+    async def _cleanup_running_tasks(self):
+        # Cancel all running tasks
+        for task in self._tasks:
+            if not task.done():
+                self.logger.debug(f"Cancelling task {task.get_name()}.")
+                task.cancel()
+
+        # Wait for tasks to complete their cancellation
+        if self._tasks:
+            try:
+                await asyncio.gather(*self._tasks, return_exceptions=True)
+            except asyncio.CancelledError as exc:
+                self.logger.debug(f"Caught {type_name(exc)}: {exc}.")
+                pass
+
+    def disconnect_device_command_socket(self):
+        self.logger.debug("Cleaning up device command sockets.")
+        if self.device_command_socket:
+            self.device_command_socket.close(linger=100)
+
+    def disconnect_service_command_socket(self):
+        self.logger.debug("Cleaning up service command sockets.")
+        if self.service_command_socket:
+            self.service_command_socket.close(linger=100)
+
+    async def process_device_command(self):
+        self.logger.info("Starting device command processing ...")
+
+        while not self.interrupted.is_set():
+            try:
+                # Wait for a request with timeout to allow checking if still running
+                try:
+                    parts = await asyncio.wait_for(self.device_command_socket.recv_multipart(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                if VERBOSE_DEBUG:
+                    self.logger.debug(f"Received multipart message: {parts}")
+
+                # For commanding, we only accept simple commands as a string or a complex command with arguments as
+                # JSON data. In both cases, there are only three parts in this multipart message.
+                client_id, sequence_id, message_type, data = parts
+                if message_type == b"MESSAGE_TYPE:STRING":
+                    device_command = {"command": data.decode("utf-8")}
+                elif message_type == b"MESSAGE_TYPE:JSON":
+                    device_command = json.loads(data.decode())
+                else:
+                    filename, lineno, function_name = get_current_location()
+                    # We have an unknown message format, send an error message back
+                    message = zmq_error_response(
+                        {
+                            "success": False,
+                            "message": f"Incorrect message type: {message_type}",
+                            "metadata": {
+                                "data": data.decode(),
+                                "file": filename,
+                                "lineno": lineno,
+                                "function": function_name,
+                            },
+                        }
+                    )
+                    await self.device_command_socket.send_multipart([client_id, sequence_id, *message])
+                    continue
+
+                self.logger.debug(f"Received device command: {device_command}")
+
+                self.logger.debug("Process the command...")
+                response = await self._process_device_command(device_command)
+
+                self.logger.debug("Send the response...")
+                await self.device_command_socket.send_multipart([client_id, sequence_id, *response])
+
+            except asyncio.CancelledError:
+                self.logger.debug("Device command handling task cancelled.")
+                break
+
+    async def _process_device_command(self, cmd: dict[str, Any]) -> list:
+        command = cmd.get("command")
+        if not command:
+            return zmq_error_response(
+                {
+                    "success": False,
+                    "message": "no command field provide, don't know what to do.",
+                }
+            )
+
+        handler = self.device_command_handlers.get(command)
+        if not handler:
+            filename, lineno, function_name = get_current_location()
+            return zmq_error_response(
+                {
+                    "success": False,
+                    "message": f"Unknown command: {command}",
+                    "metadata": {"file": filename, "lineno": lineno, "function": function_name},
+                }
+            )
+
+        return await handler(cmd)
+
+    def add_device_command_handler(self, command_name: str, command_handler: Callable):
+        self.device_command_handlers[command_name] = command_handler
+
+    def add_service_command_handler(self, command_name: str, command_handler: Callable):
+        self.service_command_handlers[command_name] = command_handler
+
+    async def _do_say(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Executing command: '{cmd['command']}")
+        self.logger.debug(f"Message: {cmd['message']}")
+        return zmq_string_response(f"Message said: {cmd['message']}")
+
+    async def _do_block(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Blocking the commanding for {cmd['sleep']}s...")
+        await asyncio.sleep(cmd["sleep"])
+        self.logger.debug(f"Blocking finished after {cmd['sleep']}s.")
+        return zmq_string_response("block: ACK")
+
+    async def _handle_block(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Handling '{cmd['command']}' service request.")
+        await asyncio.sleep(cmd["sleep"])
+        self.logger.debug(f"Blocking finished after {cmd['sleep']}s.")
+        return zmq_string_response("block: ACK")
+
+    async def _handle_ping(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Handling '{cmd['command']}' service request.")
+        return zmq_string_response("pong")
+
+    async def _handle_info(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Handling '{cmd['command']}' service request.")
+        return zmq_json_response(
+            {
+                "success": True,
+                "message": self.get_service_info(),
+            }
+        )
+
+    async def _handle_terminate(self, cmd: dict[str, Any]) -> list:
+        self.logger.debug(f"Handling '{cmd['command']}' request.")
+
+        self.stop()
+
+        return zmq_json_response(
+            {
+                "success": True,
+                "message": {"status": "terminating"},
+            }
+        )
+
+    async def process_service_command(self):
+        self.logger.info("Starting service command processing ...")
+
+        while not self.interrupted.is_set():
+            try:
+                # Wait for a request with timeout to allow checking if still running
+                try:
+                    parts = await asyncio.wait_for(self.service_command_socket.recv_multipart(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                if VERBOSE_DEBUG:
+                    self.logger.debug(f"{parts=}")
+
+                # For commanding, we only accept simple commands as a string or a complex command with arguments as
+                # JSON data. In both cases, there are only three parts in this multipart message.
+                client_id, sequence_id, message_type, data = parts
+                if message_type == b"MESSAGE_TYPE:STRING":
+                    service_command = {"command": data.decode("utf-8")}
+                elif message_type == b"MESSAGE_TYPE:JSON":
+                    service_command = json.loads(data.decode())
+                else:
+                    filename, lineno, function_name = get_current_location()
+                    # We have an unknown message format, send an error message back
+                    message = zmq_error_response(
+                        {
+                            "success": False,
+                            "message": f"Incorrect message type: {message_type}",
+                            "metadata": {
+                                "data": data.decode(),
+                                "file": filename,
+                                "lineno": lineno,
+                                "function": function_name,
+                            },
+                        }
+                    )
+                    await self.service_command_socket.send_multipart([client_id, sequence_id, *message])
+                    continue
+
+                self.logger.debug(f"Received service request: {service_command}")
+
+                self.logger.debug("Process the command...")
+                response = await self._process_service_command(service_command)
+
+                self.logger.debug("Send the response...")
+                await self.service_command_socket.send_multipart([client_id, sequence_id, *response])
+
+            except asyncio.CancelledError:
+                self.logger.debug("Service command handling task cancelled.")
+                break
+
+    async def _process_service_command(self, cmd: dict[str, Any]) -> list:
+        command = cmd.get("command")
+        if not command:
+            return zmq_error_response(
+                {
+                    "success": False,
+                    "message": "no command field provide, don't know what to do.",
+                }
+            )
+
+        handler = self.service_command_handlers.get(command)
+        if not handler:
+            filename, lineno, function_name = get_current_location()
+            return zmq_error_response(
+                {
+                    "success": False,
+                    "message": f"Unknown command: {command}",
+                    "metadata": {"file": filename, "lineno": lineno, "function": function_name},
+                }
+            )
+
+        return await handler(cmd)
+
+    async def process_sequential_queue(self):
+        """
+        Process operations that need to be executed sequentially.
+
+        When the operation return "Quit" the processing is interrupted.
+        """
+
+        self.logger.info("Starting sequential queue processing ...")
+
+        while not self.interrupted.is_set():
+            try:
+                operation = await asyncio.wait_for(self._sequential_queue.get(), 0.1)
+                await operation
+                self._sequential_queue.task_done()
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                self.logger.error(f"Error processing sequential operation: {exc}")
+
+    async def send_status_updates(self):
+        """
+        Send status information about the control server and the device connection to the monitoring channel.
+        """
+
+        self.logger.info("Starting status updates ...")
+
+        async def status():
+            self.logger.info(f"{datetime.datetime.now()} Sending status updates.")
+            await asyncio.sleep(0.5)  # ideally, should not be larger than periodic interval
+
+        try:
+            periodic = Periodic(interval=1.0, callback=status)
+            periodic.start()
+
+            await self.interrupted.wait()
+
+            periodic.stop()
+
+        except asyncio.CancelledError:
+            self.logger.debug("Caught CancelledError on status updates keep-alive loop.")
+
+    async def enqueue_sequential_operation(self, coroutine_func):
+        """
+        Add an operation to the sequential queue.
+
+        Args:
+            coroutine_func: A coroutine function (async function) to be executed sequentially
+        """
+
+        if self._sequential_queue is not None:  # sanity check
+            self._sequential_queue.put_nowait(coroutine_func)
+
+
+DEFAULT_CLIENT_REQUEST_TIMEOUT = 5.0  # seconds
+"""Default timeout for sending requests to the control server."""
+DEFAULT_LINGER = 100  # milliseconds
+"""Default linger for ZeroMQ sockets."""
+
+
+class AsyncControlClient:
+    service_type: str | None = None
+
+    def __init__(
+        self,
+        endpoint: str | None = None,
+        service_type: str | None = None,
+        client_id: str = CONTROL_CLIENT_ID,
+        timeout: float = DEFAULT_CLIENT_REQUEST_TIMEOUT,
+        linger: int = DEFAULT_LINGER,
+    ):
+        self.logger = logging.getLogger("egse.async_control.client")
+
+        self.endpoint = endpoint
+        self.service_type = service_type or self.__class__.service_type
+        self.timeout = timeout  # seconds
+        self.linger = linger  # milliseconds
+        self._client_id = f"{client_id}-{uuid.uuid4()}".encode()
+        self._sequence = 0
+
+        self.context: zmq.asyncio.Context = zmq.asyncio.Context.instance()
+
+        self.device_command_socket: zmq.asyncio.Socket | None = self.context.socket(zmq.DEALER)
+        self.service_command_socket: zmq.asyncio.Socket | None = self.context.socket(zmq.DEALER)
+
+        self.device_command_port: int = 0
+        self.service_command_port: int = 0
+
+        self._post_init_is_done = False
+
+    async def _post_init(self) -> bool:
+        """
+        A post initialization method that sets the device and service commanding
+        ports and the endpoint for this client. The information is retrieved from
+        the service registry.
+
+        Returns:
+            The method returns True if the device and service commanding port and
+            the endpoint could be determined from the service registry.
+
+            If the post initialization step has already been called, a warning is
+            issued, and the method returns True.
+
+            If no service_type is known or the service_type is not registered,
+            False is returned.
+
+        """
+        if self._post_init_is_done:
+            self.logger.warning("The post_init function is already called, returning.")
+            return True
+
+        self._post_init_is_done = True
+        if self.service_type:
+            with AsyncRegistryClient() as registry:
+                service = await registry.discover_service(self.service_type)
+            if service:
+                hostname = service["host"]
+                self.device_command_port = port = service["port"]
+                self.service_command_port = service["metadata"]["service_port"]
+                self.endpoint = f"tcp://{hostname}:{port}"
+                return True
+            else:
+                return False
+
+        return False
+
+    # Q: Why do we need this create method here?
+    # A: The constructor (`__init__`) can not be an async method and to properly initialise the client,
+    # we need to contact the ServiceRegistry for the hostname and port numbers. The service discovery
+    # is an async operation.
+    #
+    # Additionally, it's not a good idea to perform such initialization inside the constructor of the
+    # class anyway. The class can also be called as an async context manager, in which case the create()
+    # is not needed and the post initialization will be done in the `__aenter__` method.
+
+    @classmethod
+    async def create(cls, service_type: str | None = None) -> AsyncControlClient:
+        """Factory method that creates an AsyncControlClient and collects information about the service it needs to
+        connect to."""
+        resolved_service_type = service_type or cls.service_type
+        if not resolved_service_type:
+            raise InitializationError(
+                "Could not initialise AsyncControlClient, no service_type provided and no class default configured."
+            )
+
+        client = cls(service_type=resolved_service_type)
+        if not await client._post_init():
+            raise InitializationError(
+                "Could not initialise AsyncControlClient, "
+                f"no service_type ({resolved_service_type}) found. "
+                "Will not be able to connect to the control server."
+            )
+        return client
+
+    async def send_device_command(
+        self,
+        request: dict[str, Any] | str,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Send a command over the device command channel."""
+        return await self._send_request(SocketType.DEVICE, request, timeout=timeout)
+
+    async def send_service_command(
+        self,
+        request: dict[str, Any] | str,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Send a command over the service command channel."""
+        return await self._send_request(SocketType.SERVICE, request, timeout=timeout)
+
+    def connect(self):
+        self.connect_device_command_socket()
+        self.connect_service_command_socket()
+
+    def disconnect(self):
+        self.disconnect_device_command_socket()
+        self.disconnect_service_command_socket()
+
+    def connect_device_command_socket(self):
+        if self.endpoint is None:
+            self.logger.warning("Cannot connect device command socket: endpoint is not defined.")
+            return
+        if self.device_command_socket is None:
+            self.device_command_socket = self.context.socket(zmq.DEALER)
+        self.device_command_socket.setsockopt(zmq.LINGER, self.linger)
+        self.device_command_socket.setsockopt(zmq.IDENTITY, self._client_id)
+        self.device_command_socket.connect(self.endpoint)
+
+    def connect_service_command_socket(self):
+        if self.endpoint is None:
+            self.logger.warning("Cannot connect service command socket: endpoint is not defined.")
+            return
+
+        if self.service_command_port == 0:
+            self.logger.warning("Service command port is 0 when connecting socket.")
+
+        if self.service_command_socket is None:
+            self.service_command_socket = self.context.socket(zmq.DEALER)
+        self.service_command_socket.setsockopt(zmq.LINGER, self.linger)
+        self.service_command_socket.setsockopt(zmq.IDENTITY, self._client_id)
+        self.service_command_socket.connect(set_address_port(self.endpoint, self.service_command_port))
+
+    def disconnect_device_command_socket(self):
+        if self.device_command_socket:
+            self.device_command_socket.setsockopt(zmq.LINGER, 100)
+            self.device_command_socket.close()
+            self.device_command_socket = None
+
+    def disconnect_service_command_socket(self):
+        if self.service_command_socket:
+            self.service_command_socket.setsockopt(zmq.LINGER, 100)
+            self.service_command_socket.close()
+            self.service_command_socket = None
+
+    async def __aenter__(self):
+        if not self._post_init_is_done:
+            if not await self._post_init():
+                raise InitializationError(
+                    f"Could not initialise AsyncControlClient, no service_type ({self.service_type}) found. Will not "
+                    f"be able to connect to the control server."
+                )
+                return self
+
+        self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    async def do(self, cmd: dict[str, Any], timeout: float = 5.0) -> dict[str, Any]:
+        """
+        Sends a device command to the control server and waits for a response.
+
+        Args:
+            cmd (dict): The command to send. Should contain at least a 'command' key.
+            timeout (float, optional): Maximum time to wait for a response in seconds. Defaults to 5.0.
+
+        Returns:
+            dict: The response from the control server. Contains at least:
+                - 'success' (bool): True if the command was processed successfully, False otherwise.
+                - 'message' (str or dict): The server's response or an error message.
+
+        Notes:
+            If the request times out or a socket error occurs, the method attempts
+            to reset the sockets and returns a response with 'success' set to False
+            and an appropriate error message.
+        """
+        response = await self.send_device_command(cmd, timeout=timeout)
+        return response
+
+    async def block(self, sleep: int, timeout: int | None = None) -> str | None:
+        cmd = {"command": "block", "sleep": sleep}
+        response = await self.send_service_command(cmd, timeout=timeout)
+        if response["success"]:
+            return response["message"]
+        else:
+            self.logger.error(f"Server returned an error: {response['message']}")
+            return None
+
+    async def ping(self, timeout: int | None = None) -> str | None:
+        response = await self.send_service_command("ping", timeout=timeout)
+        if response["success"]:
+            return response["message"]
+        else:
+            self.logger.error(f"Server returned an error: {response['message']}")
+            return None
+
+    async def info(self) -> str | None:
+        response = await self.send_service_command("info")
+        if response["success"]:
+            return response["message"]
+        else:
+            self.logger.error(f"Server returned an error: {response['message']}")
+            return None
+
+    async def stop_server(self) -> dict | None:
+        response = await self.send_service_command("terminate")
+        if response["success"]:
+            return response["message"]
+        else:
+            self.logger.error(f"Server returned an error: {response['message']}")
+            return None
+
+    async def _send_request(
+        self,
+        socket_type: SocketType,
+        request: dict[str, Any] | str,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Send a request to the control server and get the response.
+
+        A request can be a string with a simple command, e.g. 'ping', or it can be a dictionary
+        in which case it will be sent as a JSON request. The dictionary shall have the following format:
+
+            request = {
+                'command': <the command string without arguments>,
+                'args': [*args],
+                'kwargs': {**kwargs},
+            }
+
+        The response from the server will always be a dictionary with at least the following structure:
+
+            response = {
+                'success': <True or False>,
+                'message': <The content of the data returned by the server>,
+            }
+
+        Args:
+            socket_type: socket type to use for the command request.
+            request: The request to send to the control server.
+            timeout: how many seconds before the request times out.
+
+        Returns:
+            The response from the control server as a dictionary.
+        """
+
+        timeout = timeout or self.timeout
+
+        socket = self._get_socket(socket_type)
+        self._sequence += 1
+        try:
+            if socket is None:
+                raise RuntimeError("Socket of the AsyncControlClient is not initialized.")
+
+            if isinstance(request, str):
+                message = zmq_string_request(request)
+            elif isinstance(request, dict):
+                message = zmq_json_request(request)
+            else:
+                raise ValueError(f"request argument shall be a string or a dictionary, not {type(request)}.")
+
+            if VERBOSE_DEBUG:
+                self.logger.debug(f"Sending multipart message: {message}")
+
+            await socket.send_multipart([str(self._sequence).encode(), *message])
+
+            while True:
+                sequence, msg_type, data = await asyncio.wait_for(socket.recv_multipart(), timeout=timeout)
+
+                if VERBOSE_DEBUG:
+                    self.logger.debug(f"Received multipart message: {sequence}, {msg_type}, {data}")
+
+                if int(sequence.decode()) < self._sequence:
+                    self.logger.warning(
+                        f"Received a reply from a previous command: {int(sequence.decode())}, {msg_type}, {data}, "
+                        f"current sequence id = {self._sequence}"
+                    )
+                    continue
+                elif int(sequence.decode()) > self._sequence:
+                    self.logger.error(
+                        f"Protocol violation: received reply for future request {sequence} "
+                        f"(current sequence: {self._sequence}). "
+                        f"Possible bug or multiple clients with the same identity."
+                    )
+                    raise RuntimeError(
+                        f"Protocol violation: "
+                        f"Got a reply with a future sequence id {sequence}, current sequence id is {self._sequence}."
+                    )
+
+                if msg_type == b"MESSAGE_TYPE:STRING":
+                    return {"success": True, "message": data.decode("utf-8")}
+                elif msg_type == b"MESSAGE_TYPE:JSON":
+                    return json.loads(data)
+                elif msg_type == b"MESSAGE_TYPE:ERROR":
+                    return pickle.loads(data)
+                else:
+                    msg = f"Unknown server response message type: {msg_type}"
+                    self.logger.error(msg)
+                    return {"success": False, "message": msg}
+
+        except asyncio.TimeoutError:
+            self.logger.error(f"{socket_type.name} request timed out after {timeout:.3f}s")
+            self.recreate_socket(socket_type)
+            return {
+                "success": False,
+                "message": f"Request timed out after {timeout:.3f}s",
+            }
+
+        except zmq.ZMQError as exc:
+            self.logger.error(f"ZMQ error: {exc}")
+            self.recreate_socket(socket_type)
+            return {
+                "success": False,
+                "message": f"ZMQError: {exc}",
+            }
+
+        except Exception as exc:
+            self.logger.error(f"Error sending request: {type(exc).__name__} – {exc}")
+            traceback = Traceback.from_exception(
+                type(exc),
+                exc,
+                exc.__traceback__,
+                show_locals=True,  # Optional: show local variables
+                width=None,  # Optional: use full width
+                extra_lines=3,  # Optional: context lines
+            )
+            log_rich_output(self.logger, logging.ERROR, traceback)
+            return {"success": False, "message": str(exc)}
+
+    def _get_socket(self, socket_type: SocketType):
+        match socket_type:
+            case SocketType.DEVICE:
+                return self.device_command_socket
+            case SocketType.SERVICE:
+                return self.service_command_socket
+
+    def recreate_socket(self, socket_type: SocketType):
+        if RECREATE_SOCKET:
+            self.logger.warning(f"Recreating {socket_type.name} socket ...")
+            match socket_type:
+                case SocketType.DEVICE:
+                    self.disconnect_device_command_socket()
+                    self.connect_device_command_socket()
+                case SocketType.SERVICE:
+                    self.disconnect_service_command_socket()
+                    self.connect_service_command_socket()
+        else:
+            self.logger.debug("Socket recreation after timeout has been disabled.")
+
+
+class TypedAsyncControlClient(AsyncControlClient):
+    """Small helper base class for client subclasses with typed command wrappers.
+
+    Subclasses can call these helpers to keep command methods concise and consistent.
+    """
+
+    def _success_message(self, response: dict[str, Any], command_name: str) -> Any | None:
+        if response.get("success"):
+            return response.get("message")
+        self.logger.error(f"{command_name} failed: {response.get('message')}")
+        return None
+
+    def _success_message_as_str(self, response: dict[str, Any], command_name: str) -> str | None:
+        message = self._success_message(response, command_name)
+        if message is None:
+            return None
+        if isinstance(message, str):
+            return message
+        self.logger.error(f"{command_name} returned non-string message: {type(message).__name__}")
+        return None
+
+    def _success_message_as_dict(self, response: dict[str, Any], command_name: str) -> dict[str, Any] | None:
+        message = self._success_message(response, command_name)
+        if message is None:
+            return None
+        if isinstance(message, dict):
+            return message
+        self.logger.error(f"{command_name} returned non-dict message: {type(message).__name__}")
+        return None
+
+
+async def cs_test_device_command_timeouts():
+    """
+    This test is about timeouts on the client and blocking commands on the server
+    for *device commands*.
+
+    We start a control server which will register to the service registry and
+    send out heartbeats.
+
+    We start a control client that will connect to the server through its service type.
+    Then we send the following commands, from the client perspective:
+
+    - send a 'block' device command of 8s and a timeout of 3s. This will block the
+      device commanding part on the server for ten seconds. The client will
+      time out on this command after three seconds.
+    - sleep for ten seconds.
+    - send a 'say' command with a timeout of 2s. This will return immediately.
+
+    The client should properly discard the server reply from the timed out block
+    command. You should see a warning message saying a reply was received from a
+    previous command. The 'say' command should receive its response as expected.
+
+    """
+
+    # First start the control server as a background task.
+    server = AsyncControlServer()
+    server_task = asyncio.create_task(server.start())
+
+    logger.info("Starting Asynchronous Control Server ...")
+
+    # Give the control server the time to start up
+    logger.info("Sleep for 0.5s...")
+    await asyncio.sleep(0.5)
+
+    # As of now, the server_task is running 'in the background' in the event loop.
+
+    # Now create a control client that will connect to the above server.
+    async with AsyncControlClient(service_type=CONTROL_SERVER_SERVICE_TYPE) as client:
+        # Sleep some time, so we can see the control server in action, e.g. status reports, housekeeping, etc
+        logger.info("Sleep for 5s...")
+        await asyncio.sleep(5.0)
+
+        logger.info("Send a blocking device command, duration is 8s, timeout is 3s.")
+        response = await client.do({"command": "block", "sleep": 8}, timeout=3)
+        logger.info(f"block: {response=}")
+
+        if response["success"] or "timed out" not in response["message"]:
+            logger.error(f"Did not get expected message from server: {response['message']}")
+
+        logger.info("Sleep for 10s...")
+        await asyncio.sleep(10.0)
+
+        logger.info("Send a 'say' device command, timeout is 2s.")
+        response = await client.do({"command": "say", "message": "Hello, World!"}, timeout=2.0)
+        logger.info(f"say: {response=}")
+
+        if not response["success"] or "Hello, World!" not in response["message"]:
+            logger.error(f"Did not get expected message from server: {response['message']}")
+
+        is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+        logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+        logger.info("Sleeping 1s before terminating the server...")
+        await asyncio.sleep(1.0)
+
+        logger.info("Terminating the server.")
+        response = await client.stop_server()
+        logger.info(f"stop_server: {response = }")
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+    await server_task
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+
+async def cs_test_service_command_timeouts():
+    """
+    This test is about timeouts on the client and blocking commands on the server
+    for *service commands*.
+
+    We start a control server which will register to the service registry and
+    send out heartbeats.
+
+    We start a control client that will connect to the server through its service type.
+    Then we send the following commands, from the client perspective:
+
+    - send a 'block' service command of 8s and a timeout of 3s. This will block the
+      service commanding part on the server for ten seconds. The client will
+      time out on this command after three seconds.
+    - sleep for ten seconds.
+    - send a 'info' command with a timeout of 2s. This will return immediately.
+
+    The client should properly discard the server reply from the timed out block
+    command. You should see a warning message saying a reply was received from a
+    previous command. The 'info' command should receive its response as expected.
+
+    """
+
+    # First start the control server as a background task.
+    server = AsyncControlServer()
+    server_task = asyncio.create_task(server.start())
+
+    logger.info("Starting Asynchronous Control Server ...")
+
+    # Give the control server the time to start up
+    logger.info("Sleep for 0.5s...")
+    await asyncio.sleep(0.5)
+
+    # As of now, the server_task is running 'in the background' in the event loop.
+
+    # Now create a control client that will connect to the above server.
+    async with AsyncControlClient(service_type=CONTROL_SERVER_SERVICE_TYPE) as client:
+        # Sleep some time, so we can see the control server in action, e.g. status reports, housekeeping, etc
+        logger.info("Sleep for 5s...")
+        await asyncio.sleep(5.0)
+
+        logger.info("Send a blocking service command, duration is 8s, timeout is 3s.")
+        response = await client.block(sleep=8, timeout=3)
+        logger.info(f"service block: {response=}")
+
+        logger.info("Sleep for 10s...")
+        await asyncio.sleep(10.0)
+
+        logger.info("Get info on the control server.")
+        response = await client.info()
+        logger.info(f"service info: {response=}")
+
+        is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+        logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+        logger.info("Sleeping 1s before terminating the server...")
+        await asyncio.sleep(1.0)
+
+        logger.info("Terminating the server.")
+        response = await client.stop_server()
+        logger.info(f"stop_server: {response = }")
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+    await server_task
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+
+async def control_server_test():
+    # First start the control server as a background task.
+    server = AsyncControlServer()
+    server_task = asyncio.create_task(server.start())
+
+    logger.info("Starting Asynchronous Control Server ...")
+
+    # Give the control server the time to start up
+    logger.info("Sleep for 0.5s...")
+    await asyncio.sleep(0.5)
+
+    # As of now, the server_task is running 'in the background' in the event loop.
+
+    # Now create a control client that will connect to the above server.
+    async with AsyncControlClient(service_type=CONTROL_SERVER_SERVICE_TYPE) as client:
+        # Sleep some time, so we can see the control server in action, e.g. status reports, housekeeping, etc
+        logger.info("Sleep for 5s...")
+        await asyncio.sleep(5.0)
+
+        logger.info("Send a 'ping' service command...")
+        response = await client.ping()
+        logger.info(f"ping service command: {response = }")  # should be: response = 'pong'
+
+        logger.info("Send an 'info' service command...")
+        response = await client.info()
+        logger.info(f"info service command: {response = }")  # should be: response = {'name': 'AsyncControlServer', ...
+
+        logger.info("Send an 'info' device command...")
+        # info() is a service command and not a device command, so this will fail.
+        response = await client.do({"command": "info"})
+        # should be: response={'success': False, 'message': 'Unknown command: info', ...
+        logger.info(f"info device command: {response=}")
+
+        # this will block commanding since device commands are executed in the same task
+        # the do() will timeout after 3s, but the block command will run for 10s on the
+        # server, and it will send back an ACK (which will be caught and interpreted by
+        # –in this case– the seconds do 'say' command, which will not yet have timed out.
+        logger.info("Send a blocking device command, duration is 9s, timeout is 3s.")
+        response = await client.do({"command": "block", "sleep": 9}, timeout=3.0)
+        # should be: response={'success': False, 'message': 'Request timed out after 3.000s'}
+        logger.info(f"Blocking device command: {response=}")
+
+        # ping() is a service command, so this is not blocked by the above block() command
+        logger.info("Send a 'ping' service command...")
+        response = await client.ping()
+        logger.info(f"ping service command: {response=}")
+
+        # say() is a device command and will time out after 2s because the above blocking
+        # block() command is still running on the server
+        logger.info("Send a 'say' device command, timeout is 2s.")
+        response = await client.do({"command": "say", "message": "Hello, World!"}, timeout=2.0)
+        logger.info(f"say device command: {response=}")
+
+        # Sleep some time, so we can see the control server in action, e.g. status reports, housekeeping, etc
+        logger.info("Sleep for 10s...")
+        await asyncio.sleep(10.0)
+
+        # This time we won't let the command time out...
+        logger.info("Send a 'say' device command, timeout is 2s.")
+        response = await client.do({"command": "say", "message": "Hello, Again!"}, timeout=2.0)
+        logger.info(f"say device command: {response=}")
+
+        is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+        logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+        logger.info("Sleeping 1s before terminating the server...")
+        await asyncio.sleep(1.0)
+
+        logger.info("Terminating the server.")
+        response = await client.stop_server()
+        logger.info(f"stop_server: {response = }")
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+    await server_task
+
+    is_active = await is_control_server_active(service_type=CONTROL_SERVER_SERVICE_TYPE)
+    logger.info(f"Server status: {'active' if is_active else 'unreachable'}")
+
+
+if __name__ == "__main__":
+    # The statement logging.captureWarnings(True) redirects Python's warnings module output
+    # (such as warnings.warn(...)) to the logging system, so warnings appear in your logs
+    # instead of just printing to stderr. This is useful for unified logging and easier
+    # debugging, especially in larger applications.
+    logging.captureWarnings(True)
+
+    try:
+        main_task = asyncio.run(cs_test_device_command_timeouts())
+        # main_task = asyncio.run(cs_test_service_command_timeouts())
+        # main_task = asyncio.run(control_server_test())
+    except KeyboardInterrupt:
+        print("Caught KeyboardInterrupt, terminating.")

--- a/libs/cgse-core/src/egse/async_dummy.py
+++ b/libs/cgse-core/src/egse/async_dummy.py
@@ -8,6 +8,17 @@ import threading
 from typing import Any
 from typing import Callable
 
+try:
+    from typing import override
+except ImportError:
+    try:
+        from typing_extensions import override
+    except ImportError:
+
+        def override(method, /):
+            return method
+
+
 import typer
 
 from egse.async_control import AcquisitionAsyncControlServer
@@ -108,6 +119,7 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
         self._daq_simulator: DummyDAQSimulator | None = None
         super().__init__()
 
+    @override
     def register_custom_handlers(self):
         """Register dummy command handlers, including acquisition lifecycle commands."""
         self.add_device_command_handler("echo", self._do_echo)
@@ -116,6 +128,7 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
         self.add_device_command_handler("stop-acquisition", self._do_stop_acquisition)
         self.add_service_command_handler("health", self._handle_health)
 
+    @override
     def get_service_info(self) -> dict[str, Any]:
         """Return service metadata, including acquisition state and counters."""
         info = super().get_service_info()
@@ -226,6 +239,7 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
         await asyncio.to_thread(simulator.stop)
         return True
 
+    @override
     async def handle_acquisition_record(self, record: dict[str, Any]):
         """Receive one processed acquisition record and log it."""
         self._acquisition_logged_count += 1
@@ -246,6 +260,7 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
             }
         )
 
+    @override
     def stop(self):
         """Stop acquisition first, then stop the base server lifecycle."""
         if self._is_acquisition_running():

--- a/libs/cgse-core/src/egse/async_dummy.py
+++ b/libs/cgse-core/src/egse/async_dummy.py
@@ -1,14 +1,91 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import random
+import threading
+import time
 from typing import Any
+from typing import Callable
 
-from egse.async_control import AsyncControlServer
+from egse.async_control import AcquisitionAsyncControlServer
 from egse.async_control import TypedAsyncControlClient
+from egse.system import do_every
 from egse.zmq_ser import zmq_json_response
 from egse.zmq_ser import zmq_string_response
 
 
-class DummyAsyncControlServer(AsyncControlServer):
+class DummyDAQSimulator:
+    """Minimal DAQ-like simulator that invokes a callback from a dedicated thread.
+
+    This simulator produces records with a simple sequence number and random value at a configurable interval.
+    It can be instantiated and started/stopped multiple times to test acquisition lifecycle management
+    in the control server. The acquisition callback is invoked in a try/except block to prevent thread crashes
+    from exceptions in the callback, which can help with debugging issues in the control server without
+    losing the simulator thread.
+
+    An example use can be found in the `start-acquisition` command handler of `DummyAsyncControlServer`,
+    which creates and starts the simulator, and in the `stop_acquisition` method, which stops it.
+    """
+
+    def __init__(self, callback: Callable[..., None], interval_s: float):
+        """Create a thread-backed producer.
+
+        Args:
+            callback: Acquisition callback provided by the control server.
+            interval_s: Time between produced records.
+        """
+        self._callback = callback
+        self._interval_s = interval_s
+        self._running = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._sequence = 0
+        self.logger = logging.getLogger("egse.dummy_daq_simulator")
+
+    @property
+    def running(self) -> bool:
+        """Return True when the simulator thread is alive and acquisition is enabled."""
+        return self._running.is_set() and self._thread is not None and self._thread.is_alive()
+
+    def start(self):
+        """Start the simulator thread if it is not already running."""
+        if self.running:
+            return
+        self._running.set()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="dummy-daq-simulator")
+        self._thread.start()
+
+    def stop(self):
+        """Stop the simulator thread and wait briefly for it to exit."""
+        self._running.clear()
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        self._thread = None
+
+    def _callback_wrapper(self):
+        """Invoke the acquisition callback and catch any exceptions to prevent thread crashes."""
+        try:
+            self._sequence += 1
+            self._callback(
+                {
+                    "sequence": self._sequence,
+                    "value": random.random(),
+                },
+                source="dummy-acquisition",
+                metadata={"interval": self._interval_s, "origin": "dummy-daq-simulator"},
+            )
+        except Exception as exc:
+            # Log exceptions from the callback to help debug issues without crashing the thread
+            self.logger.error(f"Exception in DummyDAQSimulator callback: {type(exc).__name__}: {exc}")
+
+    def _run(self):
+        do_every(self._interval_s, self._callback_wrapper, stop_event=self._stop)
+
+
+class DummyAsyncControlServer(AcquisitionAsyncControlServer):
     """Example async control server showing what belongs in a subclass.
 
     The superclass handles sockets, request/response framing, registration, lifecycle,
@@ -21,34 +98,136 @@ class DummyAsyncControlServer(AsyncControlServer):
     def __init__(self):
         self._last_value: str | None = None
         self._echo_count = 0
+        self._acquisition_logged_count = 0
+        self._acquisition_interval_s = 0.05
+        self._daq_simulator: DummyDAQSimulator | None = None
         super().__init__()
 
     def register_custom_handlers(self):
+        """Register dummy command handlers, including acquisition lifecycle commands."""
         self.add_device_command_handler("echo", self._do_echo)
         self.add_device_command_handler("set-value", self._do_set_value)
+        self.add_device_command_handler("start-acquisition", self._do_start_acquisition)
+        self.add_device_command_handler("stop-acquisition", self._do_stop_acquisition)
         self.add_service_command_handler("health", self._handle_health)
 
     def get_service_info(self) -> dict[str, Any]:
+        """Return service metadata, including acquisition state and counters."""
         info = super().get_service_info()
         info.update(
             {
-                "supports": ["echo", "set-value", "health", "ping", "info", "terminate"],
+                "supports": [
+                    "echo",
+                    "set-value",
+                    "start-acquisition",
+                    "stop-acquisition",
+                    "health",
+                    "ping",
+                    "info",
+                    "terminate",
+                ],
                 "echo count": self._echo_count,
                 "last value": self._last_value,
+                "acquisition running": self._is_acquisition_running(),
+                "acquisition logged": self._acquisition_logged_count,
+                "acquisition interval": self._acquisition_interval_s,
             }
         )
         return info
 
     async def _do_echo(self, cmd: dict[str, Any]) -> list:
+        """Echo the provided message and increment a call counter."""
         payload = str(cmd.get("message", ""))
         self._echo_count += 1
         return zmq_string_response(payload)
 
     async def _do_set_value(self, cmd: dict[str, Any]) -> list:
+        """Store a value in memory so tests can verify device state transitions."""
         self._last_value = str(cmd.get("value", ""))
         return zmq_json_response({"success": True, "message": {"stored": self._last_value}})
 
+    def _is_acquisition_running(self) -> bool:
+        """Return True when the DAQ simulator is actively producing samples."""
+        return self._daq_simulator is not None and self._daq_simulator.running
+
+    async def _do_start_acquisition(self, cmd: dict[str, Any]) -> list:
+        """Start the DAQ simulator and stream samples through the acquisition callback."""
+        interval_s = float(cmd.get("interval", self._acquisition_interval_s))
+        if interval_s <= 0:
+            return zmq_json_response(
+                {
+                    "success": False,
+                    "message": {"error": "interval must be > 0"},
+                }
+            )
+
+        self._acquisition_interval_s = interval_s
+
+        # Don't start a new simulator if one is already running, but return success with the current state
+        if self._is_acquisition_running():
+            return zmq_json_response(
+                {
+                    "success": True,
+                    "message": {
+                        "running": True,
+                        "interval": self._acquisition_interval_s,
+                        "already_running": True,
+                    },
+                }
+            )
+
+        callback = self.get_acquisition_callback()
+
+        # The DummyDAQSimulator runs in a separate thread and invokes the callback for each produced record.
+        self._daq_simulator = DummyDAQSimulator(callback=callback, interval_s=self._acquisition_interval_s)
+        self._daq_simulator.start()
+
+        return zmq_json_response(
+            {
+                "success": True,
+                "message": {
+                    "running": True,
+                    "interval": self._acquisition_interval_s,
+                    "already_running": False,
+                },
+            }
+        )
+
+    async def _do_stop_acquisition(self, cmd: dict[str, Any]) -> list:
+        """Stop acquisition and return status/counter information."""
+        was_running = await self.stop_acquisition()
+        return zmq_json_response(
+            {
+                "success": True,
+                "message": {
+                    "running": False,
+                    "stopped": was_running,
+                    "acquisition logged": self._acquisition_logged_count,
+                },
+            }
+        )
+
+    async def stop_acquisition(self) -> bool:
+        """Stop the simulator thread without blocking the event loop.
+
+        Returns:
+            True if acquisition was running and has been stopped, otherwise False.
+        """
+        simulator = self._daq_simulator
+        if simulator is None:
+            return False
+
+        self._daq_simulator = None
+        await asyncio.to_thread(simulator.stop)
+        return True
+
+    async def handle_acquisition_record(self, record: dict[str, Any]):
+        """Receive one processed acquisition record and log it."""
+        self._acquisition_logged_count += 1
+        self.logger.info(f"Dummy acquisition record {self._acquisition_logged_count}: {record.get('data')}")
+
     async def _handle_health(self, cmd: dict[str, Any]) -> list:
+        """Return a compact health payload for monitoring and tests."""
         return zmq_json_response(
             {
                 "success": True,
@@ -56,9 +235,21 @@ class DummyAsyncControlServer(AsyncControlServer):
                     "status": "ok",
                     "echo count": self._echo_count,
                     "last value": self._last_value,
+                    "acquisition running": self._is_acquisition_running(),
+                    "acquisition logged": self._acquisition_logged_count,
                 },
             }
         )
+
+    def stop(self):
+        """Stop acquisition first, then stop the base server lifecycle."""
+        if self._is_acquisition_running():
+            if self._loop is not None and self._loop.is_running():
+                self._loop.create_task(self.stop_acquisition())
+            elif self._daq_simulator is not None:
+                self._daq_simulator.stop()
+                self._daq_simulator = None
+        super().stop()
 
 
 class DummyAsyncControlClient(TypedAsyncControlClient):
@@ -67,10 +258,12 @@ class DummyAsyncControlClient(TypedAsyncControlClient):
     service_type = DummyAsyncControlServer.service_type
 
     async def echo(self, message: str, timeout: float | None = None) -> str | None:
+        """Send an `echo` device command and return the echoed message."""
         response = await self.send_device_command({"command": "echo", "message": message}, timeout=timeout)
         return self._success_message_as_str(response, "echo")
 
     async def set_value(self, value: str, timeout: float | None = None) -> str | None:
+        """Send `set-value` and return the stored value from the device response."""
         response = await self.send_device_command({"command": "set-value", "value": value}, timeout=timeout)
         message = self._success_message_as_dict(response, "set-value")
         if message is None:
@@ -78,5 +271,19 @@ class DummyAsyncControlClient(TypedAsyncControlClient):
         return str(message.get("stored"))
 
     async def health(self, timeout: float | None = None) -> dict[str, Any] | None:
+        """Return the dummy server health payload."""
         response = await self.send_service_command("health", timeout=timeout)
         return self._success_message_as_dict(response, "health")
+
+    async def start_acquisition(self, interval: float = 0.05, timeout: float | None = None) -> dict[str, Any] | None:
+        """Start simulator-backed acquisition with the requested sample interval."""
+        response = await self.send_device_command(
+            {"command": "start-acquisition", "interval": interval},
+            timeout=timeout,
+        )
+        return self._success_message_as_dict(response, "start-acquisition")
+
+    async def stop_acquisition(self, timeout: float | None = None) -> dict[str, Any] | None:
+        """Stop simulator-backed acquisition and return final acquisition status."""
+        response = await self.send_device_command({"command": "stop-acquisition"}, timeout=timeout)
+        return self._success_message_as_dict(response, "stop-acquisition")

--- a/libs/cgse-core/src/egse/async_dummy.py
+++ b/libs/cgse-core/src/egse/async_dummy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+from egse.async_control import AsyncControlServer
+from egse.async_control import TypedAsyncControlClient
+from egse.zmq_ser import zmq_json_response
+from egse.zmq_ser import zmq_string_response
+
+
+class DummyAsyncControlServer(AsyncControlServer):
+    """Example async control server showing what belongs in a subclass.
+
+    The superclass handles sockets, request/response framing, registration, lifecycle,
+    task management, and common service commands. This subclass only defines
+    device-specific commands and extra service metadata.
+    """
+
+    service_type = "dummy-async-control-server"
+
+    def __init__(self):
+        self._last_value: str | None = None
+        self._echo_count = 0
+        super().__init__()
+
+    def register_custom_handlers(self):
+        self.add_device_command_handler("echo", self._do_echo)
+        self.add_device_command_handler("set-value", self._do_set_value)
+        self.add_service_command_handler("health", self._handle_health)
+
+    def get_service_info(self) -> dict[str, Any]:
+        info = super().get_service_info()
+        info.update(
+            {
+                "supports": ["echo", "set-value", "health", "ping", "info", "terminate"],
+                "echo count": self._echo_count,
+                "last value": self._last_value,
+            }
+        )
+        return info
+
+    async def _do_echo(self, cmd: dict[str, Any]) -> list:
+        payload = str(cmd.get("message", ""))
+        self._echo_count += 1
+        return zmq_string_response(payload)
+
+    async def _do_set_value(self, cmd: dict[str, Any]) -> list:
+        self._last_value = str(cmd.get("value", ""))
+        return zmq_json_response({"success": True, "message": {"stored": self._last_value}})
+
+    async def _handle_health(self, cmd: dict[str, Any]) -> list:
+        return zmq_json_response(
+            {
+                "success": True,
+                "message": {
+                    "status": "ok",
+                    "echo count": self._echo_count,
+                    "last value": self._last_value,
+                },
+            }
+        )
+
+
+class DummyAsyncControlClient(TypedAsyncControlClient):
+    """Example client wrapper with strongly named methods for dummy commands."""
+
+    service_type = DummyAsyncControlServer.service_type
+
+    async def echo(self, message: str, timeout: float | None = None) -> str | None:
+        response = await self.send_device_command({"command": "echo", "message": message}, timeout=timeout)
+        return self._success_message_as_str(response, "echo")
+
+    async def set_value(self, value: str, timeout: float | None = None) -> str | None:
+        response = await self.send_device_command({"command": "set-value", "value": value}, timeout=timeout)
+        message = self._success_message_as_dict(response, "set-value")
+        if message is None:
+            return None
+        return str(message.get("stored"))
+
+    async def health(self, timeout: float | None = None) -> dict[str, Any] | None:
+        response = await self.send_service_command("health", timeout=timeout)
+        return self._success_message_as_dict(response, "health")

--- a/libs/cgse-core/src/egse/async_dummy.py
+++ b/libs/cgse-core/src/egse/async_dummy.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import sys
 import threading
-import time
 from typing import Any
 from typing import Callable
 
+import typer
+
 from egse.async_control import AcquisitionAsyncControlServer
 from egse.async_control import TypedAsyncControlClient
+from egse.log import logger
+from egse.logger import remote_logging
+from egse.system import TyperAsyncCommand
 from egse.system import do_every
 from egse.zmq_ser import zmq_json_response
 from egse.zmq_ser import zmq_string_response
@@ -287,3 +292,37 @@ class DummyAsyncControlClient(TypedAsyncControlClient):
         """Stop simulator-backed acquisition and return final acquisition status."""
         response = await self.send_device_command({"command": "stop-acquisition"}, timeout=timeout)
         return self._success_message_as_dict(response, "stop-acquisition")
+
+
+app = typer.Typer()
+
+
+@app.command(cls=TyperAsyncCommand)
+async def start_cs():
+    """Start the dummy async control server on localhost."""
+
+    with remote_logging():
+        try:
+            control_server = DummyAsyncControlServer()
+            await control_server.start()
+        except KeyboardInterrupt:
+            print("Shutdown requested...exiting")
+        except SystemExit as exit_code:
+            print(f"System Exit with code {exit_code}.")
+            sys.exit(-1)
+        except Exception:  # noqa
+            import traceback
+
+            traceback.print_exc(file=sys.stdout)
+
+
+@app.command(cls=TyperAsyncCommand)
+async def stop_cs():
+    """Send a quit service command to the dummy async control server."""
+    async with DummyAsyncControlClient() as dummy:
+        logger.info("Sending a stop_server() to the async dummy control server.")
+        await dummy.stop_server()
+
+
+if __name__ == "__main__":
+    app()

--- a/libs/cgse-core/src/egse/async_dummy.py
+++ b/libs/cgse-core/src/egse/async_dummy.py
@@ -82,7 +82,18 @@ class DummyDAQSimulator:
         self._thread = None
 
     def _callback_wrapper(self):
-        """Invoke the acquisition callback and catch any exceptions to prevent thread crashes."""
+        """Invoke the acquisition callback and catch any exceptions to prevent thread crashes.
+
+        This simulates a device driver invoking a callback for each produced record of device information/data.
+        The callback is expected to be provided by the control server and can perform any processing or forwarding
+        of the produced record. Wrapping the callback in a try/except block allows us to log any exceptions that
+        occur without crashing the simulator thread, which can help with debugging issues in the control server's
+        acquisition handling.
+
+        The callback is expected to accept at least one argument which can be anything, but in this case we provide a
+        dictionary with a sequence number and random value to simulate produced records of device data.
+        The callback can also accept additional keyword arguments for metadata, source, etc. if desired.
+        """
         try:
             self._sequence += 1
             self._callback(
@@ -168,6 +179,22 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
         """Return True when the DAQ simulator is actively producing samples."""
         return self._daq_simulator is not None and self._daq_simulator.running
 
+    def custom_callback(self, data, *args, **kwargs):
+        # Do some custom processing of the device driver record here, this might be to extract data from the record, but
+        # the 'record' might also be a handle to a device driver object that can be queried for more information, or it
+        # could be any other data structure depending on how the acquisition callback is invoked by the device
+        # driver/simulator. In this example, we just log the record sequence and value for demonstration purposes,
+        # but in a real control server this is where you would implement the logic to handle incoming acquisition
+        # records, such as parsing the data, applying calibrations, checking for alerts, forwarding to other services,
+        # etc.
+
+        # The DummyDAQSimulator provides a dictionary as the record, but this could be any data structure.
+        record = data
+        logger.debug(f"Custom processing of record {record.get('sequence')} with value {record.get('value')}")
+
+        # Then pass it to the default callback for further processing and finally enqueuing in the acquisition queue.
+        self.on_acquisition_data(record, source="custom", metadata={"processed": True})
+
     async def _do_start_acquisition(self, cmd: dict[str, Any]) -> list:
         """Start the DAQ simulator and stream samples through the acquisition callback."""
         interval_s = float(cmd.get("interval", self._acquisition_interval_s))
@@ -194,7 +221,20 @@ class DummyAsyncControlServer(AcquisitionAsyncControlServer):
                 }
             )
 
+        # This will return the default acquisition callback function that is defined in the superclass.
+        # The default callback expects one positional argument for the acquisition record, which can be any data
+        # structure but in this case we provide a dictionary with a sequence number and random value to simulate
+        # produced records of device data. The default callback also accept optional keyword arguments,
+        # in this case, 'source' and 'metadata' are provided.
+
         callback = self.get_acquisition_callback()
+
+        # Alternatively, you could also define a custom callback function here in the control server subclass that
+        # performs additional processing or forwarding of the produced records, and pass that to the device
+        # acquisition method instead of the default callback from the superclass.
+        # For example:
+
+        # callback = self.custom_callback
 
         # The DummyDAQSimulator runs in a separate thread and invokes the callback for each produced record.
         self._daq_simulator = DummyDAQSimulator(callback=callback, interval_s=self._acquisition_interval_s)

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -1066,7 +1066,8 @@ class AsyncRegistryClient:
 
             return service
         else:
-            self.logger.warning(f"Service discovery failed: {response.get('error')}")
+            if VERBOSE_DEBUG:
+                self.logger.debug(f"Service discovery failed: {response.get('error')}")
             return None
 
     async def get_service(self, service_id: str | None = None) -> dict[str, Any] | None:

--- a/libs/cgse-core/tests/test_async_control.py
+++ b/libs/cgse-core/tests/test_async_control.py
@@ -1,9 +1,11 @@
 import asyncio
+from typing import Any
 from typing import cast
 
 import pytest
 from fixtures.helpers import capture_log_records
 
+from egse.async_control import AcquisitionAsyncControlServer
 from egse.async_control import AsyncControlClient
 from egse.async_control import AsyncControlServer
 from egse.async_control import InitializationError
@@ -11,11 +13,48 @@ from egse.async_control import is_control_server_active
 from egse.async_dummy import DummyAsyncControlClient
 from egse.async_dummy import DummyAsyncControlServer
 from egse.log import logging
+from egse.logger import remote_logging
 from egse.system import type_name
 
 # pytestmark = pytest.mark.skip("Implementation and tests are still a WIP")
 
 logger = logging.getLogger("egse.tests.async_control")
+
+
+class RecordingAsyncControlServer(AcquisitionAsyncControlServer):
+    """Test helper server that records acquisition flow for assertions."""
+
+    def __init__(self):
+        """Initialize in-memory buffers used by acquisition tests."""
+        super().__init__()
+        self.processed_records: list[dict[str, Any]] = []
+        self.processed_batches: list[list[dict[str, Any]]] = []
+        self.processed_event = asyncio.Event()
+        self.expected_records = 0
+
+    async def handle_acquisition_batch(self, records: list[dict[str, Any]]):
+        """Capture batch boundaries before delegating to per-record processing."""
+        self.processed_batches.append(records.copy())
+        await super().handle_acquisition_batch(records)
+
+    async def handle_acquisition_record(self, record: dict[str, Any]):
+        """Capture records and signal when the expected test count is reached."""
+        self.processed_records.append(record)
+        if len(self.processed_records) >= self.expected_records:
+            self.processed_event.set()
+
+
+class SequentialExecutionTestServer(AsyncControlServer):
+    """Test helper server exposing sequential execution behavior."""
+
+    def __init__(self):
+        super().__init__()
+        self.execution_order: list[int] = []
+
+    async def append_after(self, token: int, delay: float):
+        await asyncio.sleep(delay)
+        self.execution_order.append(token)
+        return token
 
 
 @pytest.mark.asyncio
@@ -69,47 +108,213 @@ async def test_control_server(caplog):
 @pytest.mark.asyncio
 async def test_dummy_control_server():
     """Test DummyAsyncControlServer as an implementation example."""
-    server = DummyAsyncControlServer()
-    server_task = asyncio.create_task(server.start())
 
-    await asyncio.sleep(0.5)  # give the server time to startup
+    with remote_logging():
+        server = DummyAsyncControlServer()
+        server_task = asyncio.create_task(server.start())
 
-    # Now create a control client that will connect to the above server.
-    async with DummyAsyncControlClient() as client:
-        response = await client.ping()
-        logger.debug(f"{response = }")
-        assert isinstance(response, str)
-        assert response == "pong"
+        await asyncio.sleep(0.5)  # give the server time to startup
 
-        response = await client.echo("dummy")
-        logger.debug(f"{response = }")
-        assert response == "dummy"
+        # Now create a control client that will connect to the above server.
+        async with DummyAsyncControlClient() as client:
+            response = await client.ping()
+            logger.debug(f"{response = }")
+            assert isinstance(response, str)
+            assert response == "pong"
 
-        response = await client.set_value("configured")
-        logger.debug(f"{response = }")
-        assert response == "configured"
+            response = await client.echo("dummy")
+            logger.debug(f"{response = }")
+            assert response == "dummy"
 
-        info_response = await client.info()
-        logger.debug(f"{info_response = }")
-        assert isinstance(info_response, dict)
-        info_response = cast(dict[str, object], info_response)
-        assert "name" in info_response
-        assert "hostname" in info_response
-        assert "device commanding port" in info_response
-        assert "service commanding port" in info_response
-        assert info_response["service type"] == DummyAsyncControlServer.service_type
-        assert info_response["echo count"] == 1
-        assert info_response["last value"] == "configured"
+            response = await client.set_value("configured")
+            logger.debug(f"{response = }")
+            assert response == "configured"
 
-        health_response = await client.health()
-        logger.debug(f"{health_response = }")
-        assert isinstance(health_response, dict)
-        assert health_response["status"] == "ok"
-        assert health_response["echo count"] == 1
-        assert health_response["last value"] == "configured"
+            info_response = await client.info()
+            logger.debug(f"{info_response = }")
+            assert isinstance(info_response, dict)
+            info_response = cast(dict[str, object], info_response)
+            assert "name" in info_response
+            assert "hostname" in info_response
+            assert "device commanding port" in info_response
+            assert "service commanding port" in info_response
+            assert info_response["service type"] == DummyAsyncControlServer.service_type
+            assert info_response["echo count"] == 1
+            assert info_response["last value"] == "configured"
 
-    server_task.cancel()
-    await server_task
+            health_response = await client.health()
+            logger.debug(f"{health_response = }")
+            assert isinstance(health_response, dict)
+            assert health_response["status"] == "ok"
+            assert health_response["echo count"] == 1
+            assert health_response["last value"] == "configured"
+
+            start_response = await client.start_acquisition(interval=0.02)
+            logger.debug(f"{start_response = }")
+            assert isinstance(start_response, dict)
+            assert start_response["running"] is True
+
+            await asyncio.sleep(1.5)  # this should allow for ~75 records to be acquired at 20ms intervals
+
+            stop_response = await client.stop_acquisition()
+            logger.debug(f"{stop_response = }")
+            assert isinstance(stop_response, dict)
+            assert stop_response["running"] is False
+            assert int(stop_response["acquisition logged"]) > 0
+
+            health_response = await client.health()
+            logger.debug(f"{health_response = }")
+            assert isinstance(health_response, dict)
+            assert health_response["acquisition running"] is False
+            assert int(health_response["acquisition logged"]) > 0
+
+        server_task.cancel()
+        await server_task
+
+
+@pytest.mark.asyncio
+async def test_acquisition_callback_from_thread_is_processed_in_order():
+    server = RecordingAsyncControlServer()
+    server.expected_records = 3
+    server._loop = asyncio.get_running_loop()
+
+    processing_task = asyncio.create_task(server.process_acquisition_data())
+
+    try:
+        callback = cast(Any, server.get_acquisition_callback())
+
+        await asyncio.to_thread(callback, {"value": 1}, source="sensor-a", metadata={"index": 1})
+        await asyncio.to_thread(callback, {"value": 2}, source="sensor-a", metadata={"index": 2})
+        await asyncio.to_thread(callback, {"value": 3}, source="sensor-a", metadata={"index": 3})
+
+        await asyncio.wait_for(server.processed_event.wait(), timeout=1.0)
+
+        assert [record["data"]["value"] for record in server.processed_records] == [1, 2, 3]
+        assert [record["metadata"]["index"] for record in server.processed_records] == [1, 2, 3]
+        assert all(record["source"] == "sensor-a" for record in server.processed_records)
+        assert server.acquisition_dropped_count == 0
+        assert len(server.processed_batches) == 3
+        assert all(len(batch) == 1 for batch in server.processed_batches)
+    finally:
+        server.stop()
+        processing_task.cancel()
+        await asyncio.gather(processing_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_acquisition_callback_same_thread_defaults_to_single_record_processing():
+    server = RecordingAsyncControlServer()
+    server.expected_records = 3
+    server._loop = asyncio.get_running_loop()
+
+    processing_task = asyncio.create_task(server.process_acquisition_data())
+
+    try:
+        callback = cast(Any, server.get_acquisition_callback())
+
+        callback("first", source="sensor-local", metadata={"index": 1})
+        callback("second", source="sensor-local", metadata={"index": 2})
+        callback("third", source="sensor-local", metadata={"index": 3})
+
+        await asyncio.wait_for(server.processed_event.wait(), timeout=1.0)
+
+        assert [record["data"] for record in server.processed_records] == ["first", "second", "third"]
+        assert [record["metadata"]["index"] for record in server.processed_records] == [1, 2, 3]
+        assert all(record["source"] == "sensor-local" for record in server.processed_records)
+        assert server.acquisition_batch_enabled is False
+        assert len(server.processed_batches) == 3
+        assert all(len(batch) == 1 for batch in server.processed_batches)
+    finally:
+        server.stop()
+        processing_task.cancel()
+        await asyncio.gather(processing_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_acquisition_batching_is_optional_and_preserves_order():
+    server = RecordingAsyncControlServer()
+    server.expected_records = 3
+    server.acquisition_batch_enabled = True
+    server.acquisition_batch_max_size = 10
+    server.acquisition_batch_max_wait_s = 0.2
+    server._loop = asyncio.get_running_loop()
+
+    processing_task = asyncio.create_task(server.process_acquisition_data())
+
+    try:
+        callback = cast(Any, server.get_acquisition_callback())
+
+        callback("first", source="sensor-b", metadata={"index": 1})
+        callback("second", source="sensor-b", metadata={"index": 2})
+        callback("third", source="sensor-b", metadata={"index": 3})
+
+        await asyncio.wait_for(server.processed_event.wait(), timeout=1.0)
+
+        assert [record["data"] for record in server.processed_records] == ["first", "second", "third"]
+        assert [record["metadata"]["index"] for record in server.processed_records] == [1, 2, 3]
+        assert len(server.processed_batches) >= 1
+        assert [record["data"] for record in server.processed_batches[0]] == ["first", "second", "third"]
+    finally:
+        server.stop()
+        processing_task.cancel()
+        await asyncio.gather(processing_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_acquisition_queue_overflow_increments_drop_count():
+    server = RecordingAsyncControlServer()
+    server._loop = asyncio.get_running_loop()
+    server._acquisition_queue = asyncio.Queue(maxsize=2)
+
+    callback = cast(Any, server.get_acquisition_callback())
+
+    callback("first", source="sensor-overflow")
+    callback("second", source="sensor-overflow")
+    callback("third", source="sensor-overflow")
+
+    await asyncio.sleep(0)
+
+    assert server._acquisition_queue.qsize() == 2
+    assert server.acquisition_dropped_count == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_sequential_serializes_concurrent_submissions_in_enqueue_order():
+    server = SequentialExecutionTestServer()
+    queue_task = asyncio.create_task(server.process_sequential_queue())
+
+    try:
+        tasks = [
+            asyncio.create_task(server._execute_sequential(server.append_after(1, 0.03))),
+            asyncio.create_task(server._execute_sequential(server.append_after(2, 0.01))),
+            asyncio.create_task(server._execute_sequential(server.append_after(3, 0.0))),
+        ]
+
+        results = await asyncio.gather(*tasks)
+
+        assert results == [1, 2, 3]
+        assert server.execution_order == [1, 2, 3]
+    finally:
+        server.stop()
+        queue_task.cancel()
+        await asyncio.gather(queue_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_execute_sequential_propagates_operation_exceptions():
+    server = SequentialExecutionTestServer()
+    queue_task = asyncio.create_task(server.process_sequential_queue())
+
+    async def failing_operation():
+        raise RuntimeError("boom")
+
+    try:
+        with pytest.raises(RuntimeError, match="boom"):
+            await server._execute_sequential(failing_operation())
+    finally:
+        server.stop()
+        queue_task.cancel()
+        await asyncio.gather(queue_task, return_exceptions=True)
 
 
 if __name__ == "__main__":

--- a/libs/cgse-core/tests/test_async_control.py
+++ b/libs/cgse-core/tests/test_async_control.py
@@ -1,0 +1,117 @@
+import asyncio
+from typing import cast
+
+import pytest
+from fixtures.helpers import capture_log_records
+
+from egse.async_control import AsyncControlClient
+from egse.async_control import AsyncControlServer
+from egse.async_control import InitializationError
+from egse.async_control import is_control_server_active
+from egse.async_dummy import DummyAsyncControlClient
+from egse.async_dummy import DummyAsyncControlServer
+from egse.log import logging
+from egse.system import type_name
+
+# pytestmark = pytest.mark.skip("Implementation and tests are still a WIP")
+
+logger = logging.getLogger("egse.tests.async_control")
+
+
+@pytest.mark.asyncio
+async def test_control_server(caplog):
+    # First start the control server as a background task.
+    server = AsyncControlServer()
+    server_task = asyncio.create_task(server.start())
+
+    await asyncio.sleep(0.5)  # give the server time to startup
+
+    try:
+        # Now create a control client that will connect to the above server.
+        async with AsyncControlClient(service_type="async-control-server") as client:
+            caplog.clear()
+
+            # Sleep some time, so we can see the control server in action, e.g. status reports, housekeeping, etc
+            await asyncio.sleep(5.0)
+
+            assert "Sending status updates" in caplog.text  # this should there be 5 times actually
+
+            response = await client.ping()
+            logger.debug(f"{response = }")
+            assert isinstance(response, str)
+            assert response == "pong"
+
+            response = await client.info()
+            logger.debug(f"{response = }")
+            assert isinstance(response, dict)
+            assert "name" in response
+            assert "hostname" in response
+            assert "device commanding port" in response
+            assert "service commanding port" in response
+
+            assert await is_control_server_active(service_type="async-control-server")
+
+            response = await client.stop_server()
+            logger.debug(f"{response = }")
+            assert isinstance(response, dict)
+            assert response["status"] == "terminating"
+
+            assert await is_control_server_active(service_type="async-control-server")
+    except InitializationError as exc:
+        logger.error(f"Could not create AsyncControlClient: {type_name(exc)}: {exc}")
+
+    server_task.cancel()
+    await server_task
+
+    assert not await is_control_server_active(service_type="async-control-server")
+
+
+@pytest.mark.asyncio
+async def test_dummy_control_server():
+    """Test DummyAsyncControlServer as an implementation example."""
+    server = DummyAsyncControlServer()
+    server_task = asyncio.create_task(server.start())
+
+    await asyncio.sleep(0.5)  # give the server time to startup
+
+    # Now create a control client that will connect to the above server.
+    async with DummyAsyncControlClient() as client:
+        response = await client.ping()
+        logger.debug(f"{response = }")
+        assert isinstance(response, str)
+        assert response == "pong"
+
+        response = await client.echo("dummy")
+        logger.debug(f"{response = }")
+        assert response == "dummy"
+
+        response = await client.set_value("configured")
+        logger.debug(f"{response = }")
+        assert response == "configured"
+
+        info_response = await client.info()
+        logger.debug(f"{info_response = }")
+        assert isinstance(info_response, dict)
+        info_response = cast(dict[str, object], info_response)
+        assert "name" in info_response
+        assert "hostname" in info_response
+        assert "device commanding port" in info_response
+        assert "service commanding port" in info_response
+        assert info_response["service type"] == DummyAsyncControlServer.service_type
+        assert info_response["echo count"] == 1
+        assert info_response["last value"] == "configured"
+
+        health_response = await client.health()
+        logger.debug(f"{health_response = }")
+        assert isinstance(health_response, dict)
+        assert health_response["status"] == "ok"
+        assert health_response["echo count"] == 1
+        assert health_response["last value"] == "configured"
+
+    server_task.cancel()
+    await server_task
+
+
+if __name__ == "__main__":
+    with capture_log_records("egse") as caplog:
+        asyncio.run(test_control_server(caplog=caplog))

--- a/libs/cgse-core/tests/test_async_control.py
+++ b/libs/cgse-core/tests/test_async_control.py
@@ -2,6 +2,17 @@ import asyncio
 from typing import Any
 from typing import cast
 
+try:
+    from typing import override
+except ImportError:
+    try:
+        from typing_extensions import override
+    except ImportError:
+
+        def override(method, /):
+            return method
+
+
 import pytest
 from fixtures.helpers import capture_log_records
 
@@ -32,11 +43,13 @@ class RecordingAsyncControlServer(AcquisitionAsyncControlServer):
         self.processed_event = asyncio.Event()
         self.expected_records = 0
 
+    @override
     async def handle_acquisition_batch(self, records: list[dict[str, Any]]):
         """Capture batch boundaries before delegating to per-record processing."""
         self.processed_batches.append(records.copy())
         await super().handle_acquisition_batch(records)
 
+    @override
     async def handle_acquisition_record(self, record: dict[str, Any]):
         """Capture records and signal when the expected test count is reached."""
         self.processed_records.append(record)


### PR DESCRIPTION
This pull request is an initial implementation of the asynchronous control server and client. The control server has the following features:

- asynchronous processing of device and service commands
- asynchronous status information
- sequential execution of device commands, including commanding from internal timers
- push-based data acquisition
- Subclasses can:
  - add asynchronous tasks to the base tasks
  - register custom device and service handlers
  - start/stop data acquisition with a callback


