### PR TITLE
Refactor AsyncRegistryClient usage to support async context management and ensure proper connection handling

### DIFF
--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -124,7 +124,7 @@ async def rm_cs_status(suppress_errors: bool = True):
 @rm_cs.command(cls=TyperAsyncCommand, name="list-services")
 async def reg_list_services():
     """Print the active services that are registered."""
-    with AsyncRegistryClient() as client:
+    async with AsyncRegistryClient() as client:
         services = await client.list_services()
 
         for service in services:
@@ -137,7 +137,7 @@ async def reg_list_services():
 @rm_cs.command(cls=TyperAsyncCommand, name="deregister")
 async def reg_deregister(service_type: str):
     """De-register the given service from the service registry."""
-    with AsyncRegistryClient() as client:
+    async with AsyncRegistryClient() as client:
         services = await client.list_services(service_type)
 
         if not services:

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -78,7 +78,7 @@ async def is_control_server_active(service_type: str, timeout: float = 0.5) -> b
     #
     # 1. I can connect to the ServiceRegistry, and analyse the 'health' field if it is 'passing', or
 
-    with AsyncRegistryClient() as registry:
+    async with AsyncRegistryClient() as registry:
         service = await registry.discover_service(service_type)
     if service:
         return True if service["health"] == "passing" else False
@@ -235,7 +235,7 @@ class AsyncControlServer:
     async def register_service(self):
         self.logger.info(f"Registering service {type(self).__name__} as type {self.service_type}")
 
-        self.registry.connect()
+        await self.registry.connect()
 
         self._service_id = await self.registry.register(
             name=type_name(self),
@@ -250,7 +250,7 @@ class AsyncControlServer:
         await self.registry.stop_heartbeat()
         await self.registry.deregister()
 
-        self.registry.disconnect()
+        await self.registry.disconnect()
 
     async def _check_tasks_health(self):
         """Check if any tasks unexpectedly terminated."""
@@ -775,7 +775,7 @@ class AsyncControlClient:
 
         self._post_init_is_done = True
         if self.service_type:
-            with AsyncRegistryClient() as registry:
+            async with AsyncRegistryClient() as registry:
                 service = await registry.discover_service(self.service_type)
             if service:
                 hostname = service["host"]

--- a/libs/cgse-core/src/egse/metricshub/server.py
+++ b/libs/cgse-core/src/egse/metricshub/server.py
@@ -141,7 +141,6 @@ class AsyncMetricsHub:
 
         # Service registry
         self.registry_client = AsyncRegistryClient(timeout=REQUEST_TIMEOUT)
-        self.registry_client.connect()
 
         self.service_id = None
         self.service_name = PROCESS_NAME
@@ -228,6 +227,8 @@ class AsyncMetricsHub:
             asyncio.create_task(self._handle_requests()),
         ]
 
+        await self.registry_client.connect()
+
         await self.register_service()
 
         await self._shutdown_event.wait()
@@ -253,7 +254,7 @@ class AsyncMetricsHub:
         self.collector_socket.close()
         self.requests_socket.close()
 
-        self.registry_client.disconnect()
+        await self.registry_client.disconnect()
 
         self._logger.info("Async Metrics Hub shutdown complete.")
 

--- a/libs/cgse-core/src/egse/notifyhub/server.py
+++ b/libs/cgse-core/src/egse/notifyhub/server.py
@@ -55,7 +55,6 @@ class AsyncNotificationHub:
 
         # Register notification hub to the service registry
         self.registry_client = AsyncRegistryClient(timeout=REQUEST_TIMEOUT)
-        self.registry_client.connect()
 
         self.service_id = None
         self.service_name = PROCESS_NAME
@@ -97,6 +96,8 @@ class AsyncNotificationHub:
             asyncio.create_task(self._handle_requests()),
         ]
 
+        await self.registry_client.connect()
+
         await self.register_service()
 
         await self._shutdown_event.wait()
@@ -119,7 +120,7 @@ class AsyncNotificationHub:
         self.publisher_socket.close()
         self.requests_socket.close()
 
-        self.registry_client.disconnect()
+        await self.registry_client.disconnect()
 
         self.logger.info("Async Notification Hub shutdown complete")
 

--- a/libs/cgse-core/src/egse/registry/__init__.py
+++ b/libs/cgse-core/src/egse/registry/__init__.py
@@ -61,7 +61,7 @@ async def async_is_service_registry_active(timeout: float = 0.5) -> bool:
 
     from egse.registry.client import AsyncRegistryClient  # prevent circular import
 
-    with AsyncRegistryClient(timeout=timeout) as client:
+    async with AsyncRegistryClient(timeout=timeout) as client:
         if not await client.health_check():
             return False
         else:

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -590,16 +590,20 @@ class AsyncRegistryClient:
         self.sub_socket: zmq.asyncio.Socket | None = None
         self.hb_socket: zmq.asyncio.Socket | None = None
 
-    def __enter__(self):
-        self.connect()
+    async def __aenter__(self):
+        await self.connect()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.disconnect()
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.disconnect()
 
-    def connect(self):
+    async def connect(self) -> None:
         if VERBOSE_DEBUG:
             self.logger.debug("Connecting to service registry...")
+
+        if self.req_socket is not None and self.sub_socket is not None:
+            self.logger.warning("Already connected to service registry, skipping connection.")
+            return
 
         # REQ socket for request-reply pattern
         self.req_socket = self.context.socket(zmq.DEALER)
@@ -619,9 +623,13 @@ class AsyncRegistryClient:
         self.hb_socket.setsockopt(zmq.IDENTITY, self._client_id)
         self.hb_socket.connect(self.registry_hb_endpoint)
 
-    def disconnect(self):
+    async def disconnect(self) -> None:
         if VERBOSE_DEBUG:
             self.logger.debug("Disconnecting from service registry...")
+
+        self._running = False
+        await self.stop_all_tasks()
+        self._disconnect_hb_socket()
 
         if self.req_socket:
             self.req_socket.close(linger=0)
@@ -1159,28 +1167,8 @@ class AsyncRegistryClient:
         return response
 
     async def close(self) -> None:
-        """Clean up resources."""
-        await self.stop_heartbeat()  # This stops all tasks
-
-        try:
-            if hasattr(self, "req_socket") and self.req_socket:
-                self.req_socket.close()
-
-            if hasattr(self, "sub_socket") and self.sub_socket:
-                self.sub_socket.close()
-
-            # We can not terminate the context, because we use a global instance, i.e. a singleton context.
-            # When we try to terminate it, even after checking if it was closed, it raises an exception.
-            if hasattr(self, "context") and self.context:
-                if VERBOSE_DEBUG:
-                    self.logger.debug(f"{self.context = !r}")
-                    self.logger.debug(f"{self.context._sockets = !r}")
-                # The zmq context instance is the global singleton instance.
-                # Terminating it here would affect other parts of the application using zmq.
-                # if not self.context.closed:
-                #     self.context.term()
-        except Exception as exc:
-            self.logger.error(f"Error during cleanup: {exc}")
+        """Backward-compatible alias for disconnect()."""
+        await self.disconnect()
 
 
 def is_service_registered(service_type: str):

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -596,7 +596,7 @@ async def status(
     hb_port: int = DEFAULT_RS_HB_PORT,
     host: str = "localhost",
 ):
-    with AsyncRegistryClient(
+    async with AsyncRegistryClient(
         registry_req_endpoint=f"tcp://{host}:{req_port}",
         registry_sub_endpoint=f"tcp://{host}:{pub_port}",
         registry_hb_endpoint=f"tcp://{host}:{hb_port}",
@@ -627,7 +627,7 @@ async def stop(
     hb_port: int = DEFAULT_RS_HB_PORT,
     host: str = "localhost",
 ):
-    with AsyncRegistryClient(
+    async with AsyncRegistryClient(
         registry_req_endpoint=f"tcp://{host}:{req_port}",
         registry_sub_endpoint=f"tcp://{host}:{pub_port}",
         registry_hb_endpoint=f"tcp://{host}:{hb_port}",

--- a/libs/cgse-core/src/egse/registry/service.py
+++ b/libs/cgse-core/src/egse/registry/service.py
@@ -94,7 +94,6 @@ class ZMQMicroservice:
         self.registry_client = AsyncRegistryClient(
             registry_req_endpoint=self.registry_req_endpoint, registry_sub_endpoint=self.registry_sub_endpoint
         )
-        self.registry_client.connect()
 
         self.command_handlers = {}
 
@@ -152,6 +151,8 @@ class ZMQMicroservice:
         - start the background task to handle requests
         """
         module_logger.info(f"Starting {self.service_name} ({self.service_type}) on {self.host_ip}:{self.rep_port}")
+
+        await self.registry_client.connect()
 
         # Register with the registry
         self.service_id = await self.registry_client.register(


### PR DESCRIPTION
This pull request makes the AsyncRegistryClient context manager and the connect/disconnect functions asynchronous. All occurrences where the AsyncRegistryClient is used are updated with the `async with..` statement.