### PR TITLE
Add tests for ObservationContext and enhance state management

### DIFF
--- a/libs/cgse-common/tests/test_decorators.py
+++ b/libs/cgse-common/tests/test_decorators.py
@@ -239,6 +239,104 @@ def test_borg():
     assert BorgOne() is not BorgOne()  # it's not a singleton
 
 
+def test_borg_instances_share_instance_attributes():
+    """Instance attributes set on one instance are visible on all others."""
+
+    @borg
+    class Config:
+        def __init__(self):
+            pass
+
+    a = Config()
+    b = Config()
+
+    a.value = 42
+    assert b.value == 42
+
+    b.value = 99
+    assert a.value == 99
+
+
+def test_borg_init_with_arguments():
+    """@borg works correctly when __init__ accepts and stores arguments."""
+
+    @borg
+    class Connection:
+        def __init__(self, host: str = "localhost", port: int = 8080):
+            self.host = host
+            self.port = port
+
+    c1 = Connection("server-a", 5000)
+    c2 = Connection()
+
+    # c2.__init__ runs after c1 and overwrites shared state with its defaults
+    assert c1.host == "localhost"
+    assert c1.port == 8080
+    assert c1.host == c2.host
+    assert c1.port == c2.port
+
+
+def test_borg_undecorated_subclass_shares_parent_state():
+    """An undecorated subclass shares the parent Borg class's shared state."""
+
+    @borg
+    class Base:
+        def __init__(self):
+            pass
+
+    class Child(Base):
+        def __init__(self):
+            super().__init__()
+
+    base = Base()
+    child = Child()
+
+    base.tag = "from-base"
+    assert child.tag == "from-base"
+
+    child.tag = "from-child"
+    assert base.tag == "from-child"
+
+
+def test_borg_decorated_subclass_has_independent_state():
+    """A subclass also decorated with @borg gets its own independent shared state."""
+
+    @borg
+    class Parent:
+        def __init__(self):
+            pass
+
+    @borg
+    class Child(Parent):
+        def __init__(self):
+            pass
+
+    p = Parent()
+    c = Child()
+
+    p.marker = "parent-only"
+    assert not hasattr(c, "marker")
+
+    c.marker = "child-only"
+    assert p.marker == "parent-only"
+
+
+def test_borg_shared_state_dict_is_identical():
+    """All instances of a Borg class literally share the same __dict__ object."""
+
+    @borg
+    class State:
+        def __init__(self):
+            pass
+
+    a = State()
+    b = State()
+    c = State()
+
+    assert a.__dict__ is b.__dict__
+    assert b.__dict__ is c.__dict__
+
+
 def test_singleton():
     @singleton
     class Foo:

--- a/libs/cgse-core/src/egse/observation.py
+++ b/libs/cgse-core/src/egse/observation.py
@@ -23,8 +23,18 @@ class ObservationContext:
           without having to pass around an instance of this class.
     """
 
+    INACTIVE_LEVEL = -1
+
     def __init__(self) -> None:
-        self.level = -1
+        # Borg classes share __dict__, so __init__ runs on every instantiation.
+        # Only initialize state once and use reset_state() for lifecycle resets.
+        if not getattr(self, "_state_initialized", False):
+            self.reset_state()
+            self._state_initialized = True
+
+    def reset_state(self):
+        """Reset observation context to an inactive, testable baseline."""
+        self.level = self.INACTIVE_LEVEL
         self.bbid_count = 0
         self.bbids = deque()
 
@@ -34,7 +44,8 @@ class ObservationContext:
             raise ValueError(
                 f"This building block ({bbid}) is already in execution, check dependencies between building blocks."
             )
-        if self.level == -1:
+
+        if self.level == self.INACTIVE_LEVEL:
             raise RuntimeError(f"This building block ({bbid}) is called outside the scope of an observation context.")
 
         self.bbids.append(bbid)
@@ -53,32 +64,36 @@ class ObservationContext:
         return self.level
 
     def start_observation(self, function_info: dict):
-        if self.level == -1:
-            self.level = 0
-        else:
+        if self.is_active():
             raise Failure(
                 "An observation can only be started when no observation is already running. "
                 "Only one Observation can be active at a time."
             )
 
+        # Starting a new observation always begins with a clean context.
+        self.reset_state()
+        self.level = 0
+
         try:
             with ConfigurationManagerProxy() as cm:
                 rc = cm.start_observation(function_info)
                 if not rc.successful:
-                    self.level = -1
+                    self.reset_state()
+                    logger.error(f"Failed to start observation: {rc.message}, level={self.level}")
                     raise rc
                 else:
+                    logger.info(
+                        f"Started observation with obsid={rc.return_code} and info={function_info}, level={self.level}"
+                    )
                     return rc.return_code
         except ConnectionError as exc:
-            self.level = -1
+            self.reset_state()
             raise Failure("Couldn't connect to the Configuration Manager Control Server", exc)
 
     def end_observation(self):
         if self.level > 0 or self.bbids:
             logger.warning(f"Observation contexts not empty at time of reset! (Level={self.level}, bbids={self.bbids})")
-        self.level = -1
-        self.bbid_count = 0
-        self.bbids.clear()
+        self.reset_state()
 
         with ConfigurationManagerProxy() as cm:
             rc = cm.end_observation()
@@ -86,7 +101,7 @@ class ObservationContext:
                 raise rc
 
     def is_active(self):
-        return self.level >= 0
+        return self.level > self.INACTIVE_LEVEL
 
 
 def request_obsid():
@@ -166,7 +181,7 @@ def start_observation(description: str):
         ObservationContext().start_observation({"description": description})
 
         obsid = request_obsid()
-        logger.info(f"Observation started with obsid={obsid}")
+        logger.info(f"Observation started with obsid={obsid}, level={ObservationContext().get_level()}")
 
     except Failure as exc:
         logger.error(f"Failed to start observation or test: {exc}")

--- a/libs/cgse-core/tests/script_test_start_observation_with_building_block.py
+++ b/libs/cgse-core/tests/script_test_start_observation_with_building_block.py
@@ -1,0 +1,51 @@
+import sys
+import time
+
+from egse.log import logging
+from egse.observation import ObservationContext
+from egse.observation import building_block
+from egse.observation import end_observation
+from egse.observation import execute
+from egse.observation import start_observation
+
+logger = logging.getLogger("egse.test.script.observation_with_building_block")
+
+
+def execute_start_observation_and_building_block():
+    obsid = start_observation("Test observation with building block")
+    logger.info(f"Started observation with obsid={obsid}")
+
+    time.sleep(1.0)
+    result = example_building_block()
+    logger.info(f"Result of building block: {result}")
+    time.sleep(1.0)
+
+    end_observation()
+    logger.info("Ended observation")
+
+
+def execute_building_block():
+    result = execute(example_building_block)
+    logger.info(f"Result of building block: {result}")
+
+
+def check_observation_context():
+    ObservationContext().start_observation({"description": "Check observation context"})
+    assert ObservationContext().get_level() == 0, "Observation level should be 0 at the start of the observation"
+    ObservationContext().end_observation()
+
+
+@building_block
+def example_building_block() -> int:
+    logger.info("Executing example building block")
+    time.sleep(2.0)
+    logger.info("Finishing example building block")
+    return 42
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    execute_start_observation_and_building_block()
+    execute_building_block()
+    check_observation_context()

--- a/libs/cgse-core/tests/test_observation.py
+++ b/libs/cgse-core/tests/test_observation.py
@@ -70,6 +70,34 @@ def test_start_observation_success(mock_cm, obs_context):
     assert obs_context.get_level() == 0
 
 
+def test_observation_context_init_does_not_reset_shared_state(obs_context):
+    obs_context.level = 5
+    obs_context.bbid_count = 12
+    obs_context.bbids.extend(["BBID-1"])
+
+    another = ObservationContext()
+
+    assert another.get_level() == 5
+    assert another.bbid_count == 12
+    assert list(another.bbids) == ["BBID-1"]
+
+
+@patch("egse.observation.ConfigurationManagerProxy")
+def test_start_observation_resets_stale_context_before_start(mock_cm, obs_context):
+    obs_context.level = -1
+    obs_context.bbid_count = 3
+    obs_context.bbids.extend(["BBID-OLD"])
+
+    mock_cm.return_value.__enter__.return_value.start_observation.return_value = Success("ok", 777)
+
+    rc = obs_context.start_observation({"description": "test"})
+
+    assert rc == 777
+    assert obs_context.get_level() == 0
+    assert obs_context.bbid_count == 0
+    assert list(obs_context.bbids) == []
+
+
 def test_start_observation_rejects_when_active(obs_context):
     obs_context.level = 0
 


### PR DESCRIPTION
- Implement tests for ObservationContext to verify shared state behavior and reset functionality.
- Ensure that starting an observation resets the context to a clean state.
- Validate that new instances of ObservationContext do not reset shared state.