### PR TITLE
Release/v0.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-03-17
+
+- Fixed an issue in the Storage Manager where attempting to use the HDF5 persistence backend would fail if the HDF5 package was not listed as a dependency. The Storage Manager now handles this gracefully.
+- Query InfluxDB3 database name and authentication token when initializing the CGSE with `cgse init`.
+- Fixed ref_model and reference_frame in `egse.coordinates` where a bug was introduced after the refactoring of the package.
+
+
 ## [0.19.4] - 2026-03-13
 
 - The 'ID' for the SUT (System Under Test) in the Setup can now be lower (sut.id) or upper (sut.ID) case.
@@ -305,7 +312,8 @@ This release is mainly on maintenance and improvements to the `cgse-common` pack
 - Renamed `cgse` subcommands `registry` →  `reg`, `notify` →  `not`.
 
 
-[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.4...HEAD
+[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.5...HEAD
+[0.19.5]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.4...v0.19.5
 [0.19.4]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.3...v0.19.4
 [0.19.3]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/IvS-KULeuven/cgse/compare/v0.19.1...v0.19.2

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.19.4"
+version = "0.19.5"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.19.4"
+version = "0.19.5"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.19.4"
+version = "0.19.5"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.19.4"
+version = "0.19.5"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.19.4"
+version = "0.19.5"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.19.4"
+version = "0.19.5"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.19.4"
+version = "0.19.5"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.19.4"
+version = "0.19.5"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.19.4"
+version = "0.19.5"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.19.4"
+version = "0.19.5"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.19.4"
+version = "0.19.5"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.19.4"
+version = "0.19.5"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.19.4"
+version = "0.19.5"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.19.4"
+version = "0.19.5"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.19.4"
+version = "0.19.5"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.19.4"
+version = "0.19.5"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.19.4"
+version = "0.19.5"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
- Fixed an issue in the Storage Manager where attempting to use the HDF5 persistence backend would fail if the HDF5 package was not listed as a dependency. The Storage Manager now handles this gracefully.
- Query InfluxDB3 database name and authentication token when initializing the CGSE with `cgse init`.
- Fixed ref_model and reference_frame in `egse.coordinates` where a bug was introduced after the refactoring of the package.
