### PR TITLE
Fix submit setup

### DIFF
--- a/libs/cgse-common/src/egse/setup.py
+++ b/libs/cgse-common/src/egse/setup.py
@@ -767,18 +767,42 @@ def submit_setup_to_disk(setup: Setup, description: str, **kwargs) -> str | None
         The Setup ID of the newly created Setup or None.
     """
 
+    site_id = kwargs.get("site_id") or setup.get("site_id") or get_site_id()
+    setup_location = Path(get_conf_data_location(site_id)).expanduser()
+    setup_location.mkdir(parents=True, exist_ok=True)
+
+    setup_files = sorted(setup_location.glob(f"SETUP_{site_id}_*.yaml"))
+    existing_setup_ids = [
+        int(parsed_setup_id)
+        for file in setup_files
+        if (parsed_setup_id := _parse_filename_for_setup_id(file.name)) is not None
+    ]
+    setup_id = (max(existing_setup_ids) + 1) if existing_setup_ids else 0
+
+    filename = f"SETUP_{site_id}_{setup_id:05d}_{format_datetime(fmt='%y%m%d_%H%M%S')}.yaml"
+
+    history = setup.get("history")
+    if not isinstance(history, dict):
+        history = {}
+        setup["history"] = history
+
+    history.update({f"{setup_id}": description})
+    setup.set_private_attribute("_setup_id", setup_id)
+    setup.to_yaml_file(setup_location / filename)
+    save_last_setup_id(setup_id, site_id=site_id)
+
     rich.print(
         textwrap.dedent(
-            f"""\
-            Saving setup to disk, a new setup identifier will be assigned. 
-            To finalise the submit, reload the setup:
+            """\
+            Saving setup to disk, a new setup identifier has been assigned.
+            To finalize the submit, reload the setup:
 
-            setup = load_setup() 
+            setup = load_setup()
             """
         )
     )
 
-    return "00000"
+    return f"{setup_id:05d}"
 
 
 @runtime_checkable
@@ -944,7 +968,25 @@ class SetupManager:
         return self._default_source
 
     def load_setup(self, setup_id: int = None, **kwargs):
+        """Load a Setup.
+
+        Args:
+            setup_id: identifier for the requested Setup
+
+        Optional keyword arguments:
+            site_id: the name of the test site
+            from_disk: if True, load the Setup from disk instead of the configuration manager
+            source: the source to load the Setup from, e.g. 'core-services' or 'local' ('local'
+                is equivalent to using 'from_disk=True')
+
+        Returns:
+            The loaded Setup or None when the Setup could not be loaded.
+        """
+        if kwargs.get("from_disk", False):
+            return LocalSetupProvider().load_setup(setup_id, **kwargs)
+
         source = kwargs.get("source") or self.get_default_source()
+        logger.info(f"Loading Setup with source = {source}, setup_id = {setup_id}, kwargs = {kwargs}")
         for provider in self.providers:
             if provider.can_handle(source):
                 return provider.load_setup(setup_id, **kwargs)

--- a/libs/cgse-common/tests/test_setup.py
+++ b/libs/cgse-common/tests/test_setup.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 import rich
 import yaml
+from fixtures.helpers import create_text_file
 from navdict import NavigableDict
 
 from egse.device import DeviceInterface
@@ -18,8 +19,8 @@ from egse.env import get_conf_data_location
 from egse.env import get_conf_data_location_env_name
 from egse.env import get_conf_repo_location_env_name
 from egse.env import print_env
-from egse.env import setup_env
 from egse.env import set_conf_repo_location
+from egse.env import setup_env
 from egse.setup import Setup
 from egse.setup import get_last_setup_id_file_path
 from egse.setup import get_path_of_setup_file
@@ -27,8 +28,8 @@ from egse.setup import load_last_setup_id
 from egse.setup import load_setup
 from egse.setup import navdict
 from egse.setup import save_last_setup_id
+from egse.setup import submit_setup_to_disk
 from egse.system import AttributeDict
-from fixtures.helpers import create_text_file
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -818,13 +819,11 @@ def test_get_path_of_last_setup_file():
 
 
 def test_load_setup():
-    from egse.setup import _setup_manager  # noqa
-
-    _setup_manager.set_default_source("local")
-
-    setup = load_setup(setup_id=28)
+    setup = load_setup(setup_id=28, source="local")
     rich.print(setup)
-    assert int(setup.get_id()) == 28
+    assert setup is not None
+    assert setup.get_id() == "00028"
+    assert int(setup.get_id() or "0") == 28
 
 
 # @pytest.mark.skip(reason="load_setup prefers the repo location over the conf data location.")
@@ -867,6 +866,24 @@ def test_load_setup_from_disk():
             assert setup.site_id == "CSL"
             assert 29 not in setup.history
             assert "SETUP_CSL_00028" in str(setup.get_private_attribute("_filename"))
+
+
+def test_submit_setup_to_disk_creates_new_setup_file_and_returns_new_id():
+    site_id = "LAB23"
+    setup_location = Path(get_conf_data_location(site_id))
+
+    before_files = sorted(setup_location.glob(f"SETUP_{site_id}_*.yaml"))
+    assert before_files
+
+    setup = Setup.from_dict({"site_id": site_id, "history": {}})
+
+    returned_setup_id = submit_setup_to_disk(setup, "regression test submit to disk", site_id=site_id)
+
+    after_files = sorted(setup_location.glob(f"SETUP_{site_id}_*.yaml"))
+
+    # A disk submit should persist a new setup and return that newly assigned setup ID.
+    assert len(after_files) == len(before_files) + 1
+    assert returned_setup_id != "00000"
 
 
 def test_last_setup_id():


### PR DESCRIPTION
This pull request implements the `submit_setup()` in the `cgse-common` package, where the Setup will be written to disk and the new setup id will be returned.