### PR TITLE
Fix exception pickling for DeviceError and subclasses

### DIFF
--- a/libs/cgse-common/src/egse/device.py
+++ b/libs/cgse-common/src/egse/device.py
@@ -31,6 +31,7 @@ class DeviceError(Error):
     """
 
     def __init__(self, device_name: str, message: str):
+        super().__init__(device_name, message)
         self.device_name = device_name
         self.message = message
 


### PR DESCRIPTION
When a `DeviceConnectionError` (or any `DeviceError` subclass) is raised inside a control server and sent back to a client over ZeroMQ, the exception fails to reconstruct on the client side with: 

```python
  DeviceConnectionError.__init__() missing 2 required positional arguments: 'device_name' and 'message'                                                                                                                                                 
```

**Root cause**:  Python serializes exceptions by storing `self.args` (set by `BaseException.__init__`) and reconstructs them via `cls(*self.args)`. `DeviceError.__init__` was setting `self.device_name` and `self.message` directly but never calling `super().__init__()`, so `self.args` remained `()`. On the receiving end, CGSE would call `DeviceConnectionError()` with no arguments, triggering the `TypeError`.

**Fix**: Call `super().__init__(device_name, message)` at the top of `DeviceError.__init__`. This ensures `self.args = (device_name, message)`, so pickle correctly reconstructs the exception as `DeviceConnectionError(device_name, message)`. All subclasses (`DeviceConnectionError`, `DeviceTimeoutError`, `DeviceInterfaceError`, `DeviceControllerError`) are fixed automatically since they all delegate to `DeviceError.__init__` via super`()`.