### PR TITLE
Check for broken pipe in TGF4000 and add socket keepalives

### DIFF
--- a/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
+++ b/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
@@ -90,6 +90,7 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
 
         try:
             self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             # The following lines are to experiment with blocking and timeout, but there is no need.
             # self._sock.setblocking(1)
             # self._sock.settimeout(3)

--- a/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
+++ b/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
@@ -211,7 +211,7 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
             self._sock.sendall(command.encode("latin1"))
 
         except BrokenPipeError:
-            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect...")
+            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect and resend...")
             self._is_connection_open = False
             try:
                 self.connect()
@@ -264,7 +264,7 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
             # noinspection PyUnboundLocalVariable
             return return_string
         except BrokenPipeError:
-            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect...")
+            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect and resend...")
             self._is_connection_open = False
             try:
                 self.connect()

--- a/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
+++ b/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
@@ -217,7 +217,9 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
                 self.connect()
                 self._sock.sendall(command.encode("latin1"))
             except Exception as exc:
-                raise DeviceConnectionError(self.device_id, "Socket communication error after reconnect attempt.") from exc
+                raise DeviceConnectionError(
+                    self.device_id, "Socket communication error after reconnect attempt."
+                ) from exc
         except socket.timeout as e_timeout:
             raise DeviceTimeoutError(self.device_id, "Socket timeout error") from e_timeout
         except socket.error as e_socket:

--- a/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
+++ b/projects/generic/aim-tti-awg/src/egse/arbitrary_wave_generator/aim_tti/tgf4000_devif.py
@@ -209,6 +209,14 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
 
             self._sock.sendall(command.encode("latin1"))
 
+        except BrokenPipeError:
+            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect...")
+            self._is_connection_open = False
+            try:
+                self.connect()
+                self._sock.sendall(command.encode("latin1"))
+            except Exception as exc:
+                raise DeviceConnectionError(self.device_id, "Socket communication error after reconnect attempt.") from exc
         except socket.timeout as e_timeout:
             raise DeviceTimeoutError(self.device_id, "Socket timeout error") from e_timeout
         except socket.error as e_socket:
@@ -252,6 +260,16 @@ class Tgf4000EthernetInterface(DeviceConnectionInterface, DeviceTransport):
         except UnicodeError:
             # noinspection PyUnboundLocalVariable
             return return_string
+        except BrokenPipeError:
+            logger.warning(f"{self.device_id}: Broken pipe detected, attempting to reconnect...")
+            self._is_connection_open = False
+            try:
+                self.connect()
+                self._sock.sendall(command.encode("latin1"))
+                return_string = self.read()
+                return return_string.decode().rstrip()
+            except Exception as exc:
+                raise DeviceConnectionError(self.device_id, "Connection error after reconnect attempt.") from exc
         except socket.timeout as e_timeout:
             raise DeviceTimeoutError(self.device_id, "Socket timeout error") from e_timeout
         except socket.error as e_socket:

--- a/projects/generic/digilent/src/egse/digilent/measurpoint/digilent_devif.py
+++ b/projects/generic/digilent/src/egse/digilent/measurpoint/digilent_devif.py
@@ -64,6 +64,7 @@ class DigilentEthernetInterface(DeviceConnectionInterface, DeviceTransport):
 
         try:
             self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             # The following lines are to experiment with blocking and timeout, but there is no need.
             # self._sock.setblocking(1)
             # self._sock.settimeout(3)

--- a/projects/generic/kikusui-power-supply/src/egse/power_supply/kikusui/pmx_devif.py
+++ b/projects/generic/kikusui-power-supply/src/egse/power_supply/kikusui/pmx_devif.py
@@ -84,6 +84,7 @@ class PmxEthernetInterface(DeviceConnectionInterface, DeviceTransport):
 
         try:
             self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
             # The following lines are to experiment with blocking and timeout, but there is no need.
             # self._sock.setblocking(1)
             # self._sock.settimeout(3)


### PR DESCRIPTION
We've experienced a lot of issues with socket connections getting broken with the TGF4000 devices. This PR attempts to fix this in two ways:
1. Check for a `BrokenPipeError` and try to reconnect after the detection
2. Add socket keepalives. A hypothesis is that for the TVAC AWGs, we use several time.sleep statements for power sequencing. It's possible that the TGF4000 has a TCP timeout that closes the socket after an idle period. With the keepalives, the socket should remain open