### PR TITLE
Feature add metrics hub to core services

### DIFF
--- a/libs/cgse-common/src/egse/metrics.py
+++ b/libs/cgse-common/src/egse/metrics.py
@@ -5,6 +5,7 @@ __all__ = [
     "get_metrics_repo",
 ]
 
+import datetime
 from typing import Any
 from typing import Optional
 from typing import Protocol
@@ -24,6 +25,8 @@ from egse.system import format_datetime
 from egse.system import str_to_datetime
 
 SITE_ID = Settings.load("SITE").ID
+
+TimestampLike = str | int | float | datetime.datetime
 
 
 def define_metrics(
@@ -130,9 +133,9 @@ class PointLike(Protocol):
 
     def field(self, field, value) -> Self: ...
 
-    def time(self, time) -> Self: ...
+    def time(self, time: TimestampLike) -> Self: ...
 
-    def as_dict(self) -> dict: ...
+    def as_dict(self) -> dict[str, Any]: ...
 
 
 class DataPoint(PointLike):
@@ -140,11 +143,13 @@ class DataPoint(PointLike):
         self.measurement_name: str = measurement_name
         self.tags: dict[str, str] = {}
         self.fields: dict[str, Any] = {}
-        self.timestamp: int | str = format_datetime()
+        self.timestamp: TimestampLike = format_datetime()
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, Any]:
         if isinstance(self.timestamp, str):
             timestamp = str_to_datetime(self.timestamp).timestamp()
+        elif isinstance(self.timestamp, datetime.datetime):
+            timestamp = self.timestamp.timestamp()
         else:
             timestamp = self.timestamp
 
@@ -156,7 +161,7 @@ class DataPoint(PointLike):
         }
 
     @staticmethod
-    def measurement(measurement_name):
+    def measurement(measurement_name: str) -> "DataPoint":
         data_point = DataPoint(measurement_name)
         return data_point
 
@@ -168,7 +173,7 @@ class DataPoint(PointLike):
         self.fields[field] = value
         return self
 
-    def time(self, time):
+    def time(self, time: TimestampLike) -> Self:
         self.timestamp = time
         return self
 

--- a/libs/cgse-common/tests/test_metrics.py
+++ b/libs/cgse-common/tests/test_metrics.py
@@ -1,6 +1,20 @@
+import datetime
 import os
 
+from egse.metrics import DataPoint
 from egse.metrics import get_metrics_repo
+
+
+def test_datapoint_as_dict_serializes_datetime_timestamp():
+    timestamp = datetime.datetime(2026, 3, 25, 15, 12, 52, tzinfo=datetime.timezone.utc)
+
+    point = DataPoint.measurement("camera_tm").field("temperature", 23.4).time(timestamp)
+
+    payload = point.as_dict()
+
+    assert payload["measurement"] == "camera_tm"
+    assert payload["fields"]["temperature"] == 23.4
+    assert payload["time"] == timestamp.timestamp()
 
 
 def test_get_metrics_repo():

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -39,6 +39,7 @@ Storage Manager Control Server:                  # SM_CS
     MONITORING_PORT:               6116          # The port on which the controller sends periodic status information of the device - PUB-SUB
     SERVICE_PORT:                  6117          # The port on which the controller listens for configuration and administration - REQ-REP
     DELAY:                            1          # The delay time between publishing status information [seconds]
+    STORAGE_MNEMONIC:                SM          # The mnemonic to be used in the filename storing the housekeeping data
 
 Process Manager Control Server:                  # PM_CS
 

--- a/libs/cgse-core/src/egse/control.py
+++ b/libs/cgse-core/src/egse/control.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import abc
 import datetime
 import logging
-import os
 import pickle
 import textwrap
 import threading
@@ -21,7 +20,11 @@ from urllib3.exceptions import NewConnectionError
 from egse.listener import Listeners
 from egse.log import logger
 from egse.logger import close_all_zmq_handlers
-from egse.metrics import get_metrics_repo
+from egse.metrics import DataPoint
+from egse.metricshub import DEFAULT_COLLECTOR_PORT
+from egse.metricshub import SERVICE_TYPE as METRICS_HUB_SERVICE_TYPE
+from egse.metricshub.client import MetricsHubClient
+from egse.metricshub.client import MetricsHubSender
 from egse.notifyhub.services import EventSubscriber
 from egse.process import ProcessStatus
 from egse.registry.client import RegistryClient
@@ -104,7 +107,7 @@ class ControlServer(metaclass=abc.ABCMeta):
     """
 
     def __init__(self, device_id: str = None):
-        """Initialisation of a new Control Server."""
+        """Initialization of a new Control Server."""
 
         from egse.monitoring import MonitoringProtocol
         from egse.services import ServiceProtocol
@@ -173,21 +176,60 @@ class ControlServer(metaclass=abc.ABCMeta):
         self.poller.register(self.dev_ctrl_mon_sock, zmq.POLLIN)  # FIXME: I think this should not be registered
         self.poller.register(self.event_subscription.socket, zmq.POLLIN)
 
-        token = os.getenv("INFLUXDB3_AUTH_TOKEN")
-        database_name = os.getenv("INFLUXDB3_DATABASE_NAME")
+        collector_endpoint = self._resolve_metrics_hub_collector_endpoint()
 
-        if database_name and token:
-            self.metrics_client = get_metrics_repo(
-                "influxdb", {"host": "http://localhost:8181", "database": database_name, "token": token}
-            )
-            # self.metrics_client = get_metrics_repo("duckdb", {"db_path": "duckdb_metrics.db", "table_name": "cs_timeseries"})
-            self.metrics_client.connect()
+        if collector_endpoint:
+            self.metrics_sender = MetricsHubSender(hub_endpoint=collector_endpoint)
+            self.metrics_sender.connect()
+            self.logger.info(f"Metrics Hub sender connected to collector endpoint {collector_endpoint}")
         else:
-            self.metrics_client = None
+            self.metrics_sender = None
             logger.warning(
-                "INFLUXDB3_AUTH_TOKEN and/or PROJECT environment variable is not set. "
-                "Metrics will not be propagated to InfluxDB."
+                "Metrics Hub collector endpoint could not be resolved. "
+                "Metrics will not be propagated to the Metrics Hub."
             )
+
+    def _resolve_metrics_hub_collector_endpoint(self) -> str | None:
+        """Resolve the Metrics Hub collector endpoint.
+
+        When the collector port is configured explicitly, use it directly.
+        When it is configured as ``0`` (OS-assigned), discover the Metrics Hub
+        service in the registry and read ``metadata.collector_port``.
+        """
+        if DEFAULT_COLLECTOR_PORT:
+            return f"tcp://localhost:{DEFAULT_COLLECTOR_PORT}"
+
+        service = self.registry.discover_service(METRICS_HUB_SERVICE_TYPE)
+        if not service:
+            self.logger.warning("Metrics Hub service is not discoverable via Registry.")
+            return None
+
+        host = service.get("host") or "localhost"
+        metadata = service.get("metadata") or {}
+        collector_port = metadata.get("collector_port")
+
+        if collector_port:
+            return f"tcp://{host}:{collector_port}"
+
+        requests_port = service.get("port")
+        if not requests_port:
+            self.logger.warning("Metrics Hub service discovery did not return a requests port.")
+            return None
+
+        req_endpoint = f"tcp://{host}:{requests_port}"
+        try:
+            with MetricsHubClient(req_endpoint=req_endpoint, request_timeout=1.0) as client:
+                status = client.server_status()
+            collector_port = status.get("collector_port")
+            if collector_port:
+                return f"tcp://{host}:{collector_port}"
+        except Exception as exc:
+            self.logger.warning(
+                f"Failed to query Metrics Hub info via {req_endpoint} to resolve collector port: {exc!r}"
+            )
+
+        self.logger.warning("Unable to resolve Metrics Hub collector port from Registry or hub info.")
+        return None
 
     def get_event_subscriptions(self) -> list[str]:
         """Override this in the subclass to actually subscribe to events."""
@@ -567,7 +609,7 @@ class ControlServer(metaclass=abc.ABCMeta):
                             f"""{type_name(exc)}
                             An Exception occurred while collecting housekeeping from the device to be stored in {self.get_storage_mnemonic()}.
                             This might be a temporary problem, still needs to be looked into:
-        
+
                             {exc}
                             """
                         )
@@ -605,6 +647,9 @@ class ControlServer(metaclass=abc.ABCMeta):
         self.dev_ctrl_cmd_sock.close(linger=0)
 
         self.event_subscription.disconnect()
+
+        if self.metrics_sender:
+            self.metrics_sender.close()
 
         close_all_zmq_handlers()
 
@@ -666,10 +711,10 @@ class ControlServer(metaclass=abc.ABCMeta):
 
     def propagate_metrics(self, hk: dict) -> None:
         """
-        Propagates the given housekeeping information to the metrics database.
+        Propagates the given housekeeping information to the metrics hub.
 
-        Nothing will be written to the metrics database if the `hk` dict doesn't
-        contain any metrics (except for the timestamp).
+        Nothing will be written if the `hk` dict doesn't contain any metrics
+        (except for the timestamp), or if the metrics hub sender is not configured.
 
         Args:
             hk (dict): Dictionary containing parameter name and value of all device housekeeping. There is also
@@ -682,22 +727,27 @@ class ControlServer(metaclass=abc.ABCMeta):
             logger.debug(f"no metrics defined for {origin}")
             return
 
+        if not self.metrics_sender:
+            logger.warning(f"Could not send {origin} metrics to the Metrics Hub (metrics_sender is not configured).")
+            return
+
         try:
-            if self.metrics_client:
-                point = {
-                    "measurement": origin.lower(),
-                    "tags": {"site_id": SITE_ID, "origin": origin},
-                    "fields": {hk_name.lower(): hk[hk_name] for hk_name in hk if hk_name != "timestamp"},
-                    "time": str_to_datetime(hk["timestamp"]),
-                }
-                self.metrics_client.write(point)
-            else:
-                logger.warning(
-                    f"Could not write {origin} metrics to the time series database (self.metrics_client is None)."
-                )
+            point = (
+                DataPoint.measurement(origin.lower())
+                .tag("site_id", SITE_ID)
+                .tag("origin", origin)
+                .time(str_to_datetime(hk["timestamp"]))
+            )
+            for hk_name, hk_value in hk.items():
+                if hk_name != "timestamp":
+                    point.field(hk_name.lower(), hk_value)
+
+            logger.info(f"Sending data point to metrics hub: {point.as_dict()}")
+
+            self.metrics_sender.send(point)
         except NewConnectionError:
             logger.warning(
-                f"No connection to the time series database could be established to propagate {origin} metrics.  Check "
+                f"No connection to the Metrics Hub could be established to propagate {origin} metrics. Check "
                 f"whether this service is (still) running."
             )
 

--- a/libs/cgse-core/src/egse/metricshub/client.py
+++ b/libs/cgse-core/src/egse/metricshub/client.py
@@ -1,11 +1,11 @@
 """Client for the Async Metrics Hub.
 
-Use :class:`AsyncMetricsHubClient` to send control requests (health, info,
-terminate) to a running ``mh_cs`` service.
+Use `AsyncMetricsHubClient` to send control requests (health, info,
+terminate) to a running metrics hub (`mh_cs`) service.
 
-For sending data points to the hub use :class:`AsyncMetricsHubSender` (async)
-or :class:`MetricsHubSender` (sync), both of which keep a ZMQ PUSH socket and
-serialise :class:`~egse.metrics.DataPoint` objects as JSON.
+For sending data points to the hub use `AsyncMetricsHubSender` (async)
+or `MetricsHubSender` (sync), both of which keep a ZMQ PUSH socket and
+serialize `DataPoint` objects as JSON.
 
 Canonical payload format (``DataPoint.as_dict()``)::
 
@@ -262,7 +262,7 @@ class MetricsHubClient:
 
 
 class AsyncMetricsHubSender:
-    """Lightweight sender for pushing :class:`~egse.metrics.DataPoint` objects to the hub.
+    """Lightweight sender for pushing `DataPoint` objects to the hub.
 
     Maintains a single ZMQ PUSH socket for the lifetime of the sender.
     Fire-and-forget: if the hub queue is full the point is silently dropped and
@@ -350,11 +350,10 @@ class MetricsHubSender:
         self.socket = None
 
     def send(self, point: DataPoint | dict[str, Any]) -> bool:
-        """Serialise *point* and push it to the hub.
+        """Serialize *point* and push it to the hub.
 
         Args:
-            point: a :class:`~egse.metrics.DataPoint` instance or a pre-serialized
-                dictionary matching ``DataPoint.as_dict()``.
+            point: a `DataPoint` instance or a pre-serialized dictionary matching `DataPoint.as_dict()`.
 
         Returns:
             True when successfully queued to ZMQ, False when local send buffer

--- a/libs/cgse-core/src/egse/metricshub/server.py
+++ b/libs/cgse-core/src/egse/metricshub/server.py
@@ -164,9 +164,7 @@ class AsyncMetricsHub:
         # Batching configuration (from env, with sensible defaults)
         self.batch_size: int = _env_or_settings_int("CGSE_METRICS_BATCH_SIZE", "BATCH_SIZE", 500)
         self.flush_interval: float = _env_or_settings_float("CGSE_METRICS_FLUSH_INTERVAL", "FLUSH_INTERVAL", 2.0)
-        self.debug_counters_enabled: bool = _env_or_settings_bool(
-            "CGSE_METRICS_DEBUG_COUNTERS", "DEBUG_COUNTERS", True
-        )
+        self.debug_counters_enabled: bool = _env_or_settings_bool("CGSE_METRICS_DEBUG_COUNTERS", "DEBUG_COUNTERS", True)
 
         # Internal queue: raw dicts as received from ZMQ
         self.data_queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)

--- a/libs/cgse-core/src/egse/metricshub/server.py
+++ b/libs/cgse-core/src/egse/metricshub/server.py
@@ -1,14 +1,14 @@
 """Async Metrics Hub — core service for receiving and persisting telemetry/HK data.
 
-Clients send :class:`~egse.metrics.DataPoint` objects serialised as JSON to the
+Clients send `DataPoint` objects serialized as JSON to the
 PULL socket.  The hub batches the incoming points and flushes them to the
 configured storage backend (InfluxDB, DuckDB, …) via the plugin system in
 ``egse.plugins.metrics``.
 
-Backend selection is driven by the environment variable ``CGSE_METRICS_BACKEND``
-(default: ``"influxdb"``).  Backend-specific configuration is picked up from the
-environment inside the respective plugin (e.g. ``CGSE_INFLUX_*`` for InfluxDB).
-DuckDB additionally requires ``CGSE_DUCKDB_PATH``.
+Backend selection is driven by the environment variable `CGSE_METRICS_BACKEND`
+(default: `"influxdb"`).  Backend-specific configuration is picked up from the
+environment inside the respective plugin (e.g. `CGSE_INFLUX_*` for InfluxDB).
+DuckDB additionally requires `CGSE_DUCKDB_PATH`.
 """
 
 import asyncio
@@ -25,6 +25,7 @@ import typer
 import zmq
 import zmq.asyncio
 
+from egse.env import bool_env
 from egse.env import float_env
 from egse.env import int_env
 from egse.env import str_env
@@ -69,6 +70,10 @@ def _env_or_settings_float(env_name: str, setting_name: str, default: float) -> 
     return float_env(env_name, float(settings.get(setting_name, default)))
 
 
+def _env_or_settings_bool(env_name: str, setting_name: str, default: bool) -> bool:
+    return bool_env(env_name, bool(settings.get(setting_name, default)))
+
+
 def _get_backend_config() -> tuple[str, dict[str, Any], dict[str, Any]]:
     """Resolve backend name/config and return a safe public info dict.
 
@@ -106,7 +111,7 @@ def _get_backend_config() -> tuple[str, dict[str, Any], dict[str, Any]]:
 
 
 def _load_repository() -> tuple[TimeSeriesRepository, dict[str, Any]]:
-    """Build a :class:`~egse.metrics.TimeSeriesRepository` and safe backend metadata."""
+    """Build a `TimeSeriesRepository` and safe backend metadata."""
     backend, config, public_info = _get_backend_config()
     return get_metrics_repo(backend, config), public_info
 
@@ -118,7 +123,7 @@ class AsyncMetricsHub:
     Sockets
     -------
     collector_socket (PULL)
-        Receives serialised :class:`~egse.metrics.DataPoint` JSON from services.
+        Receives serialized `DataPoint` JSON from services.
     requests_socket (ROUTER)
         Handles control requests: health, info, terminate.
     """
@@ -159,6 +164,9 @@ class AsyncMetricsHub:
         # Batching configuration (from env, with sensible defaults)
         self.batch_size: int = _env_or_settings_int("CGSE_METRICS_BATCH_SIZE", "BATCH_SIZE", 500)
         self.flush_interval: float = _env_or_settings_float("CGSE_METRICS_FLUSH_INTERVAL", "FLUSH_INTERVAL", 2.0)
+        self.debug_counters_enabled: bool = _env_or_settings_bool(
+            "CGSE_METRICS_DEBUG_COUNTERS", "DEBUG_COUNTERS", True
+        )
 
         # Internal queue: raw dicts as received from ZMQ
         self.data_queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)
@@ -168,6 +176,9 @@ class AsyncMetricsHub:
             "written": 0,
             "dropped": 0,
             "errors": 0,
+            "filtered_none_fields": 0,
+            "filtered_none_tags": 0,
+            "dropped_all_none_fields": 0,
             "start_time": time.time(),
         }
 
@@ -253,12 +264,15 @@ class AsyncMetricsHub:
     async def register_service(self):
         self._logger.info("Registering Metrics Hub with service registry...")
 
+        requests_port = get_port_number(self.requests_socket)
+        collector_port = get_port_number(self.collector_socket)
+
         self.service_id = await self.registry_client.register(
             name=self.service_name,
             host=get_host_ip() or "127.0.0.1",
-            port=DEFAULT_REQUESTS_PORT,
+            port=requests_port,
             service_type=self.service_type,
-            metadata={"collector_port": DEFAULT_COLLECTOR_PORT},
+            metadata={"collector_port": collector_port},
         )
 
         if not self.service_id:
@@ -305,9 +319,20 @@ class AsyncMetricsHub:
 
             point_dict, error = _normalize_payload(payload)
             if point_dict is None:
+                if self.debug_counters_enabled and error == "all field values are None":
+                    self.stats["dropped_all_none_fields"] += 1
                 self._logger.warning(f"Received malformed payload, discarding: {error}")
                 self.stats["dropped"] += 1
                 continue
+
+            if self.debug_counters_enabled and isinstance(payload, dict):
+                fields = payload.get("fields")
+                if isinstance(fields, dict):
+                    self.stats["filtered_none_fields"] += sum(1 for value in fields.values() if value is None)
+
+                tags = payload.get("tags")
+                if isinstance(tags, dict):
+                    self.stats["filtered_none_tags"] += sum(1 for value in tags.values() if value is None)
 
             try:
                 await asyncio.wait_for(self.data_queue.put(point_dict), timeout=0.1)
@@ -489,6 +514,7 @@ class AsyncMetricsHub:
         backend_info["reachable"] = await self._backend_reachable()
         statistics = self.stats.copy()
         statistics["queue"] = self.data_queue.qsize()
+        statistics["debug_counters_enabled"] = self.debug_counters_enabled
 
         return {
             "success": True,
@@ -535,25 +561,30 @@ def _normalize_payload(payload: Any) -> tuple[dict | None, str | None]:
         return None, "invalid 'tags'"
 
     # keep field values compatible with downstream backends
+    cleaned_fields: dict[str, Any] = {}
     for key, value in fields.items():
         if not isinstance(key, str) or not key:
             return None, "field keys must be non-empty strings"
-        if value is None:
-            return None, "field values cannot be None"
+        if value is not None:
+            cleaned_fields[key] = value
 
+    if not cleaned_fields:
+        return None, "all field values are None"
+
+    cleaned_tags: dict[str, Any] = {}
     for key, value in tags.items():
         if not isinstance(key, str) or not key:
             return None, "tag keys must be non-empty strings"
-        if value is None:
-            return None, "tag values cannot be None"
+        if value is not None:
+            cleaned_tags[key] = value
 
     if timestamp is not None and not isinstance(timestamp, (str, int, float)):
         return None, "invalid timestamp/time"
 
     point = {
         "measurement": measurement,
-        "fields": fields,
-        "tags": tags,
+        "fields": cleaned_fields,
+        "tags": cleaned_tags,
     }
     if timestamp is not None:
         point["time"] = timestamp
@@ -621,6 +652,10 @@ async def status():
                     Dropped:     {stats.get("dropped", 0)}
                     Errors:      {stats.get("errors", 0)}
                     Queue size:  {stats.get("queue", "?")}
+                    None fields: {stats.get("filtered_none_fields", 0)}
+                    None tags:   {stats.get("filtered_none_tags", 0)}
+                    All-None:    {stats.get("dropped_all_none_fields", 0)}
+                    Debug counters:  {stats.get("debug_counters_enabled", True)}
             """
         )
     else:

--- a/libs/cgse-core/src/egse/storage/__init__.py
+++ b/libs/cgse-core/src/egse/storage/__init__.py
@@ -508,7 +508,7 @@ class StorageInterface:
         pass
 
     @dynamic_interface
-    def get_loaded_setup_id(self) -> str:
+    def get_loaded_setup_id(self) -> int:
         """
         Returns the ID of the currently loaded Setup.
 
@@ -1052,8 +1052,8 @@ class StorageController(StorageInterface):
         total, used, free = shutil.disk_usage(location)
         return total, used, free
 
-    def get_loaded_setup_id(self) -> str:
-        return self._setup.get_id() if self._setup is not None else "no setup loaded"
+    def get_loaded_setup_id(self) -> int:
+        return int(self._setup.get_id()) if self._setup is not None else 0
 
     def load_setup(self, setup_id: int = 0):
         # Use get_setup() here instead of load_setup() in order to prevent recursively notifying and loading Setups.
@@ -1132,9 +1132,12 @@ class StorageProtocol(CommandProtocol):
         return super().get_status()
 
     def get_housekeeping(self) -> dict:
+        setup_id = self.controller.get_loaded_setup_id()
+
         return {
             "timestamp": format_datetime(),
             "random": random.randint(0, 100),
+            "sm_setup_id": setup_id,
         }
 
 

--- a/libs/cgse-core/src/egse/storage/storage_cs.py
+++ b/libs/cgse-core/src/egse/storage/storage_cs.py
@@ -32,16 +32,15 @@ from egse.logger import remote_logging
 from egse.process import SubProcess
 from egse.registry.client import RegistryClient
 from egse.services import ServiceProxy
-from egse.storage import (
-    StorageProtocol,
-    PROCESS_NAME,
-    SERVICE_TYPE,
-    PROTOCOL,
-    COMMANDING_PORT,
-    SERVICE_PORT,
-    MONITORING_PORT,
-    HOSTNAME,
-)
+from egse.storage import COMMANDING_PORT
+from egse.storage import HOSTNAME
+from egse.storage import MONITORING_PORT
+from egse.storage import PROCESS_NAME
+from egse.storage import PROTOCOL
+from egse.storage import SERVICE_PORT
+from egse.storage import SERVICE_TYPE
+from egse.storage import STORAGE_MNEMONIC
+from egse.storage import StorageProtocol
 from egse.storage import StorageProxy
 from egse.storage import cycle_daily_files
 from egse.zmq_ser import get_port_number
@@ -98,6 +97,9 @@ class StorageControlServer(ControlServer):
 
     def get_monitoring_port(self):
         return get_port_number(self.dev_ctrl_mon_sock) or MONITORING_PORT
+
+    def get_storage_mnemonic(self):
+        return STORAGE_MNEMONIC
 
     def get_event_subscriptions(self) -> list[str]:
         return ["new_setup"]
@@ -200,6 +202,7 @@ def status(full: Annotated[bool, typer.Option(help="Give a full status report")]
     """Print the status of the control server."""
 
     import rich
+
     from egse.storage import get_status
 
     rich.print(get_status(full=full), end="")

--- a/libs/cgse-core/tests/test_metricshub.py
+++ b/libs/cgse-core/tests/test_metricshub.py
@@ -95,6 +95,22 @@ def test_normalize_payload_accepts_valid_datapoint():
     assert point == payload
 
 
+def test_normalize_payload_filters_none_fields_and_tags():
+    payload = {
+        "measurement": "camera_tm",
+        "tags": {"device_id": "cam_01", "mode": None},
+        "fields": {"temperature": 23.4, "pressure": None},
+        "time": "2026-03-23T12:34:56Z",
+    }
+
+    point, error = _normalize_payload(payload)
+
+    assert error is None
+    assert point is not None
+    assert point["fields"] == {"temperature": 23.4}
+    assert point["tags"] == {"device_id": "cam_01"}
+
+
 @pytest.mark.parametrize(
     ("payload", "error_fragment"),
     [
@@ -102,14 +118,10 @@ def test_normalize_payload_accepts_valid_datapoint():
         ({"measurement": "camera_tm", "fields": {}}, "missing/invalid 'fields'"),
         ({"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": []}, "invalid 'tags'"),
         ({"measurement": "camera_tm", "fields": {"": 1.0}}, "field keys must be non-empty strings"),
-        ({"measurement": "camera_tm", "fields": {"temperature": None}}, "field values cannot be None"),
+        ({"measurement": "camera_tm", "fields": {"temperature": None}}, "all field values are None"),
         (
             {"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": {"": "cam_01"}},
             "tag keys must be non-empty strings",
-        ),
-        (
-            {"measurement": "camera_tm", "fields": {"temperature": 1.0}, "tags": {"device_id": None}},
-            "tag values cannot be None",
         ),
         ({"measurement": "camera_tm", "fields": {"temperature": 1.0}, "time": {}}, "invalid timestamp/time"),
     ],
@@ -126,6 +138,54 @@ def test_normalize_payload_rejects_non_dict_payload():
 
     assert point is None
     assert error == "payload is not a dict"
+
+
+@pytest.mark.asyncio
+async def test_collector_tracks_none_filtering_debug_counters():
+    repository = RecordingRepository()
+    hub = AsyncMetricsHub(repository=repository)
+
+    endpoint = f"tcp://127.0.0.1:{hub.collector_socket.bind_to_random_port('tcp://127.0.0.1')}"
+    push = hub.context.socket(zmq.PUSH)
+    push.connect(endpoint)
+
+    hub.running = True
+    collector_task = asyncio.create_task(hub._collector())
+
+    try:
+        await push.send_json(
+            {
+                "measurement": "camera_tm",
+                "fields": {"temperature": 23.4, "pressure": None},
+                "tags": {"device_id": "cam_01", "mode": None},
+            }
+        )
+        await push.send_json(
+            {
+                "measurement": "camera_tm",
+                "fields": {"temperature": None},
+                "tags": {"device_id": "cam_01"},
+            }
+        )
+
+        for _ in range(50):
+            if hub.stats["received"] >= 1 and hub.stats["dropped"] >= 1:
+                break
+            await asyncio.sleep(0.02)
+
+        assert hub.stats["received"] == 1
+        assert hub.stats["dropped"] == 1
+        assert hub.stats["filtered_none_fields"] == 1
+        assert hub.stats["filtered_none_tags"] == 1
+        assert hub.stats["dropped_all_none_fields"] == 1
+    finally:
+        hub.running = False
+        collector_task.cancel()
+        await asyncio.gather(collector_task, return_exceptions=True)
+        push.close(linger=0)
+        hub.collector_socket.close(linger=0)
+        hub.requests_socket.close(linger=0)
+        hub.context.term()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR integrates Metrics Hub into the core services, refactors Control Server metric propagation to use the hub, and improves robustness around payload normalization, backend discovery, and observability. It also adds tests and tooling for end-to-end metrics validation.