### PR TITLE
Feature implementation - metrics hub

### DIFF
--- a/libs/cgse-common/src/egse/env.py
+++ b/libs/cgse-common/src/egse/env.py
@@ -45,6 +45,7 @@ __all__ = [
     "bool_env",
     "int_env",
     "str_env",
+    "float_env",
     "load_dotenv",
     "setup_env",
     "env_var",
@@ -130,7 +131,19 @@ def bool_env(var_name: str, default: bool = False) -> bool:
     return default
 
 
-def str_env(var_name: str, default: str | None = None) -> str:
+def float_env(var_name: str, default: float = 0.0) -> float:
+    """Return a float environment override, falling back to `default` on errors."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring invalid float for {var_name}: {raw!r}, returning {default=}")
+        return default
+
+
+def str_env(var_name: str, default: str = "") -> str:
     """Return the value of the environment variable or default if variable is not defined."""
     return os.getenv(var_name, default)
 

--- a/libs/cgse-common/src/egse/metrics.py
+++ b/libs/cgse-common/src/egse/metrics.py
@@ -26,7 +26,9 @@ from egse.system import str_to_datetime
 SITE_ID = Settings.load("SITE").ID
 
 
-def define_metrics(origin: str, dashboard: str = None, use_site: bool = False, setup: Optional[Setup] = None) -> dict:
+def define_metrics(
+    origin: str, dashboard: str | None = None, use_site: bool = False, setup: Optional[Setup] = None
+) -> dict:
     """Creates a metrics dictionary from the telemetry dictionary.
 
     Read the metric names and their descriptions from the telemetry dictionary, and create Prometheus gauges based on
@@ -49,7 +51,10 @@ def define_metrics(origin: str, dashboard: str = None, use_site: bool = False, s
     try:
         hk_info_table = setup.telemetry.dictionary
     except AttributeError:
-        raise SetupError("Version of the telemetry dictionary not specified in the current setup")
+        raise SetupError(
+            "Version of the telemetry dictionary not specified in the current setup, "
+            "expected to find it in setup.telemetry.dictionary. Cannot define metrics without telemetry dictionary."
+        )
 
     hk_info_table = hk_info_table.replace(np.nan, "")
 
@@ -132,7 +137,7 @@ class PointLike(Protocol):
 
 class DataPoint(PointLike):
     def __init__(self, measurement_name: str):
-        self.measurement: str = measurement_name
+        self.measurement_name: str = measurement_name
         self.tags: dict[str, str] = {}
         self.fields: dict[str, Any] = {}
         self.timestamp: int | str = format_datetime()
@@ -144,7 +149,7 @@ class DataPoint(PointLike):
             timestamp = self.timestamp
 
         return {
-            "measurement": self.measurement,
+            "measurement": self.measurement_name,
             "tags": self.tags,
             "fields": self.fields,
             "time": timestamp,
@@ -152,8 +157,8 @@ class DataPoint(PointLike):
 
     @staticmethod
     def measurement(measurement_name):
-        p = DataPoint(measurement_name)
-        return p
+        data_point = DataPoint(measurement_name)
+        return data_point
 
     def tag(self, key, value):
         self.tags[key] = value
@@ -170,6 +175,8 @@ class DataPoint(PointLike):
 
 class TimeSeriesRepository(Protocol):
     def connect(self) -> None: ...
+
+    def ping(self) -> bool: ...
 
     def write(self, points: PointLike | dict | list[PointLike | dict]) -> None: ...
 

--- a/libs/cgse-common/src/egse/plugins/metrics/duckdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/duckdb.py
@@ -1,0 +1,483 @@
+__all__ = [
+    "DuckDBRepository",
+    "get_repository_class",
+]
+import json
+from datetime import datetime
+from typing import Any
+from typing import Dict
+from typing import List
+
+import duckdb
+
+from egse.metrics import DataPoint
+
+
+class DuckDBRepository:
+    """
+    DuckDB TimeSeriesRepository implementation.
+
+    DuckDB stores time-series data in a table with columns for:
+    - measurement: The measurement name (like table name in InfluxDB)
+    - timestamp: Time column
+    - tags: JSON object storing tag key-value pairs
+    - fields: JSON object storing field key-value pairs
+    """
+
+    def __init__(self, db_path: str, table_name: str = "timeseries"):
+        """
+        Initialize DuckDB repository.
+
+        Args:
+            db_path: Path to DuckDB database file (or ":memory:" for in-memory)
+            table_name: Name of the main timeseries table
+        """
+        self.db_path = db_path
+        self.table_name = table_name
+        self.conn = None
+
+    def connect(self) -> None:
+        """Connect to DuckDB database and create schema."""
+        try:
+            self.conn = duckdb.connect(self.db_path)
+
+            # Create main timeseries table if it doesn't exist
+            self.conn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self.table_name} (
+                    measurement VARCHAR NOT NULL,
+                    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                    tags JSON,
+                    fields JSON,
+                    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+                )
+            """
+            )
+
+            # Create indices for better query performance
+            self.conn.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS idx_{self.table_name}_measurement
+                ON {self.table_name}(measurement)
+            """
+            )
+
+            self.conn.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS idx_{self.table_name}_timestamp
+                ON {self.table_name}(timestamp)
+            """
+            )
+
+            # Create a view that flattens the JSON for easier querying
+            self.conn.execute(
+                f"""
+                CREATE OR REPLACE VIEW {self.table_name}_flat AS
+                SELECT
+                    measurement,
+                    timestamp,
+                    tags,
+                    fields,
+                    created_at,
+                    -- Extract all tag keys and values
+                    json_extract_string(tags, '$.*') as tag_values,
+                    -- Extract all field keys and values
+                    json_extract_string(fields, '$.*') as field_values
+                FROM {self.table_name}
+            """
+            )
+
+        except Exception as e:
+            raise ConnectionError(f"Failed to connect to DuckDB at {self.db_path}: {e}")
+
+    def ping(self) -> bool:
+        """Return True if the DuckDB connection is alive, False otherwise."""
+        if self.conn is None:
+            return False
+        try:
+            self.conn.execute("SELECT 1")
+            return True
+        except Exception:
+            return False
+
+    def write(self, points: DataPoint | dict | List[DataPoint | dict]) -> None:
+        """Write data points to DuckDB.
+
+        Accepts a single or a list of `DataPoint` objects or plain dicts in the `DataPoint.as_dict()`
+        format, i.e. `{"measurement": ..., "tags": {...}, "fields": {...}, "time": ...}`.
+        """
+        if not self.conn:
+            raise ConnectionError("Not connected. Call connect() first.")
+
+        if not points:
+            return
+
+        if not isinstance(points, list):
+            points = [points]
+
+        # Prepare data for bulk insert
+        data = []
+        for point in points:
+            if isinstance(point, dict):
+                measurement = point.get("measurement", "unknown")
+                # DataPoint.as_dict() uses "time"; allow "timestamp" as fallback
+                timestamp = point.get("time") or point.get("timestamp")
+                tags = point.get("tags") or {}
+                fields = point.get("fields") or {}
+            else:
+                measurement = point.measurement
+                timestamp = point.timestamp
+                tags = point.tags or {}
+                fields = point.fields or {}
+
+            # Normalize timestamp to ISO string
+            if timestamp is None:
+                timestamp = datetime.now().isoformat()
+            elif isinstance(timestamp, (int, float)):
+                timestamp = datetime.fromtimestamp(timestamp).isoformat()
+            elif isinstance(timestamp, str):
+                try:
+                    dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+                    timestamp = dt.isoformat()
+                except ValueError:
+                    timestamp = datetime.now().isoformat()
+
+            data.append(
+                {
+                    "measurement": measurement,
+                    "timestamp": timestamp,
+                    "tags": json.dumps(tags) if isinstance(tags, dict) else tags,
+                    "fields": json.dumps(fields) if isinstance(fields, dict) else fields,
+                }
+            )
+
+        try:
+            # Use prepared statement for bulk insert
+            placeholders = ", ".join(["(?, ?, ?, ?)"] * len(data))
+            values = []
+            for row in data:
+                values.extend([row["measurement"], row["timestamp"], row["tags"], row["fields"]])
+
+            self.conn.execute(
+                f"""
+                INSERT INTO {self.table_name} (measurement, timestamp, tags, fields)
+                VALUES {placeholders}
+            """,
+                values,
+            )
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to write data points: {e}")
+
+    def query(self, query_str: str) -> List[Dict]:
+        """Execute SQL query and return results."""
+        if self.conn is None:
+            raise ConnectionError("Not connected. Call connect() first.")
+
+        try:
+            assert self.conn.description is not None  # for type checker
+
+            result = self.conn.execute(query_str).fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+
+            # Convert to list of dictionaries
+            return [dict(zip(columns, row)) for row in result]
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to execute query: {e}")
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self.conn:
+            self.conn.close()
+            self.conn = None
+
+    # Schema exploration methods
+    def get_tables(self) -> List[str]:
+        """Get all measurements (equivalent to tables)."""
+        try:
+            query = f"SELECT DISTINCT measurement FROM {self.table_name} ORDER BY measurement"
+            results = self.query(query)
+            return [row["measurement"] for row in results]
+        except Exception as exc:
+            print(f"Error getting measurements: {exc}")
+            return []
+
+    def get_columns(self, table_name: str) -> List[Dict[str, Any]]:
+        """Get column information for a measurement."""
+        try:
+            # Get basic schema
+            columns = [
+                {"column_name": "measurement", "data_type": "VARCHAR", "is_nullable": "NO"},
+                {"column_name": "timestamp", "data_type": "TIMESTAMPTZ", "is_nullable": "YES"},
+                {"column_name": "tags", "data_type": "JSON", "is_nullable": "YES"},
+                {"column_name": "fields", "data_type": "JSON", "is_nullable": "YES"},
+                {"column_name": "created_at", "data_type": "TIMESTAMPTZ", "is_nullable": "YES"},
+            ]
+
+            # Get unique tag keys for this measurement
+            tag_query = f"""
+                SELECT DISTINCT json_extract_string(tags, '$.' || key) as tag_key
+                FROM {table_name},
+                     unnest(json_object_keys(json(tags))) as key
+                WHERE measurement = ?
+                AND tags IS NOT NULL
+                AND tags != '{{}}'
+            """
+
+            try:
+                assert self.conn is not None  # for type checker
+
+                tag_results = self.conn.execute(tag_query, [table_name]).fetchall()
+                for row in tag_results:
+                    if row[0]:  # tag_key is not null
+                        columns.append(
+                            {
+                                "column_name": f"tag_{row[0]}",
+                                "data_type": "VARCHAR",
+                                "is_nullable": "YES",
+                                "column_type": "tag",
+                            }
+                        )
+            except Exception:
+                pass  # If JSON extraction fails, skip tag columns
+
+            # Get unique field keys for this measurement
+            field_query = f"""
+                SELECT DISTINCT json_extract_string(fields, '$.' || key) as field_key
+                FROM {table_name},
+                     unnest(json_object_keys(json(fields))) as key
+                WHERE measurement = ?
+                AND fields IS NOT NULL
+                AND fields != '{{}}'
+            """
+
+            try:
+                assert self.conn is not None  # for type checker
+
+                field_results = self.conn.execute(field_query, [table_name]).fetchall()
+                for row in field_results:
+                    if row[0]:  # field_key is not null
+                        columns.append(
+                            {
+                                "column_name": f"field_{row[0]}",
+                                "data_type": "DOUBLE",
+                                "is_nullable": "YES",
+                                "column_type": "field",
+                            }
+                        )
+            except Exception:
+                pass  # If JSON extraction fails, skip field columns
+
+            return columns
+
+        except Exception as e:
+            print(f"Error getting columns for {table_name}: {e}")
+            return []
+
+    def get_schema_info(self, table_name: str) -> Dict[str, Any]:
+        """Get detailed schema information for a measurement."""
+        columns = self.get_columns(table_name)
+
+        schema = {
+            "table_name": table_name,
+            "time_column": None,
+            "tag_columns": [],
+            "field_columns": [],
+            "other_columns": [],
+        }
+
+        for col in columns:
+            col_name = col["column_name"]
+            col_type = col.get("column_type", "")
+
+            if col_name == "timestamp":
+                schema["time_column"] = col
+            elif col_type == "tag" or col_name.startswith("tag_"):
+                schema["tag_columns"].append(col)
+            elif col_type == "field" or col_name.startswith("field_"):
+                schema["field_columns"].append(col)
+            else:
+                schema["other_columns"].append(col)
+
+        # Add row count
+        try:
+            count_result = self.query(f"SELECT COUNT(*) as count FROM {table_name} WHERE measurement = '{table_name}'")
+            schema["row_count"] = count_result[0]["count"] if count_result else 0
+        except Exception:
+            schema["row_count"] = 0
+
+        return schema
+
+    def inspect_database(self) -> Dict[str, Any]:
+        """Get complete database schema information."""
+        measurements = self.get_tables()
+
+        database_info = {
+            "database_path": self.db_path,
+            "main_table": self.table_name,
+            "total_measurements": len(measurements),
+            "measurements": {},
+        }
+
+        # Get total row count
+        try:
+            total_rows = self.query(f"SELECT COUNT(*) as count FROM {self.table_name}")
+            database_info["total_rows"] = total_rows[0]["count"] if total_rows else 0
+        except Exception:
+            database_info["total_rows"] = 0
+
+        # Get schema info for each measurement
+        for measurement in measurements:
+            database_info["measurements"][measurement] = self.get_schema_info(measurement)
+
+        return database_info
+
+    def query_latest(self, measurement: str, limit: int = 20) -> List[Dict]:
+        """Get latest records for a measurement."""
+        try:
+            assert self.conn is not None  # for type checker
+            assert self.conn.description is not None  # for type checker
+
+            query = f"""
+                SELECT measurement, timestamp, tags, fields, created_at
+                FROM {self.table_name}
+                WHERE measurement = ?
+                ORDER BY timestamp DESC, created_at DESC
+                LIMIT ?
+            """
+
+            result = self.conn.execute(query, [measurement, limit]).fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+
+            # Convert to list of dictionaries and parse JSON
+            records = []
+            for row in result:
+                record = dict(zip(columns, row))
+
+                # Parse JSON fields
+                try:
+                    record["tags"] = json.loads(record["tags"]) if record["tags"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    record["tags"] = {}
+
+                try:
+                    record["fields"] = json.loads(record["fields"]) if record["fields"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    record["fields"] = {}
+
+                records.append(record)
+
+            return records
+
+        except Exception as e:
+            print(f"Error getting latest records for {measurement}: {e}")
+            return []
+
+    def get_measurements_with_stats(self) -> List[Dict[str, Any]]:
+        """Get measurements with statistics."""
+        try:
+            query = f"""
+                SELECT
+                    measurement,
+                    COUNT(*) as record_count,
+                    MIN(timestamp) as earliest_timestamp,
+                    MAX(timestamp) as latest_timestamp,
+                    COUNT(DISTINCT json_object_keys(json(tags))) as unique_tag_keys,
+                    COUNT(DISTINCT json_object_keys(json(fields))) as unique_field_keys
+                FROM {self.table_name}
+                GROUP BY measurement
+                ORDER BY record_count DESC
+            """
+
+            return self.query(query)
+
+        except Exception as e:
+            print(f"Error getting measurement statistics: {e}")
+            return []
+
+    def query_by_tags(self, measurement: str, tags: Dict[str, str], limit: int = 100) -> List[Dict]:
+        """Query records by measurement and tag filters."""
+        try:
+            assert self.conn is not None  # for type checker
+            assert self.conn.description is not None  # for type checker
+
+            # Build tag filter conditions
+            tag_conditions = []
+            params = [measurement]
+
+            for tag_key, tag_value in tags.items():
+                tag_conditions.append(f"json_extract_string(tags, '$.{tag_key}') = ?")
+                params.append(tag_value)
+
+            where_clause = " AND ".join(tag_conditions)
+            if where_clause:
+                where_clause = f" AND {where_clause}"
+
+            query = f"""
+                SELECT measurement, timestamp, tags, fields, created_at
+                FROM {self.table_name}
+                WHERE measurement = ?{where_clause}
+                ORDER BY timestamp DESC
+                LIMIT ?
+            """
+
+            params.append(limit)
+
+            result = self.conn.execute(query, params).fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+
+            # Convert to list of dictionaries and parse JSON
+            records = []
+            for row in result:
+                record = dict(zip(columns, row))
+
+                # Parse JSON fields
+                try:
+                    record["tags"] = json.loads(record["tags"]) if record["tags"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    record["tags"] = {}
+
+                try:
+                    record["fields"] = json.loads(record["fields"]) if record["fields"] else {}
+                except (json.JSONDecodeError, TypeError):
+                    record["fields"] = {}
+
+                records.append(record)
+
+            return records
+
+        except Exception as e:
+            print(f"Error querying by tags: {e}")
+            return []
+
+    def aggregate_by_time(
+        self, measurement: str, field_name: str, time_bucket: str = "1 hour", aggregation: str = "AVG"
+    ) -> List[Dict]:
+        """Aggregate field values by time buckets."""
+        try:
+            agg_func = aggregation.upper()
+            if agg_func not in ["AVG", "SUM", "COUNT", "MIN", "MAX"]:
+                raise ValueError(f"Unsupported aggregation function: {aggregation}")
+
+            query = f"""
+                SELECT
+                    date_trunc('{time_bucket}', timestamp) as time_bucket,
+                    {agg_func}(CAST(json_extract_string(fields, '$.{field_name}') AS DOUBLE)) as {field_name}_{agg_func.lower()}
+                FROM {self.table_name}
+                WHERE measurement = ?
+                AND json_extract_string(fields, '$.{field_name}') IS NOT NULL
+                GROUP BY date_trunc('{time_bucket}', timestamp)
+                ORDER BY time_bucket
+            """
+
+            return self.query(query.replace("?", f"'{measurement}'"))
+
+        except Exception as e:
+            print(f"Error in time aggregation: {e}")
+            return []
+
+
+def get_repository_class():
+    """Return the repository class for the plugin manager."""
+    return DuckDBRepository

--- a/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
@@ -32,14 +32,16 @@ __all__ = [
 ]
 
 import logging
+from datetime import datetime
+from datetime import timezone
 
 import pandas
 import pyarrow
 from influxdb_client_3 import InfluxDBClient3
 from influxdb_client_3 import Point
-from influxdb_client_3 import WriteType
 from influxdb_client_3 import write_client_options
-from influxdb_client_3.exceptions import InfluxDB3ClientError
+from influxdb_client_3.exceptions.exceptions import InfluxDB3ClientError
+from influxdb_client_3.write_client.client.write_api import WriteType
 from influxdb_client_3.write_client.domain.write_precision import WritePrecision
 
 from egse.env import bool_env
@@ -52,13 +54,20 @@ logger = logging.getLogger("egse.plugins")
 
 
 class InfluxDBRepository(TimeSeriesRepository):
+    """TimeSeriesRepository implementation for InfluxDB3.
+
+    Handles connection and interaction with an InfluxDB time series database, providing methods for writing points,
+    querying data, retrieving table and column names, and fetching values within specific time ranges.
+    Supports context management and configurable write options.
+    """
+
     def __init__(self, host: str, database: str, token: str):
         self.host = host
         self.database = database
         self.token = token
         self.metrics_time_precision = WritePrecision.NS
 
-        self.client = None
+        self.client: InfluxDBClient3 = None  # type: ignore
 
     def __enter__(self):
         self.connect()
@@ -74,7 +83,7 @@ class InfluxDBRepository(TimeSeriesRepository):
         self._max_retry_time = int_env("CGSE_INFLUX_RETRY_MAX_TIME_MS", 6_000, minimum=0)
         self._max_retries = int_env("CGSE_INFLUX_MAX_RETRIES", 5, minimum=0)
         self._no_sync = bool_env("CGSE_INFLUX_NO_SYNC", default=True)
-        self._write_type_env = str_env("CGSE_INFLUX_WRITE_TYPE")
+        self._write_type_env = str_env("CGSE_INFLUX_WRITE_TYPE", default="async")
         self._write_type = WriteType.asynchronous
         if self._write_type_env:
             match self._write_type_env.strip().lower():
@@ -85,7 +94,7 @@ class InfluxDBRepository(TimeSeriesRepository):
                 case "sync":
                     self._write_type = WriteType.synchronous
 
-    def connect(self):
+    def connect(self) -> None:
         self._load_client_options()
 
         wco = write_client_options(
@@ -101,8 +110,45 @@ class InfluxDBRepository(TimeSeriesRepository):
         )
         self.client = InfluxDBClient3(host=self.host, database=self.database, token=self.token, write_options=wco)
 
-    def write(self, points: Point | dict | list[Point | dict]):
-        self.client.write(record=points, write_precision=self.metrics_time_precision)
+    def ping(self) -> bool:
+        """Return True if the InfluxDB server is reachable, False otherwise."""
+        if self.client is None:
+            return False
+        try:
+            self.client.query("SHOW TABLES")
+            return True
+        except Exception as exc:
+            logger.warning(f"InfluxDB ping failed: {exc}")
+            return False
+
+    def _to_point(self, payload: Point | dict) -> Point:
+        if isinstance(payload, Point):
+            return payload
+
+        measurement = payload["measurement"]
+        point = Point(measurement)
+
+        for key, value in payload.get("tags", {}).items():
+            point.tag(key, value)
+
+        for key, value in payload.get("fields", {}).items():
+            point.field(key, value)
+
+        timestamp = payload.get("time")
+        if isinstance(timestamp, (int, float)):
+            point.time(datetime.fromtimestamp(timestamp, tz=timezone.utc))
+        elif isinstance(timestamp, str):
+            point.time(datetime.fromisoformat(timestamp.replace("Z", "+00:00")))
+
+        return point
+
+    def write(self, points: Point | dict | list[Point | dict]) -> None:
+        if isinstance(points, list):
+            records = [self._to_point(point) for point in points]
+        else:
+            records = self._to_point(points)
+
+        self.client.write(record=records, write_precision=self.metrics_time_precision)
 
     def query(self, query_str: str, mode: str = "all") -> pyarrow.Table | pandas.DataFrame:
         try:
@@ -142,7 +188,7 @@ class InfluxDBRepository(TimeSeriesRepository):
             logger.error(f"Caught {type_name(exc)} while getting column names: {exc}")
             return []
 
-    def close(self):
+    def close(self) -> None:
         if self.client:
             self.client.close()
 
@@ -170,7 +216,7 @@ class InfluxDBRepository(TimeSeriesRepository):
         query = f"""
             SELECT time, {column_name}
             FROM {table_name}
-            WHERE time >= '{start_time}' 
+            WHERE time >= '{start_time}'
               AND time < '{end_time}'
             ORDER BY time DESC
         """

--- a/libs/cgse-common/tests/test_env.py
+++ b/libs/cgse-common/tests/test_env.py
@@ -3,15 +3,17 @@ import os
 
 import pytest
 
-from egse.env import bool_env, float_env
+from egse.env import bool_env
+from egse.env import env_var
+from egse.env import float_env
+from egse.env import get_conf_data_location
 from egse.env import get_conf_repo_location
+from egse.env import get_data_storage_location
+from egse.env import get_local_settings_env_name
+from egse.env import get_local_settings_path
+from egse.env import get_log_file_location
 from egse.env import get_project_name
 from egse.env import get_site_id
-from egse.env import get_conf_data_location
-from egse.env import get_data_storage_location
-from egse.env import get_local_settings_path
-from egse.env import get_local_settings_env_name
-from egse.env import get_log_file_location
 from egse.env import int_env
 from egse.env import print_env
 from egse.env import set_conf_data_location
@@ -19,7 +21,6 @@ from egse.env import set_conf_repo_location
 from egse.env import set_data_storage_location
 from egse.env import set_local_settings
 from egse.env import set_log_file_location
-from egse.env import env_var
 
 _LOGGER = logging.getLogger("egse.test_env")
 

--- a/libs/cgse-common/tests/test_env.py
+++ b/libs/cgse-common/tests/test_env.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from egse.env import bool_env
+from egse.env import bool_env, float_env
 from egse.env import get_conf_repo_location
 from egse.env import get_project_name
 from egse.env import get_site_id
@@ -255,3 +255,17 @@ def test_int_env():
         else:
             with env_var(**{name: str(value)}):
                 assert int_env(name, default, minimum=minimum) == expected
+
+
+def test_float_env():
+    for name, value, default, expected in (
+        ("CGSE_VAR", 3.14, 1.0, 3.14),
+        ("CGSE_VAR", 2.71, 3.0, 2.71),  # value < minimum -> default
+        ("CGSE_VAR", None, 1.23, 1.23),  # var not defined -> default
+        ("CGSE_VAR", "xxx", 4.56, 4.56),  # invalid var -> default
+    ):
+        if value is None:
+            assert float_env(name, default) == expected
+        else:
+            with env_var(**{name: str(value)}):
+                assert float_env(name, default) == expected

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -32,6 +32,7 @@ monitor = "egse.monitoring:app"
 log_cs = 'egse.logger.log_cs:app'
 reg_cs = 'egse.registry.server:app'
 nh_cs = 'egse.notifyhub.server:app'
+mh_cs = 'egse.metricshub.server:app'
 sm_cs = 'egse.storage.storage_cs:app'
 cm_cs = 'egse.confman.confman_cs:app'
 pm_cs = 'egse.procman.procman_cs:app'
@@ -53,6 +54,7 @@ cm = 'cgse_core.services:cm_cs'
 sm = 'cgse_core.services:sm_cs'
 pm = 'cgse_core.services:pm_cs'
 nh = 'cgse_core.services:notifyhub'
+mh = 'cgse_core.services:metricshub'
 
 [project.entry-points."cgse.explore"]
 explore = "cgse_core.cgse_explore"

--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -88,3 +88,17 @@ def start_notifyhub():
         stdin=subprocess.DEVNULL,
         close_fds=True,
     )
+
+
+def start_metricshub():
+    rich.print("Starting the metrics hub core service...")
+
+    out = redirect_output_to_log("mh_cs.start.log")
+
+    subprocess.Popen(
+        [sys.executable, "-m", "egse.metricshub.server", "start"],
+        stdout=out,
+        stderr=out,
+        stdin=subprocess.DEVNULL,
+        close_fds=True,
+    )

--- a/libs/cgse-core/src/cgse_core/_status.py
+++ b/libs/cgse-core/src/cgse_core/_status.py
@@ -8,6 +8,7 @@ async def run_all_status(full: bool = False, suppress_errors: bool = True):
     tasks = [
         asyncio.create_task(status_rm_cs(suppress_errors)),
         asyncio.create_task(status_nh_cs(suppress_errors)),
+        asyncio.create_task(status_mh_cs(suppress_errors)),
         asyncio.create_task(status_log_cs(suppress_errors)),
         asyncio.create_task(status_sm_cs(full, suppress_errors)),
         asyncio.create_task(status_cm_cs(suppress_errors)),
@@ -39,6 +40,23 @@ async def status_nh_cs(suppress_errors):
         sys.executable,
         "-m",
         "egse.notifyhub.server",
+        "status",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stdout, stderr = await proc.communicate()
+
+    rich.print(stdout.decode().rstrip())
+    if stderr and not suppress_errors:
+        rich.print(f"[red]{stderr.decode()}[/]")
+
+
+async def status_mh_cs(suppress_errors):
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "egse.metricshub.server",
         "status",
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/libs/cgse-core/src/cgse_core/_stop.py
+++ b/libs/cgse-core/src/cgse_core/_stop.py
@@ -123,3 +123,23 @@ def stop_notifyhub():
             waiting_for(lambda: not is_process_running(["egse.notifyhub.server", "start"]), timeout=5.0)
     except TimeoutError:
         logger.warning("notifyhub should not be running anymore...")
+
+
+def stop_metricshub():
+    rich.print("Terminating the metrics hub core service...")
+
+    out = redirect_output_to_log("mh_cs.stop.log")
+
+    subprocess.Popen(
+        [sys.executable, "-m", "egse.metricshub.server", "stop"],
+        stdout=out,
+        stderr=out,
+        stdin=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+    try:
+        with Timer("metricshub stop timer", log_level=logging.DEBUG):
+            waiting_for(lambda: not is_process_running(["egse.metricshub.server", "start"]), timeout=5.0)
+    except TimeoutError:
+        logger.warning("metricshub should not be running anymore...")

--- a/libs/cgse-core/src/cgse_core/cgse_explore.py
+++ b/libs/cgse-core/src/cgse_core/cgse_explore.py
@@ -12,7 +12,7 @@ def show_processes():
     """Returns of list of ProcessInfo data classes for matching processes from this package."""
 
     def filter_procs(pi: ProcessInfo):
-        pattern = r"(log|confman|storage|procman)_cs|registry\.server|notifyhub\.server"
+        pattern = r"(log|confman|storage|procman)_cs|(registry|notifyhub|metricshub)\.server"
 
         return re.search(pattern, pi.command)
 

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -12,8 +12,10 @@ from egse.signal import DEFAULT_SIGNAL_DIR
 from egse.signal import create_signal_command_file
 from egse.system import TyperAsyncCommand
 from egse.system import format_datetime
+
 from ._start import start_cm_cs
 from ._start import start_log_cs
+from ._start import start_metricshub
 from ._start import start_notifyhub
 from ._start import start_pm_cs
 from ._start import start_rm_cs
@@ -21,12 +23,14 @@ from ._start import start_sm_cs
 from ._status import run_all_status
 from ._status import status_cm_cs
 from ._status import status_log_cs
+from ._status import status_mh_cs
 from ._status import status_nh_cs
 from ._status import status_pm_cs
 from ._status import status_rm_cs
 from ._status import status_sm_cs
 from ._stop import stop_cm_cs
 from ._stop import stop_log_cs
+from ._stop import stop_metricshub
 from ._stop import stop_notifyhub
 from ._stop import stop_pm_cs
 from ._stop import stop_rm_cs
@@ -47,6 +51,7 @@ def start_core_services(log_level: str = "WARNING"):
     start_rm_cs(log_level)
     start_log_cs()
     start_notifyhub()
+    start_metricshub()
     start_sm_cs()
     start_cm_cs()
     start_pm_cs()
@@ -62,6 +67,7 @@ def stop_core_services():
     stop_cm_cs()
     stop_sm_cs()
     stop_notifyhub()
+    stop_metricshub()
 
     # We need the logger for logging the termination process for other services, so leave it running for a while
     time.sleep(1.0)
@@ -327,3 +333,27 @@ def notifyhub_stop():
 async def nh_cs_status(suppress_errors: bool = True):
     """Print the status of the Process Manager."""
     await status_nh_cs(suppress_errors)
+
+
+metricshub = typer.Typer(
+    name="metricshub",
+    help="handle metrics hub: start, stop, status",
+)
+
+
+@metricshub.command(name="start")
+def metricshub_start():
+    """Start the Metrics Hub."""
+    start_metricshub()
+
+
+@metricshub.command(name="stop")
+def metricshub_stop():
+    """Stop the Metrics Hub."""
+    stop_metricshub()
+
+
+@metricshub.command(cls=TyperAsyncCommand, name="status")
+async def mh_cs_status(suppress_errors: bool = True):
+    """Print the status of the Metrics Hub."""
+    await status_mh_cs(suppress_errors)

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -2,7 +2,7 @@ PACKAGES:
     CGSE_CORE: The core services of the CGSE
 
 Service Registry:
-    
+
     CLEANUP_INTERVAL:                30
     REQUESTER_PORT:                6100
     PUBLISHER_PORT:                6101
@@ -45,25 +45,28 @@ Process Manager Control Server:                  # PM_CS
     SERVICE_TYPE:                 PM_CS
     PROCESS_NAME:                 pm_cs
     COMMANDING_PORT:               6120          # The port on which the controller listens to commands - REQ-REP
-    MONITORING_PORT:               6121          # The port on which the controller sends periodic status information of the devide - PUB-SUB
+    MONITORING_PORT:               6121          # The port on which the controller sends periodic status information of the device - PUB-SUB
     SERVICE_PORT:                  6122          # The port number on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
     STORAGE_MNEMONIC:                PM          # The mnemonic to be used in the filename storing the housekeeping data
 
-Notify Hub:
-    
+Notify Hub:                                      # NH_CS
+
     SERVICE_TYPE:                 NH_CS
     SERVICE_ID:                 nh_cs_1
     PROCESS_NAME:                 nh_cs
     COLLECTOR_PORT:                6125
     PUBLISHER_PORT:                6126
-    REQUESTS_PORT:                 6167
-    
-Metrics Hub:
-    
+    REQUESTS_PORT:                 6127
+
+Metrics Hub:                                     # MH_CS
+
     SERVICE_TYPE:                 MH_CS
     SERVICE_ID:                 mh_cs_1
     PROCESS_NAME:                 mh_cs
     COLLECTOR_PORT:                6130
     PUBLISHER_PORT:                6131
     REQUESTS_PORT:                 6132
+    BACKEND:                   influxdb          # The storage backend to use for the Metrics Hub. Supported values: "influxdb", "duckdb"
+    BATCH_SIZE:                     500
+    FLUSH_INTERVAL:                 2.0

--- a/libs/cgse-core/src/egse/metricshub/__init__.py
+++ b/libs/cgse-core/src/egse/metricshub/__init__.py
@@ -1,0 +1,46 @@
+__all__ = [
+    "DEFAULT_COLLECTOR_PORT",
+    "DEFAULT_REQUESTS_PORT",
+    "STATS_INTERVAL",
+    "is_metrics_hub_active",
+    "async_is_metrics_hub_active",
+]
+
+from egse.settings import Settings
+
+settings = Settings.load("Metrics Hub")
+
+PROCESS_NAME = settings.get("PROCESS_NAME", "mh_cs")
+SERVICE_ID = settings.get("SERVICE_ID", "mh_cs_1")
+SERVICE_TYPE = settings.get("SERVICE_TYPE", "MH_CS")
+
+DEFAULT_COLLECTOR_PORT = settings.get("COLLECTOR_PORT", 0)
+DEFAULT_REQUESTS_PORT = settings.get("REQUESTS_PORT", 0)
+
+STATS_INTERVAL = settings.get("STATS_INTERVAL", 30)
+"""How often the metrics hub logs batch statistics [seconds]. Defaults to 30s."""
+
+
+async def async_is_metrics_hub_active(timeout: float = 0.5) -> bool:
+    """Check if the metrics hub is running.
+
+    Sends a health request to the hub and waits for the reply. Returns True
+    when the hub responds with a healthy status within the given timeout.
+    """
+    from egse.metricshub.client import AsyncMetricsHubClient  # prevent circular import
+
+    with AsyncMetricsHubClient(request_timeout=timeout) as client:
+        return await client.health_check()
+
+
+def is_metrics_hub_active(timeout: float = 0.5) -> bool:
+    """Synchronous wrapper around :func:`async_is_metrics_hub_active`."""
+    import asyncio
+
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            raise RuntimeError("Use async_is_metrics_hub_active() from an async context.")
+        return loop.run_until_complete(async_is_metrics_hub_active(timeout))
+    except Exception:
+        return False

--- a/libs/cgse-core/src/egse/metricshub/client.py
+++ b/libs/cgse-core/src/egse/metricshub/client.py
@@ -1,0 +1,375 @@
+"""Client for the Async Metrics Hub.
+
+Use :class:`AsyncMetricsHubClient` to send control requests (health, info,
+terminate) to a running ``mh_cs`` service.
+
+For sending data points to the hub use :class:`AsyncMetricsHubSender` (async)
+or :class:`MetricsHubSender` (sync), both of which keep a ZMQ PUSH socket and
+serialise :class:`~egse.metrics.DataPoint` objects as JSON.
+
+Canonical payload format (``DataPoint.as_dict()``)::
+
+    {
+        "measurement": "camera_tm",
+        "tags": {"device_id": "cam_01"},
+        "fields": {"temperature": 23.4},
+        "time": "2026-03-23T12:34:56.000000+0000",  # optional
+    }
+
+Quick usage (async)::
+
+    sender = AsyncMetricsHubSender()
+    sender.connect()
+    await sender.send(DataPoint.measurement("camera_tm").field("temperature", 23.4))
+    sender.close()
+
+Quick usage (sync)::
+
+    sender = MetricsHubSender()
+    sender.connect()
+    sender.send(DataPoint.measurement("camera_tm").field("temperature", 23.4))
+    sender.close()
+"""
+
+__all__ = [
+    "AsyncMetricsHubClient",
+    "MetricsHubClient",
+    "AsyncMetricsHubSender",
+    "MetricsHubSender",
+]
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+import zmq
+import zmq.asyncio
+
+from egse.metrics import DataPoint
+from egse.metricshub import DEFAULT_COLLECTOR_PORT
+from egse.metricshub import DEFAULT_REQUESTS_PORT
+from egse.registry import MessageType
+
+REQUEST_TIMEOUT = 5.0  # seconds
+
+
+class AsyncMetricsHubClient:
+    """Async client for sending control requests to the Metrics Hub.
+
+    Typical use::
+
+        async with AsyncMetricsHubClient() as client:
+            ok = await client.health_check()
+    """
+
+    def __init__(
+        self,
+        req_endpoint: str | None = None,
+        request_timeout: float = REQUEST_TIMEOUT,
+        client_id: str = "async-metrics-hub-client",
+    ):
+        self.req_endpoint = req_endpoint or f"tcp://localhost:{DEFAULT_REQUESTS_PORT}"
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("egse.metricshub.client")
+
+        self._client_id = f"{client_id}-{uuid.uuid4()}".encode()
+
+        self.context = zmq.asyncio.Context.instance()
+        self.req_socket: zmq.asyncio.Socket | None = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def connect(self):
+        self.logger.debug("Connecting to Metrics Hub...")
+        self.req_socket = self.context.socket(zmq.DEALER)
+        self.req_socket.setsockopt(zmq.LINGER, 0)
+        self.req_socket.setsockopt(zmq.IDENTITY, self._client_id)
+        self.req_socket.connect(self.req_endpoint)
+
+    def disconnect(self):
+        self.logger.debug("Disconnecting from Metrics Hub...")
+        if self.req_socket:
+            self.req_socket.close(linger=0)
+        self.req_socket = None
+
+    async def health_check(self) -> bool:
+        """Return True if the hub responds with a healthy status."""
+        response = await self._send_request(MessageType.REQUEST_WITH_REPLY, {"action": "health"})
+        return response.get("success", False)
+
+    async def server_status(self) -> dict[str, Any]:
+        """Return the full info dict from the hub (ports, stats, config)."""
+        return await self._send_request(MessageType.REQUEST_WITH_REPLY, {"action": "info"})
+
+    async def terminate_metrics_hub(self) -> bool:
+        """Send a terminate request.  Returns True on success."""
+        response = await self._send_request(MessageType.REQUEST_WITH_REPLY, {"action": "terminate"})
+        return response.get("success", False)
+
+    async def _send_request(self, msg_type: MessageType, request: dict[str, Any]) -> dict[str, Any]:
+        self.logger.debug(f"Sending request: {request}")
+
+        try:
+            await self.req_socket.send_multipart([msg_type.value, json.dumps(request).encode()])  # type: ignore[union-attr]
+
+            if msg_type == MessageType.REQUEST_NO_REPLY:
+                return {"success": True}
+
+            try:
+                message_parts = await asyncio.wait_for(
+                    self.req_socket.recv_multipart(),  # type: ignore[union-attr]
+                    timeout=self.request_timeout,
+                )
+
+                if len(message_parts) >= 2:
+                    message_type = MessageType(message_parts[0])
+                    message_data = message_parts[1]
+
+                    if message_type == MessageType.RESPONSE:
+                        response = json.loads(message_data)
+                        self.logger.debug(f"Received response: {response}")
+                        return response
+                    else:
+                        return {
+                            "success": False,
+                            "error": f"Unexpected MessageType: {message_type.name}",
+                        }
+                else:
+                    return {"success": False, "error": f"Incomplete response ({len(message_parts)} parts)"}
+
+            except asyncio.TimeoutError:
+                self.logger.warning(f"Request timed out after {self.request_timeout:.2f}s")
+                return {"success": False, "error": "Request timed out"}
+
+        except zmq.ZMQError as exc:
+            self.logger.error(f"ZMQ error: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            self.logger.error(f"Error sending request: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+
+class MetricsHubClient:
+    """Synchronous client for sending control requests to the Metrics Hub.
+
+    This client is intended for older control servers that do not use asyncio.
+    """
+
+    def __init__(
+        self,
+        req_endpoint: str | None = None,
+        request_timeout: float = REQUEST_TIMEOUT,
+        client_id: str = "metrics-hub-client",
+    ):
+        self.req_endpoint = req_endpoint or f"tcp://localhost:{DEFAULT_REQUESTS_PORT}"
+        self.request_timeout = request_timeout
+        self.logger = logging.getLogger("egse.metricshub.client")
+
+        self._client_id = f"{client_id}-{uuid.uuid4()}".encode()
+
+        self.context = zmq.Context.instance()
+        self.req_socket: zmq.Socket | None = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.disconnect()
+
+    def connect(self):
+        self.logger.debug("Connecting to Metrics Hub...")
+
+        socket = self.context.socket(zmq.DEALER)
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.IDENTITY, self._client_id)
+        socket.connect(self.req_endpoint)
+        self.req_socket = socket
+
+    def disconnect(self):
+        self.logger.debug("Disconnecting from Metrics Hub...")
+
+        if self.req_socket:
+            self.req_socket.close(linger=0)
+        self.req_socket = None
+
+    def health_check(self) -> bool:
+        """Return True if the hub responds with a healthy status."""
+        response = self._send_request(MessageType.REQUEST_WITH_REPLY, {"action": "health"})
+        return response.get("success", False)
+
+    def server_status(self) -> dict[str, Any]:
+        """Return the full info dict from the hub (ports, stats, config)."""
+        return self._send_request(MessageType.REQUEST_WITH_REPLY, {"action": "info"})
+
+    def terminate_metrics_hub(self) -> bool:
+        """Send a terminate request. Returns True when request was sent."""
+        response = self._send_request(MessageType.REQUEST_NO_REPLY, {"action": "terminate"})
+        time.sleep(0.2)  # Allow request delivery before caller potentially exits.
+        return response.get("success", False)
+
+    def _send_request(self, msg_type: MessageType, request: dict[str, Any]) -> dict[str, Any]:
+        self.logger.debug(f"Sending request: {request}")
+
+        timeout_ms = int(self.request_timeout * 1000)
+
+        try:
+            self.req_socket.send_multipart([msg_type.value, json.dumps(request).encode()])  # type: ignore[union-attr]
+
+            if msg_type == MessageType.REQUEST_NO_REPLY:
+                return {"success": True}
+
+            if self.req_socket.poll(timeout=timeout_ms):  # type: ignore[union-attr]
+                message_parts = self.req_socket.recv_multipart()  # type: ignore[union-attr]
+
+                if len(message_parts) >= 2:
+                    message_type = MessageType(message_parts[0])
+                    message_data = message_parts[1]
+
+                    if message_type == MessageType.RESPONSE:
+                        response = json.loads(message_data)
+                        self.logger.debug(f"Received response: {response}")
+                        return response
+
+                    return {
+                        "success": False,
+                        "error": f"Unexpected MessageType: {message_type.name}, {message_data = }",
+                    }
+
+                return {
+                    "success": False,
+                    "error": f"Not enough parts received: {len(message_parts)}",
+                    "data": message_parts,
+                }
+
+            self.logger.warning(f"Request timed out after {self.request_timeout:.2f}s")
+            return {"success": False, "error": "Request timed out"}
+
+        except zmq.ZMQError as exc:
+            self.logger.error(f"ZMQ error: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            self.logger.error(f"Error sending request: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+
+class AsyncMetricsHubSender:
+    """Lightweight sender for pushing :class:`~egse.metrics.DataPoint` objects to the hub.
+
+    Maintains a single ZMQ PUSH socket for the lifetime of the sender.
+    Fire-and-forget: if the hub queue is full the point is silently dropped and
+    False is returned.
+
+    Typical use inside an async control server::
+
+        sender = AsyncMetricsHubSender()
+        sender.connect()
+
+        point = DataPoint.measurement("hexapod").tag("device_id", "hexapod_01").field("pos_x", 12.3)
+        await sender.send(point)
+
+        sender.close()
+    """
+
+    def __init__(
+        self,
+        hub_endpoint: str | None = None,
+    ):
+        self.hub_endpoint = hub_endpoint or f"tcp://localhost:{DEFAULT_COLLECTOR_PORT}"
+        self.logger = logging.getLogger("egse.metricshub.sender")
+
+        self.context = zmq.asyncio.Context.instance()
+        self.socket: zmq.asyncio.Socket | None = None
+
+    def connect(self):
+        self.socket = self.context.socket(zmq.PUSH)
+        self.socket.setsockopt(zmq.LINGER, 0)
+        self.socket.setsockopt(zmq.SNDHWM, 1000)
+        self.socket.connect(self.hub_endpoint)
+        self.logger.debug(f"AsyncMetricsHubSender connected to {self.hub_endpoint}")
+
+    def close(self):
+        if self.socket:
+            self.socket.close(linger=0)
+        self.socket = None
+
+    async def send(self, point: DataPoint) -> bool:
+        """Serialise *point* and push it to the hub.
+
+        Returns True on success, False if the hub is unreachable or the local
+        send buffer is full (``zmq.Again``).
+        """
+        if self.socket is None:
+            raise RuntimeError("Call connect() before send().")
+
+        try:
+            payload = json.dumps(point.as_dict()).encode()
+            await self.socket.send(payload, flags=zmq.NOBLOCK)
+            return True
+        except zmq.Again:
+            self.logger.debug("AsyncMetricsHubSender: send buffer full, point dropped.")
+            return False
+        except Exception as exc:
+            self.logger.error(f"AsyncMetricsHubSender.send error: {exc}", exc_info=True)
+            return False
+
+
+class MetricsHubSender:
+    """Synchronous sender for pushing DataPoint payloads to the Metrics Hub.
+
+    Fire-and-forget semantics: if the local ZMQ send buffer is full this sender
+    returns ``False`` rather than blocking.
+    """
+
+    def __init__(self, hub_endpoint: str | None = None):
+        self.hub_endpoint = hub_endpoint or f"tcp://localhost:{DEFAULT_COLLECTOR_PORT}"
+        self.logger = logging.getLogger("egse.metricshub.sender")
+
+        self.context = zmq.Context.instance()
+        self.socket: zmq.Socket | None = None
+
+    def connect(self):
+        socket = self.context.socket(zmq.PUSH)
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.SNDHWM, 1000)
+        socket.connect(self.hub_endpoint)
+        self.socket = socket
+        self.logger.debug(f"MetricsHubSender connected to {self.hub_endpoint}")
+
+    def close(self):
+        if self.socket:
+            self.socket.close(linger=0)
+        self.socket = None
+
+    def send(self, point: DataPoint | dict[str, Any]) -> bool:
+        """Serialise *point* and push it to the hub.
+
+        Args:
+            point: a :class:`~egse.metrics.DataPoint` instance or a pre-serialized
+                dictionary matching ``DataPoint.as_dict()``.
+
+        Returns:
+            True when successfully queued to ZMQ, False when local send buffer
+            is full (``zmq.Again``) or on other errors.
+        """
+        if self.socket is None:
+            raise RuntimeError("Call connect() before send().")
+
+        try:
+            payload = json.dumps(point.as_dict() if isinstance(point, DataPoint) else point).encode()
+            self.socket.send(payload, flags=zmq.NOBLOCK)
+            return True
+        except zmq.Again:
+            self.logger.debug("MetricsHubSender: send buffer full, point dropped.")
+            return False
+        except Exception as exc:
+            self.logger.error(f"MetricsHubSender.send error: {exc}", exc_info=True)
+            return False

--- a/libs/cgse-core/src/egse/metricshub/server.py
+++ b/libs/cgse-core/src/egse/metricshub/server.py
@@ -1,0 +1,645 @@
+"""Async Metrics Hub — core service for receiving and persisting telemetry/HK data.
+
+Clients send :class:`~egse.metrics.DataPoint` objects serialised as JSON to the
+PULL socket.  The hub batches the incoming points and flushes them to the
+configured storage backend (InfluxDB, DuckDB, …) via the plugin system in
+``egse.plugins.metrics``.
+
+Backend selection is driven by the environment variable ``CGSE_METRICS_BACKEND``
+(default: ``"influxdb"``).  Backend-specific configuration is picked up from the
+environment inside the respective plugin (e.g. ``CGSE_INFLUX_*`` for InfluxDB).
+DuckDB additionally requires ``CGSE_DUCKDB_PATH``.
+"""
+
+import asyncio
+import json
+import logging
+import multiprocessing
+import sys
+import textwrap
+import time
+from typing import Any
+from typing import Callable
+
+import typer
+import zmq
+import zmq.asyncio
+
+from egse.env import float_env
+from egse.env import int_env
+from egse.env import str_env
+from egse.log import logger
+from egse.logger import remote_logging
+from egse.metrics import TimeSeriesRepository
+from egse.metrics import get_metrics_repo
+from egse.metricshub import DEFAULT_COLLECTOR_PORT
+from egse.metricshub import DEFAULT_REQUESTS_PORT
+from egse.metricshub import PROCESS_NAME
+from egse.metricshub import SERVICE_TYPE
+from egse.metricshub import STATS_INTERVAL
+from egse.metricshub.client import AsyncMetricsHubClient
+from egse.registry import MessageType
+from egse.registry.client import REQUEST_TIMEOUT
+from egse.registry.client import AsyncRegistryClient
+from egse.settings import Settings
+from egse.system import TyperAsyncCommand
+from egse.system import get_host_ip
+from egse.zmq_ser import get_port_number
+
+REQUEST_POLL_TIMEOUT = 1.0
+"""Time to wait while listening for requests [seconds]."""
+
+app = typer.Typer(name=PROCESS_NAME)
+
+settings = Settings.load("Metrics Hub")
+
+# Note: if you need these helpers also in other services, consider moving them to the package `cgse-common`,
+#       module `egse.settings` instead of importing from this server module.
+
+
+def _env_or_settings_str(env_name: str, setting_name: str, default: str) -> str:
+    return str_env(env_name, str(settings.get(setting_name, default)))
+
+
+def _env_or_settings_int(env_name: str, setting_name: str, default: int) -> int:
+    return int_env(env_name, int(settings.get(setting_name, default)))
+
+
+def _env_or_settings_float(env_name: str, setting_name: str, default: float) -> float:
+    return float_env(env_name, float(settings.get(setting_name, default)))
+
+
+def _get_backend_config() -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Resolve backend name/config and return a safe public info dict.
+
+    The backend is selected via ``CGSE_METRICS_BACKEND`` (default ``"influxdb"``).
+    """
+    backend = _env_or_settings_str("CGSE_METRICS_BACKEND", "BACKEND", "influxdb").strip().lower()
+
+    match backend:
+        case "influxdb":
+            host = str_env("CGSE_INFLUX_HOST", "http://localhost:8181")
+            database = str_env("CGSE_INFLUX_DATABASE", str_env("PROJECT", "cgse"))
+            config = {
+                "host": host,
+                "database": database,
+                "token": str_env("INFLUXDB3_AUTH_TOKEN", ""),
+            }
+            public_info = {
+                "name": backend,
+                "host": host,
+                "database": database,
+            }
+        case "duckdb":
+            db_path = str_env("CGSE_DUCKDB_PATH", "metrics.duckdb")
+            config = {
+                "db_path": db_path,
+            }
+            public_info = {
+                "name": backend,
+                "db_path": db_path,
+            }
+        case _:
+            raise ValueError(f"Unknown CGSE_METRICS_BACKEND '{backend}'. Supported: 'influxdb', 'duckdb'.")
+
+    return backend, config, public_info
+
+
+def _load_repository() -> tuple[TimeSeriesRepository, dict[str, Any]]:
+    """Build a :class:`~egse.metrics.TimeSeriesRepository` and safe backend metadata."""
+    backend, config, public_info = _get_backend_config()
+    return get_metrics_repo(backend, config), public_info
+
+
+class AsyncMetricsHub:
+    """Async metrics hub that collects DataPoint messages and batches them to a
+    time-series backend via the plugin system.
+
+    Sockets
+    -------
+    collector_socket (PULL)
+        Receives serialised :class:`~egse.metrics.DataPoint` JSON from services.
+    requests_socket (ROUTER)
+        Handles control requests: health, info, terminate.
+    """
+
+    def __init__(self, repository: TimeSeriesRepository | None = None):
+        self.server_id = PROCESS_NAME
+
+        self.context: zmq.asyncio.Context = zmq.asyncio.Context()
+
+        # Receive DataPoint dicts from services (PULL for implicit load balancing)
+        self.collector_socket: zmq.asyncio.Socket = self.context.socket(zmq.PULL)
+
+        # Health check / control (ROUTER - can handle multiple concurrent clients)
+        self.requests_socket: zmq.asyncio.Socket = self.context.socket(zmq.ROUTER)
+
+        # Service registry
+        self.registry_client = AsyncRegistryClient(timeout=REQUEST_TIMEOUT)
+        self.registry_client.connect()
+
+        self.service_id = None
+        self.service_name = PROCESS_NAME
+        self.service_type = SERVICE_TYPE
+        self.is_service_registered: bool = False
+
+        # Storage backend — loaded from env when not injected (e.g. in tests)
+        self._repository_injected = repository is not None
+        self.repository: TimeSeriesRepository | None = repository  # may be None until start()
+        self.backend_info: dict[str, Any] = (
+            {
+                "name": "injected",
+                "repository_class": type(repository).__name__,
+                "injected": True,
+            }
+            if repository is not None
+            else {"name": "unknown", "injected": False}
+        )
+
+        # Batching configuration (from env, with sensible defaults)
+        self.batch_size: int = _env_or_settings_int("CGSE_METRICS_BATCH_SIZE", "BATCH_SIZE", 500)
+        self.flush_interval: float = _env_or_settings_float("CGSE_METRICS_FLUSH_INTERVAL", "FLUSH_INTERVAL", 2.0)
+
+        # Internal queue: raw dicts as received from ZMQ
+        self.data_queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)
+
+        self.stats = {
+            "received": 0,
+            "written": 0,
+            "dropped": 0,
+            "errors": 0,
+            "start_time": time.time(),
+        }
+
+        self.running = False
+        self._shutdown_event = asyncio.Event()
+        self._tasks: list[asyncio.Task] = []
+
+        self._logger = logging.getLogger("egse.metricshub")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self):
+        """Start the metrics hub.
+
+        Binds the ZMQ sockets, connects to the storage backend, creates the
+        asyncio tasks, registers with the service registry, and then waits for a
+        shutdown signal.
+        """
+        multiprocessing.current_process().name = PROCESS_NAME
+
+        self.running = True
+        self._logger.info("Starting Async Metrics Hub...")
+
+        self.collector_socket.bind(f"tcp://*:{DEFAULT_COLLECTOR_PORT}")
+        self.requests_socket.bind(f"tcp://*:{DEFAULT_REQUESTS_PORT}")
+
+        # High-water mark so the OS doesn't buffer unboundedly
+        self.collector_socket.setsockopt(zmq.RCVHWM, 10_000)
+
+        if not self._repository_injected:
+            self.repository, self.backend_info = _load_repository()
+
+        self.repository.connect()  # type: ignore[union-attr]
+
+        if not self.repository.ping():  # type: ignore[union-attr]
+            raise RuntimeError(
+                "Metrics Hub backend is unreachable — refusing to start. "
+                "Check your backend configuration (CGSE_METRICS_BACKEND and related env vars)."
+            )
+
+        self._logger.info("Connected to storage backend.")
+
+        self._tasks = [
+            asyncio.create_task(self._collector()),
+            asyncio.create_task(self._batch_processor()),
+            asyncio.create_task(self._stats_reporter()),
+            asyncio.create_task(self._handle_requests()),
+        ]
+
+        await self.register_service()
+
+        await self._shutdown_event.wait()
+
+        await self.deregister_service()
+
+        await self.shutdown()
+
+    async def shutdown(self):
+        """Graceful shutdown: flush remaining points, cancel tasks, close sockets."""
+        self.running = False
+        self._logger.info("Async Metrics Hub shutdown initiated...")
+
+        if self._tasks:
+            done, pending = await asyncio.wait(self._tasks, timeout=2.0)
+            for task in pending:
+                task.cancel()
+
+        await self._flush_remaining()
+
+        self.repository.close()  # type: ignore[union-attr]
+
+        self.collector_socket.close()
+        self.requests_socket.close()
+
+        self.registry_client.disconnect()
+
+        self._logger.info("Async Metrics Hub shutdown complete.")
+
+        self.context.term()
+
+    async def register_service(self):
+        self._logger.info("Registering Metrics Hub with service registry...")
+
+        self.service_id = await self.registry_client.register(
+            name=self.service_name,
+            host=get_host_ip() or "127.0.0.1",
+            port=DEFAULT_REQUESTS_PORT,
+            service_type=self.service_type,
+            metadata={"collector_port": DEFAULT_COLLECTOR_PORT},
+        )
+
+        if not self.service_id:
+            self._logger.error("Failed to register with the service registry.")
+            self.is_service_registered = False
+        else:
+            await self.registry_client.start_heartbeat()
+            self.is_service_registered = True
+
+    async def deregister_service(self):
+        self._logger.info("De-registering Metrics Hub from service registry...")
+        if self.service_id:
+            await self.registry_client.stop_heartbeat()
+            await self.registry_client.deregister()
+
+    # ------------------------------------------------------------------
+    # Core async tasks
+    # ------------------------------------------------------------------
+
+    async def _collector(self):
+        """Receive serialised DataPoint JSON from ZMQ PULL socket and queue it."""
+        self._logger.info("Collector task started.")
+
+        while self.running:
+            try:
+                message_bytes = await asyncio.wait_for(self.collector_socket.recv(), timeout=0.1)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                self._logger.warning("Collector task cancelled.")
+                self.running = False
+                break
+            except Exception as exc:
+                self._logger.error(f"Collector error: {exc}", exc_info=True)
+                await asyncio.sleep(0.1)
+                continue
+
+            try:
+                payload = json.loads(message_bytes.decode())
+            except json.JSONDecodeError as exc:
+                self._logger.warning(f"Received invalid JSON, discarding: {exc}")
+                self.stats["dropped"] += 1
+                continue
+
+            point_dict, error = _normalize_payload(payload)
+            if point_dict is None:
+                self._logger.warning(f"Received malformed payload, discarding: {error}")
+                self.stats["dropped"] += 1
+                continue
+
+            try:
+                await asyncio.wait_for(self.data_queue.put(point_dict), timeout=0.1)
+                self.stats["received"] += 1
+            except asyncio.TimeoutError:
+                self._logger.warning("Queue full — dropping point.")
+                self.stats["dropped"] += 1
+
+    async def _batch_processor(self):
+        """Drain the queue and flush to the storage backend in batches."""
+        self._logger.info("Batch processor task started.")
+
+        batch: list[dict] = []
+        last_flush = time.monotonic()
+
+        while self.running:
+            try:
+                remaining = self.flush_interval - (time.monotonic() - last_flush)
+                timeout = max(0.05, remaining)
+
+                try:
+                    point_dict = await asyncio.wait_for(self.data_queue.get(), timeout=timeout)
+                    batch.append(point_dict)
+                except asyncio.TimeoutError:
+                    pass  # check flush conditions below
+
+                should_flush = len(batch) >= self.batch_size or (
+                    batch and (time.monotonic() - last_flush) >= self.flush_interval
+                )
+
+                if should_flush:
+                    await self._flush_batch(batch)
+                    batch.clear()
+                    last_flush = time.monotonic()
+
+            except asyncio.CancelledError:
+                self._logger.warning("Batch processor task cancelled.")
+                break
+            except Exception as exc:
+                self._logger.error(f"Batch processor error: {exc}", exc_info=True)
+                await asyncio.sleep(1.0)
+
+    async def _flush_batch(self, batch: list[dict]):
+        """Write a batch of point dicts to the storage backend.
+
+        The write call is dispatched to a thread-pool executor so that blocking
+        backend clients (e.g. influxdb_client_3, duckdb) do not stall the event
+        loop.
+        """
+        if not batch:
+            return
+
+        start = time.monotonic()
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, lambda: self.repository.write(batch))  # type: ignore[union-attr]
+
+            elapsed = time.monotonic() - start
+            rate = len(batch) / elapsed if elapsed > 0 else float("inf")
+            self.stats["written"] += len(batch)
+            self._logger.debug(f"Flushed {len(batch)} points ({rate:.0f} pts/s).")
+
+        except Exception as exc:
+            self._logger.error(f"Failed to write batch of {len(batch)} points: {exc}", exc_info=True)
+            self.stats["errors"] += len(batch)
+
+    async def _flush_remaining(self):
+        """Drain the queue and flush anything left after shutdown is signalled."""
+        remaining: list[dict] = []
+        while not self.data_queue.empty():
+            try:
+                remaining.append(self.data_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+
+        if remaining:
+            self._logger.info(f"Flushing {len(remaining)} remaining points on shutdown.")
+            await self._flush_batch(remaining)
+
+    async def _stats_reporter(self):
+        """Periodically log batch statistics."""
+        while self.running:
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=STATS_INTERVAL)
+                break  # shutdown was requested
+            except asyncio.TimeoutError:
+                self._logger.info(
+                    f"Stats: received={self.stats['received']}, "
+                    f"written={self.stats['written']}, "
+                    f"dropped={self.stats['dropped']}, "
+                    f"errors={self.stats['errors']}, "
+                    f"queue={self.data_queue.qsize()}"
+                )
+            except asyncio.CancelledError:
+                self._logger.warning("Stats reporter task cancelled.")
+                self.running = False
+
+    # ------------------------------------------------------------------
+    # Request handling (ROUTER socket)
+    # ------------------------------------------------------------------
+
+    async def _handle_requests(self):
+        """Process control requests on the ROUTER socket."""
+        self._logger.info("Request handler task started.")
+
+        while self.running:
+            try:
+                try:
+                    message_parts = await asyncio.wait_for(
+                        self.requests_socket.recv_multipart(), timeout=REQUEST_POLL_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    continue
+
+                if len(message_parts) >= 3:
+                    client_id = message_parts[0]
+                    message_type = MessageType(message_parts[1])
+                    message_data = message_parts[2]
+
+                    response = await self._process_request(message_data)
+                    await self._send_response(client_id, message_type, response)
+
+            except zmq.ZMQError as exc:
+                self._logger.error(f"ZMQ error in request handler: {exc}", exc_info=True)
+            except asyncio.CancelledError:
+                self._logger.warning("Request handler task cancelled.")
+                self.running = False
+            except Exception as exc:
+                self._logger.error(f"Unexpected error in request handler: {exc}", exc_info=True)
+
+    async def _process_request(self, msg_data: bytes) -> dict[str, Any]:
+        try:
+            request = json.loads(msg_data.decode())
+        except json.JSONDecodeError as exc:
+            self._logger.error(f"Invalid JSON in request: {exc}")
+            return {"success": False, "error": "Invalid JSON format"}
+
+        action = request.get("action")
+        if not action:
+            return {"success": False, "error": "Missing required field: action"}
+
+        handlers: dict[str, Callable] = {
+            "health": self._handle_health,
+            "info": self._handle_info,
+            "terminate": self._handle_terminate,
+        }
+
+        handler = handlers.get(action)
+        if not handler:
+            return {"success": False, "error": f"Unknown action: {action}"}
+
+        return await handler(request)
+
+    async def _send_response(self, client_id: bytes, msg_type: MessageType, response: dict[str, Any]):
+        if msg_type == MessageType.REQUEST_WITH_REPLY:
+            await self.requests_socket.send_multipart(
+                [client_id, MessageType.RESPONSE.value, json.dumps(response).encode()]
+            )
+
+    async def _handle_health(self, request: dict[str, Any]) -> dict[str, Any]:
+        return {"success": True, "status": "ok", "timestamp": int(time.time())}
+
+    async def _backend_reachable(self) -> bool:
+        """Return backend connectivity state, shielding request handling from ping errors."""
+        if self.repository is None:
+            return False
+
+        try:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(None, self.repository.ping)
+        except Exception as exc:
+            self._logger.warning(f"Backend ping failed while serving info: {exc}")
+            return False
+
+    async def _handle_info(self, request: dict[str, Any]) -> dict[str, Any]:
+        backend_info = self.backend_info.copy()
+        if self.repository is not None:
+            backend_info["repository_class"] = type(self.repository).__name__
+        backend_info["reachable"] = await self._backend_reachable()
+        statistics = self.stats.copy()
+        statistics["queue"] = self.data_queue.qsize()
+
+        return {
+            "success": True,
+            "status": "ok",
+            "collector_port": get_port_number(self.collector_socket),
+            "requests_port": get_port_number(self.requests_socket),
+            "backend": backend_info,
+            "batch_size": self.batch_size,
+            "flush_interval": self.flush_interval,
+            "statistics": statistics,
+            "timestamp": int(time.time()),
+        }
+
+    async def _handle_terminate(self, request: dict[str, Any]) -> dict[str, Any]:
+        self._logger.info("Termination requested via control socket.")
+        await self.stop()
+        return {"success": True, "status": "terminating", "timestamp": int(time.time())}
+
+    async def stop(self):
+        """Signal the hub to shut down."""
+        self._shutdown_event.set()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_payload(payload: Any) -> tuple[dict | None, str | None]:
+    """Validate a DataPoint.as_dict()-style payload."""
+    if not isinstance(payload, dict):
+        return None, "payload is not a dict"
+
+    measurement = payload.get("measurement")
+    fields = payload.get("fields")
+    tags = payload.get("tags", {})
+    timestamp = payload.get("time", payload.get("timestamp"))
+
+    if not isinstance(measurement, str) or not measurement.strip():
+        return None, "missing/invalid 'measurement'"
+    if not isinstance(fields, dict) or len(fields) == 0:
+        return None, "missing/invalid 'fields'"
+    if not isinstance(tags, dict):
+        return None, "invalid 'tags'"
+
+    # keep field values compatible with downstream backends
+    for key, value in fields.items():
+        if not isinstance(key, str) or not key:
+            return None, "field keys must be non-empty strings"
+        if value is None:
+            return None, "field values cannot be None"
+
+    for key, value in tags.items():
+        if not isinstance(key, str) or not key:
+            return None, "tag keys must be non-empty strings"
+        if value is None:
+            return None, "tag values cannot be None"
+
+    if timestamp is not None and not isinstance(timestamp, (str, int, float)):
+        return None, "invalid timestamp/time"
+
+    point = {
+        "measurement": measurement,
+        "fields": fields,
+        "tags": tags,
+    }
+    if timestamp is not None:
+        point["time"] = timestamp
+    return point, None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@app.command(cls=TyperAsyncCommand)
+async def start():
+    """Start the Metrics Hub service."""
+    with remote_logging():
+        hub = AsyncMetricsHub()
+        await hub.start()
+
+
+@app.command(cls=TyperAsyncCommand)
+async def stop():
+    """Stop a running Metrics Hub service."""
+    with AsyncMetricsHubClient() as client:
+        await client.terminate_metrics_hub()
+
+
+@app.command(cls=TyperAsyncCommand)
+async def status():
+    """Show the current status of the Metrics Hub service."""
+    with AsyncMetricsHubClient() as client:
+        response = await client.server_status()
+
+    if response.get("success"):
+        stats = response.get("statistics", {})
+        backend = response.get("backend", {})
+
+        backend_name = backend.get("name", "unknown")
+        backend_reachable = backend.get("reachable", "?")
+        repository_class = backend.get("repository_class", "?")
+
+        backend_details_parts: list[str] = []
+        if "host" in backend:
+            backend_details_parts.append(f"host={backend['host']}")
+        if "database" in backend:
+            backend_details_parts.append(f"database={backend['database']}")
+        if "db_path" in backend:
+            backend_details_parts.append(f"db_path={backend['db_path']}")
+        backend_details = ", ".join(backend_details_parts) if backend_details_parts else "n/a"
+
+        status_report = textwrap.dedent(
+            f"""\
+            Metrics Hub:
+                Status:          {response["status"]}
+                Collector port:  {response["collector_port"]}
+                Requests port:   {response["requests_port"]}
+                Backend:         {backend_name}
+                  Reachable:     {backend_reachable}
+                  Repository:    {repository_class}
+                  Details:       {backend_details}
+                Batch size:      {response["batch_size"]}
+                Flush interval:  {response["flush_interval"]} s
+                Statistics:
+                    Received:    {stats.get("received", 0)}
+                    Written:     {stats.get("written", 0)}
+                    Dropped:     {stats.get("dropped", 0)}
+                    Errors:      {stats.get("errors", 0)}
+                    Queue size:  {stats.get("queue", "?")}
+            """
+        )
+    else:
+        status_report = "Metrics Hub: not active"
+
+    print(status_report)
+
+
+if __name__ == "__main__":
+    try:
+        rc = app()
+    except zmq.ZMQError as exc:
+        if "Address already in use" in str(exc):
+            logger.error(f"The Metrics Hub is already running: {exc}")
+        else:
+            logger.error("Couldn't start the Metrics Hub.", exc_info=True)
+        rc = -1
+    except KeyboardInterrupt:
+        logging.info("KeyboardInterrupt received for MetricsHub, terminating...")
+        rc = -1
+
+    sys.exit(rc)

--- a/libs/cgse-core/tests/script_send_metricshub_temperature_profile.py
+++ b/libs/cgse-core/tests/script_send_metricshub_temperature_profile.py
@@ -1,0 +1,229 @@
+"""Send a simulated 3-sensor temperature profile to Metrics Hub.
+
+This is a runnable test script (not a unit test) intended for dashboard and
+pipeline validation. It generates one synthetic device profile where all three
+sensors:
+
+1. start near room temperature,
+2. rise to about 28 degC,
+3. slowly decrease asymptotically to about -5 degC,
+4. slowly return to room temperature.
+
+By default, the complete profile takes 10 minutes.
+
+Usage examples:
+    uv run py tests/script_send_metricshub_temperature_profile.py
+
+    uv run py tests/script_send_metricshub_temperature_profile.py \
+        --device-id hexapod_01 \
+        --measurement device_temperature \
+        --duration-s 600 \
+        --interval-s 1.0
+
+    uv run py tests/script_send_metricshub_temperature_profile.py \
+        --hub-endpoint tcp://localhost:6130 --room-temp 21.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import time
+from datetime import datetime
+from datetime import timezone
+
+from egse.metrics import DataPoint
+from egse.metricshub.client import MetricsHubClient
+from egse.metricshub.client import MetricsHubSender
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Send simulated 3-sensor temperature profile to Metrics Hub.")
+
+    parser.add_argument("--hub-endpoint", default="tcp://localhost:6130", help="Metrics Hub collector endpoint")
+    parser.add_argument("--req-endpoint", default="tcp://localhost:6132", help="Metrics Hub request endpoint")
+
+    parser.add_argument("--measurement", default="device_temperature", help="Measurement name")
+    parser.add_argument("--device-id", default="device_01", help="Device identifier tag")
+
+    parser.add_argument(
+        "--duration-s",
+        type=float,
+        default=600.0,
+        help="Total profile duration in seconds (default: 600 = 10 minutes)",
+    )
+    parser.add_argument(
+        "--interval-s",
+        type=float,
+        default=1.0,
+        help="Sample interval in seconds (default: 1.0)",
+    )
+
+    parser.add_argument("--room-temp", type=float, default=21.0, help="Room temperature in degC")
+    parser.add_argument("--peak-temp", type=float, default=28.0, help="Peak temperature in degC")
+    parser.add_argument("--min-temp", type=float, default=-5.0, help="Minimum temperature in degC")
+
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for repeatable sensor noise",
+    )
+
+    return parser.parse_args()
+
+
+def _smoothstep(x: float) -> float:
+    """Cubic smoothstep for x in [0, 1]."""
+    x = max(0.0, min(1.0, x))
+    return x * x * (3.0 - 2.0 * x)
+
+
+def _base_temperature(
+    t: float,
+    duration_s: float,
+    room_temp: float,
+    peak_temp: float,
+    min_temp: float,
+) -> float:
+    """Piecewise profile for one cycle.
+
+    Segments (fraction of total duration):
+    - 0.00 .. 0.15: warm up room -> peak
+    - 0.15 .. 0.70: asymptotic cool down peak -> min
+    - 0.70 .. 1.00: asymptotic warm up min -> room
+    """
+    if duration_s <= 0:
+        return room_temp
+
+    p = max(0.0, min(1.0, t / duration_s))
+
+    if p <= 0.15:
+        x = p / 0.15
+        return room_temp + (peak_temp - room_temp) * _smoothstep(x)
+
+    if p <= 0.70:
+        x = (p - 0.15) / 0.55
+        k = 6.0
+        return min_temp + (peak_temp - min_temp) * math.exp(-k * x)
+
+    x = (p - 0.70) / 0.30
+    k = 3.5
+    return room_temp - (room_temp - min_temp) * math.exp(-k * x)
+
+
+def _sensor_temperatures(base_temp: float, elapsed_s: float, rng: random.Random) -> tuple[float, float, float]:
+    """Derive three sensor readings from the base profile with realistic offsets/noise."""
+    sensor_1 = base_temp + rng.gauss(0.0, 0.05)
+    sensor_2 = base_temp + 0.25 + 0.10 * math.sin(elapsed_s / 25.0) + rng.gauss(0.0, 0.06)
+    sensor_3 = base_temp - 0.20 + 0.07 * math.cos(elapsed_s / 35.0) + rng.gauss(0.0, 0.08)
+    return sensor_1, sensor_2, sensor_3
+
+
+def _print_header(args: argparse.Namespace) -> None:
+    print("Metrics Hub temperature profile sender")
+    print(f"  collector endpoint: {args.hub_endpoint}")
+    print(f"  request endpoint:   {args.req_endpoint}")
+    print(f"  measurement:        {args.measurement}")
+    print(f"  device_id:          {args.device_id}")
+    print(f"  duration:           {args.duration_s:.1f} s")
+    print(f"  interval:           {args.interval_s:.3f} s")
+
+
+def _print_status(req_endpoint: str) -> None:
+    try:
+        with MetricsHubClient(req_endpoint=req_endpoint, request_timeout=2.0) as client:
+            info = client.server_status()
+            if info.get("success"):
+                backend = info.get("backend", {})
+                print("Hub status:")
+                print("  status:             ok")
+                print(f"  backend:            {backend.get('name', '?')}")
+                print(f"  backend reachable:  {backend.get('reachable', '?')}")
+                print(f"  repository class:   {backend.get('repository_class', '?')}")
+            else:
+                print(f"Hub status check failed: {info.get('error', 'unknown error')}")
+    except Exception as exc:
+        print(f"Hub status check failed: {exc}")
+
+
+def run() -> int:
+    args = _parse_args()
+
+    if args.interval_s <= 0:
+        raise ValueError("--interval-s must be > 0")
+    if args.duration_s <= 0:
+        raise ValueError("--duration-s must be > 0")
+
+    rng = random.Random(args.seed)
+    _print_header(args)
+    _print_status(args.req_endpoint)
+
+    sender = MetricsHubSender(hub_endpoint=args.hub_endpoint)
+    sender.connect()
+
+    start = time.monotonic()
+    sent_ok = 0
+    dropped = 0
+
+    try:
+        sample_idx = 0
+        while True:
+            now = time.monotonic()
+            elapsed_s = now - start
+            if elapsed_s > args.duration_s:
+                break
+
+            base_temp = _base_temperature(
+                t=elapsed_s,
+                duration_s=args.duration_s,
+                room_temp=args.room_temp,
+                peak_temp=args.peak_temp,
+                min_temp=args.min_temp,
+            )
+
+            t1, t2, t3 = _sensor_temperatures(base_temp, elapsed_s, rng)
+
+            point = (
+                DataPoint.measurement(args.measurement)
+                .tag("device_id", args.device_id)
+                .tag("profile", "warm-cool-warm")
+                .field("sensor_1", round(t1, 3))
+                .field("sensor_2", round(t2, 3))
+                .field("sensor_3", round(t3, 3))
+                .field("elapsed_s", round(elapsed_s, 3))
+                .field("sample_idx", sample_idx)
+                .time(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f%z"))
+            )
+
+            if sender.send(point):
+                sent_ok += 1
+            else:
+                dropped += 1
+
+            if sample_idx % 10 == 0:
+                print(f"t={elapsed_s:6.1f}s T1={t1:6.2f}C T2={t2:6.2f}C T3={t3:6.2f}C sent={sent_ok} dropped={dropped}")
+
+            sample_idx += 1
+
+            target_elapsed = sample_idx * args.interval_s
+            sleep_s = max(0.0, target_elapsed - (time.monotonic() - start))
+            time.sleep(sleep_s)
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user, stopping...")
+    finally:
+        sender.close()
+
+    total = sent_ok + dropped
+    print("Done.")
+    print(f"  total samples:      {total}")
+    print(f"  sent successfully:  {sent_ok}")
+    print(f"  dropped:            {dropped}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/libs/cgse-core/tests/script_send_metricshub_temperature_profile.py
+++ b/libs/cgse-core/tests/script_send_metricshub_temperature_profile.py
@@ -27,6 +27,7 @@ Usage examples:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import math
 import random
 import time
@@ -34,6 +35,8 @@ from datetime import datetime
 from datetime import timezone
 
 from egse.metrics import DataPoint
+from egse.metricshub.client import AsyncMetricsHubClient
+from egse.metricshub.client import AsyncMetricsHubSender
 from egse.metricshub.client import MetricsHubClient
 from egse.metricshub.client import MetricsHubSender
 
@@ -46,6 +49,12 @@ def _parse_args() -> argparse.Namespace:
 
     parser.add_argument("--measurement", default="device_temperature", help="Measurement name")
     parser.add_argument("--device-id", default="device_01", help="Device identifier tag")
+    parser.add_argument(
+        "--async",
+        action="store_true",
+        dest="run_async",
+        help="Run using asyncio client/sender instead of synchronous mode",
+    )
 
     parser.add_argument(
         "--duration-s",
@@ -123,6 +132,7 @@ def _sensor_temperatures(base_temp: float, elapsed_s: float, rng: random.Random)
 
 def _print_header(args: argparse.Namespace) -> None:
     print("Metrics Hub temperature profile sender")
+    print(f"  mode:               {'asynchronous' if args.run_async else 'synchronous'}")
     print(f"  collector endpoint: {args.hub_endpoint}")
     print(f"  request endpoint:   {args.req_endpoint}")
     print(f"  measurement:        {args.measurement}")
@@ -131,7 +141,7 @@ def _print_header(args: argparse.Namespace) -> None:
     print(f"  interval:           {args.interval_s:.3f} s")
 
 
-def _print_status(req_endpoint: str) -> None:
+def _print_status_sync(req_endpoint: str) -> None:
     try:
         with MetricsHubClient(req_endpoint=req_endpoint, request_timeout=2.0) as client:
             info = client.server_status()
@@ -148,17 +158,46 @@ def _print_status(req_endpoint: str) -> None:
         print(f"Hub status check failed: {exc}")
 
 
-def run() -> int:
-    args = _parse_args()
+async def _print_status_async(req_endpoint: str) -> None:
+    try:
+        with AsyncMetricsHubClient(req_endpoint=req_endpoint, request_timeout=2.0) as client:
+            info = await client.server_status()
+            if info.get("success"):
+                backend = info.get("backend", {})
+                print("Hub status:")
+                print("  status:             ok")
+                print(f"  backend:            {backend.get('name', '?')}")
+                print(f"  backend reachable:  {backend.get('reachable', '?')}")
+                print(f"  repository class:   {backend.get('repository_class', '?')}")
+            else:
+                print(f"Hub status check failed: {info.get('error', 'unknown error')}")
+    except Exception as exc:
+        print(f"Hub status check failed: {exc}")
 
-    if args.interval_s <= 0:
-        raise ValueError("--interval-s must be > 0")
-    if args.duration_s <= 0:
-        raise ValueError("--duration-s must be > 0")
 
-    rng = random.Random(args.seed)
-    _print_header(args)
-    _print_status(args.req_endpoint)
+def _build_point(
+    args: argparse.Namespace,
+    t1: float,
+    t2: float,
+    t3: float,
+    elapsed_s: float,
+    sample_idx: int,
+) -> DataPoint:
+    return (
+        DataPoint.measurement(args.measurement)
+        .tag("device_id", args.device_id)
+        .tag("profile", "warm-cool-warm")
+        .field("sensor_1", round(t1, 3))
+        .field("sensor_2", round(t2, 3))
+        .field("sensor_3", round(t3, 3))
+        .field("elapsed_s", round(elapsed_s, 3))
+        .field("sample_idx", sample_idx)
+        .time(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f%z"))
+    )
+
+
+def _run_sync(args: argparse.Namespace, rng: random.Random) -> tuple[int, int]:
+    _print_status_sync(args.req_endpoint)
 
     sender = MetricsHubSender(hub_endpoint=args.hub_endpoint)
     sender.connect()
@@ -184,18 +223,7 @@ def run() -> int:
             )
 
             t1, t2, t3 = _sensor_temperatures(base_temp, elapsed_s, rng)
-
-            point = (
-                DataPoint.measurement(args.measurement)
-                .tag("device_id", args.device_id)
-                .tag("profile", "warm-cool-warm")
-                .field("sensor_1", round(t1, 3))
-                .field("sensor_2", round(t2, 3))
-                .field("sensor_3", round(t3, 3))
-                .field("elapsed_s", round(elapsed_s, 3))
-                .field("sample_idx", sample_idx)
-                .time(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f%z"))
-            )
+            point = _build_point(args, t1, t2, t3, elapsed_s, sample_idx)
 
             if sender.send(point):
                 sent_ok += 1
@@ -210,11 +238,81 @@ def run() -> int:
             target_elapsed = sample_idx * args.interval_s
             sleep_s = max(0.0, target_elapsed - (time.monotonic() - start))
             time.sleep(sleep_s)
+    finally:
+        sender.close()
+
+    return sent_ok, dropped
+
+
+async def _run_async(args: argparse.Namespace, rng: random.Random) -> tuple[int, int]:
+    await _print_status_async(args.req_endpoint)
+
+    sender = AsyncMetricsHubSender(hub_endpoint=args.hub_endpoint)
+    sender.connect()
+
+    start = time.monotonic()
+    sent_ok = 0
+    dropped = 0
+
+    try:
+        sample_idx = 0
+        while True:
+            now = time.monotonic()
+            elapsed_s = now - start
+            if elapsed_s > args.duration_s:
+                break
+
+            base_temp = _base_temperature(
+                t=elapsed_s,
+                duration_s=args.duration_s,
+                room_temp=args.room_temp,
+                peak_temp=args.peak_temp,
+                min_temp=args.min_temp,
+            )
+
+            t1, t2, t3 = _sensor_temperatures(base_temp, elapsed_s, rng)
+            point = _build_point(args, t1, t2, t3, elapsed_s, sample_idx)
+
+            if await sender.send(point):
+                sent_ok += 1
+            else:
+                dropped += 1
+
+            if sample_idx % 10 == 0:
+                print(f"t={elapsed_s:6.1f}s T1={t1:6.2f}C T2={t2:6.2f}C T3={t3:6.2f}C sent={sent_ok} dropped={dropped}")
+
+            sample_idx += 1
+
+            target_elapsed = sample_idx * args.interval_s
+            sleep_s = max(0.0, target_elapsed - (time.monotonic() - start))
+            await asyncio.sleep(sleep_s)
+    finally:
+        sender.close()
+
+    return sent_ok, dropped
+
+
+def run() -> int:
+    args = _parse_args()
+
+    if args.interval_s <= 0:
+        raise ValueError("--interval-s must be > 0")
+    if args.duration_s <= 0:
+        raise ValueError("--duration-s must be > 0")
+
+    rng = random.Random(args.seed)
+    _print_header(args)
+    sent_ok = 0
+    dropped = 0
+
+    try:
+        if args.run_async:
+            sent_ok, dropped = asyncio.run(_run_async(args, rng))
+        else:
+            sent_ok, dropped = _run_sync(args, rng)
 
     except KeyboardInterrupt:
         print("\nInterrupted by user, stopping...")
-    finally:
-        sender.close()
 
     total = sent_ok + dropped
     print("Done.")

--- a/libs/cgse-core/tests/test_metricshub.py
+++ b/libs/cgse-core/tests/test_metricshub.py
@@ -1,0 +1,328 @@
+import asyncio
+import json
+
+import pytest
+import zmq
+
+from egse.metrics import DataPoint
+from egse.metricshub.client import AsyncMetricsHubClient
+from egse.metricshub.client import AsyncMetricsHubSender
+from egse.metricshub.client import MetricsHubClient
+from egse.metricshub.client import MetricsHubSender
+from egse.metricshub.server import AsyncMetricsHub
+from egse.metricshub.server import _normalize_payload
+from egse.registry import MessageType
+
+
+class RecordingRepository:
+    def __init__(self):
+        self.connected = False
+        self.closed = False
+        self.writes: list[list[dict]] = []
+
+    def connect(self) -> None:
+        self.connected = True
+
+    def ping(self) -> bool:
+        return True
+
+    def write(self, points):
+        if isinstance(points, list):
+            self.writes.append(points.copy())
+        else:
+            self.writes.append([points])
+
+    def query(self, query_str: str, mode: str):
+        raise NotImplementedError()
+
+    def get_table_names(self) -> list[str]:
+        return []
+
+    def get_column_names(self, table_name: str) -> list[str]:
+        return []
+
+    def get_values_last_hours(self, table_name: str, column_name: str, hours: int, mode: str):
+        return []
+
+    def get_values_in_range(self, table_name: str, column_name: str, start_time: str, end_time: str, mode: str):
+        return []
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DummySyncSocket:
+    def __init__(self, poll_result=True, message_parts=None):
+        self.poll_result = poll_result
+        self.message_parts = message_parts or [
+            MessageType.RESPONSE.value,
+            json.dumps({"success": True, "status": "ok"}).encode(),
+        ]
+        self.sent: list[list[bytes]] = []
+
+    def send_multipart(self, message):
+        self.sent.append(message)
+
+    def poll(self, timeout):
+        return self.poll_result
+
+    def recv_multipart(self):
+        return self.message_parts
+
+
+class DummySyncPushSocket:
+    def __init__(self, should_raise_again: bool = False):
+        self.should_raise_again = should_raise_again
+        self.sent_payloads: list[bytes] = []
+
+    def send(self, payload: bytes, flags: int = 0):
+        if self.should_raise_again:
+            raise zmq.Again()
+        self.sent_payloads.append(payload)
+
+
+def test_normalize_payload_accepts_valid_datapoint():
+    payload = {
+        "measurement": "camera_tm",
+        "tags": {"device_id": "cam_01", "mode": "idle"},
+        "fields": {"temperature": 23.4, "pressure": 1013.2},
+        "time": "2026-03-23T12:34:56Z",
+    }
+
+    point, error = _normalize_payload(payload)
+
+    assert error is None
+    assert point == payload
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_fragment"),
+    [
+        ({}, "missing/invalid 'measurement'"),
+        ({"measurement": "camera_tm", "fields": {}}, "missing/invalid 'fields'"),
+        ({"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": []}, "invalid 'tags'"),
+        ({"measurement": "camera_tm", "fields": {"": 1.0}}, "field keys must be non-empty strings"),
+        ({"measurement": "camera_tm", "fields": {"temperature": None}}, "field values cannot be None"),
+        (
+            {"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": {"": "cam_01"}},
+            "tag keys must be non-empty strings",
+        ),
+        (
+            {"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": {"device_id": None}},
+            "tag values cannot be None",
+        ),
+        ({"measurement": "camera_tm", "fields": {"temperature": 1.0}, "time": {}}, "invalid timestamp/time"),
+    ],
+)
+def test_normalize_payload_rejects_invalid_datapoint(payload, error_fragment):
+    point, error = _normalize_payload(payload)
+
+    assert point is None
+    assert error_fragment in error
+
+
+def test_normalize_payload_rejects_non_dict_payload():
+    point, error = _normalize_payload(["not", "a", "dict"])
+
+    assert point is None
+    assert error == "payload is not a dict"
+
+
+@pytest.mark.asyncio
+async def test_flush_batch_writes_points_to_repository():
+    repository = RecordingRepository()
+    hub = AsyncMetricsHub(repository=repository)
+
+    batch = [
+        {
+            "measurement": "camera_tm",
+            "tags": {"device_id": "cam_01"},
+            "fields": {"temperature": 23.4},
+            "time": "2026-03-23T12:34:56Z",
+        },
+        {
+            "measurement": "camera_tm",
+            "tags": {"device_id": "cam_01"},
+            "fields": {"pressure": 1013.2},
+            "time": "2026-03-23T12:34:57Z",
+        },
+    ]
+
+    await hub._flush_batch(batch)
+
+    assert hub.stats["written"] == 2
+    assert hub.stats["errors"] == 0
+    assert repository.writes == [batch]
+
+
+@pytest.mark.asyncio
+async def test_flush_remaining_drains_queue_and_writes_points():
+    repository = RecordingRepository()
+    hub = AsyncMetricsHub(repository=repository)
+
+    queued_point = {
+        "measurement": "hexapod_tm",
+        "tags": {"device_id": "hex_01"},
+        "fields": {"x": 1.25},
+        "time": "2026-03-23T12:34:56Z",
+    }
+
+    await hub.data_queue.put(queued_point)
+
+    await hub._flush_remaining()
+
+    assert hub.data_queue.empty()
+    assert hub.stats["written"] == 1
+    assert repository.writes == [[queued_point]]
+
+
+def test_sync_metrics_hub_client_health_check_success():
+    client = MetricsHubClient(req_endpoint="tcp://localhost:9999")
+    client.req_socket = DummySyncSocket(  # type: ignore[assignment]
+        poll_result=True,
+        message_parts=[
+            MessageType.RESPONSE.value,
+            json.dumps({"success": True, "status": "ok"}).encode(),
+        ],
+    )
+
+    assert client.health_check() is True
+
+
+def test_sync_metrics_hub_client_server_status_timeout():
+    client = MetricsHubClient(req_endpoint="tcp://localhost:9999", request_timeout=0.01)
+    client.req_socket = DummySyncSocket(poll_result=False)  # type: ignore[assignment]
+
+    response = client.server_status()
+
+    assert response["success"] is False
+    assert response["error"] == "Request timed out"
+
+
+def test_sync_metrics_hub_client_terminate_no_reply():
+    client = MetricsHubClient(req_endpoint="tcp://localhost:9999")
+    socket = DummySyncSocket()
+    client.req_socket = socket  # type: ignore[assignment]
+
+    assert client.terminate_metrics_hub() is True
+    assert socket.sent, "Terminate request should be sent to the socket"
+    assert socket.sent[0][0] == MessageType.REQUEST_NO_REPLY.value
+
+
+@pytest.mark.asyncio
+async def test_sender_to_hub_data_path_over_zmq():
+    repository = RecordingRepository()
+    hub = AsyncMetricsHub(repository=repository)
+
+    # Use a random local port to avoid clashes with any running services.
+    endpoint = f"tcp://127.0.0.1:{hub.collector_socket.bind_to_random_port('tcp://127.0.0.1')}"
+
+    hub.batch_size = 1
+    hub.flush_interval = 0.05
+    hub.running = True
+
+    collector_task = asyncio.create_task(hub._collector())
+    batch_task = asyncio.create_task(hub._batch_processor())
+
+    sender = AsyncMetricsHubSender(hub_endpoint=endpoint)
+    sender.connect()
+
+    point = DataPoint.measurement("camera_tm").tag("device_id", "cam_01").field("temperature", 23.4)
+
+    try:
+        payload = json.dumps(point.as_dict()).encode()
+        # Bound send wait time so the test never hangs when the peer is unavailable.
+        sender.socket.setsockopt(zmq.SNDTIMEO, 200)  # type: ignore[union-attr]
+
+        sent = False
+        for _ in range(20):
+            try:
+                await sender.socket.send(payload)  # type: ignore[union-attr]
+                sent = True
+                break
+            except zmq.Again:
+                await asyncio.sleep(0.02)
+
+        assert sent is True
+
+        # Wait until the batch processor flushes the point.
+        for _ in range(50):
+            if repository.writes:
+                break
+            await asyncio.sleep(0.02)
+
+        assert repository.writes, "Expected at least one write from sender->hub pipeline."
+
+        flushed = repository.writes[0][0]
+        assert flushed["measurement"] == "camera_tm"
+        assert flushed["tags"]["device_id"] == "cam_01"
+        assert flushed["fields"]["temperature"] == 23.4
+    finally:
+        sender.close()
+
+        hub.running = False
+        collector_task.cancel()
+        batch_task.cancel()
+
+        await asyncio.gather(collector_task, batch_task, return_exceptions=True)
+
+        hub.collector_socket.close(linger=0)
+        hub.requests_socket.close(linger=0)
+        hub.context.term()
+
+
+def test_sync_sender_send_success_with_datapoint():
+    sender = MetricsHubSender(hub_endpoint="tcp://localhost:9999")
+    sender.socket = DummySyncPushSocket()  # type: ignore[assignment]
+
+    point = DataPoint.measurement("camera_tm").tag("device_id", "cam_01").field("temperature", 23.4)
+    assert sender.send(point) is True
+    assert sender.socket.sent_payloads, "Expected payload to be sent"  # type: ignore[union-attr]
+
+
+def test_sync_sender_send_returns_false_when_queue_full():
+    sender = MetricsHubSender(hub_endpoint="tcp://localhost:9999")
+    sender.socket = DummySyncPushSocket(should_raise_again=True)  # type: ignore[assignment]
+
+    point = DataPoint.measurement("camera_tm").field("temperature", 23.4)
+    assert sender.send(point) is False
+
+
+@pytest.mark.asyncio
+async def test_control_requests_health_info_terminate_in_process():
+    repository = RecordingRepository()
+    hub = AsyncMetricsHub(repository=repository)
+
+    requests_port = hub.requests_socket.bind_to_random_port("tcp://127.0.0.1")
+    req_endpoint = f"tcp://127.0.0.1:{requests_port}"
+
+    hub.running = True
+    request_task = asyncio.create_task(hub._handle_requests())
+
+    try:
+        await asyncio.sleep(0.05)
+
+        with AsyncMetricsHubClient(req_endpoint=req_endpoint, request_timeout=1.0) as client:
+            assert await client.health_check() is True
+
+            info = await client.server_status()
+            assert info["success"] is True
+            assert info["status"] == "ok"
+            assert info["requests_port"] == requests_port
+            assert info["backend"]["name"] == "injected"
+            assert info["backend"]["repository_class"] == "RecordingRepository"
+            assert info["backend"]["reachable"] is True
+            assert info["statistics"]["queue"] == 0
+
+            terminated = await client.terminate_metrics_hub()
+            assert terminated is True
+
+        assert hub._shutdown_event.is_set()
+    finally:
+        hub.running = False
+        request_task.cancel()
+        await asyncio.gather(request_task, return_exceptions=True)
+
+        hub.collector_socket.close(linger=0)
+        hub.requests_socket.close(linger=0)
+        hub.context.term()


### PR DESCRIPTION
## Summary
This PR implements the Metrics Hub service for telemetry ingestion and persistence, including async/sync client APIs, backend integration, and operational status/health improvements.

## What’s included
- Added Metrics Hub server
- Added synchronous and asynchronous Metrics Hub clients/senders
- Standardized payload handling to strict canonical `DataPoint.as_dict()` format (removed legacy compatibility paths)
- Added backend-aware configuration and startup behavior
- Improved operational observability
- Fixed InfluxDB write path
- Added comprehensive tests
- Added a runnable non-unit script to generate and send a 3-sensor simulated temperature profile for dashboard/robustness testing with Grafana in the loop (default 10-minute profile)

## Validation
- Metrics Hub test suite passes (test_metricshub.py)
- Manual verification confirmed InfluxDB measurement/table creation and queryable writes after the payload-to-Point fix.