### PR TITLE
Refactor registry port configuration to load from settings 

### DIFF
--- a/libs/cgse-core/src/egse/registry/__init__.py
+++ b/libs/cgse-core/src/egse/registry/__init__.py
@@ -1,13 +1,21 @@
 from enum import Enum
 
 from egse.log import logging
+from egse.settings import Settings
 
 logger = logging.getLogger("egse.registry")
 
-# Default ports that are assigned to REQ-REP and PUB-SUB protocols of the registry services
-DEFAULT_RS_REQ_PORT = 4242  # Handle requests
-DEFAULT_RS_PUB_PORT = 4243  # Publish events
-DEFAULT_RS_HB_PORT = 4244  # Heartbeats
+
+settings = Settings.load("Service Registry")
+
+# The ports that are assigned to REQ-REP and PUB-SUB protocols of the registry services. These can be overridden in
+# the local settings file with a fallback value specified below. Do not assign zero ('0') to these ports, as this
+# will cause the registry server to bind to a random free port, which will break the communication between the
+# registry server and its clients. Clients will then not be able to contact the registry server for service discovery.
+
+DEFAULT_RS_REQ_PORT = settings.get("REQUESTER_PORT", 4242)  # Handle requests
+DEFAULT_RS_PUB_PORT = settings.get("PUBLISHER_PORT", 4243)  # Publish events
+DEFAULT_RS_HB_PORT = settings.get("HEARTBEAT_PORT", 4244)  # Heartbeats
 
 DEFAULT_RS_DB_PATH = "service_registry.db"
 
@@ -36,6 +44,25 @@ def is_service_registry_active(timeout: float = 0.5):
 
     with RegistryClient(timeout=timeout) as client:
         if not client.health_check():
+            return False
+        else:
+            return True
+
+
+async def async_is_service_registry_active(timeout: float = 0.5) -> bool:
+    """Asynchronously check if the service registry is running and active.
+
+    This function sends a `health` request to the service registry and awaits
+    the answer.
+
+    If no reply is received within the given timeout (default: 0.5s), the
+    request times out and False is returned.
+    """
+
+    from egse.registry.client import AsyncRegistryClient  # prevent circular import
+
+    with AsyncRegistryClient(timeout=timeout) as client:
+        if not await client.health_check():
             return False
         else:
             return True


### PR DESCRIPTION
The Service Registry was the only core service that didn't read the port numbers from the Settings. This has now been fixed.
Also added an asynchronous function to check if the service is running.