### PR TITLE
Feature socketdevice with backoff strategy

### DIFF
--- a/libs/cgse-common/src/egse/backoff.py
+++ b/libs/cgse-common/src/egse/backoff.py
@@ -29,17 +29,44 @@ def calculate_retry_interval(
     jitter_strategy: JitterStrategy = JitterStrategy.EQUAL,
     exponential_factor: float = 2.0,
 ) -> float:
-    """Calculate the next retry interval using backoff and optional jitter."""
+    """Calculate the next retry interval using backoff and optional jitter.
+
+    Note: The first retry attempt is considered attempt_number=0, which will yield a delay equal to the base_interval
+    for all backoff strategies.
+
+    Args:
+        attempt_number: The number of the current retry attempt (0-based).
+        base_interval: The base interval in seconds for the first retry attempt.
+        max_interval: The maximum interval in seconds to cap the retry delay.
+        backoff_strategy: The strategy to use for calculating the backoff delay.
+        jitter_strategy: The strategy to use for adding jitter to the delay.
+        exponential_factor: The factor by which to multiply the base interval for each attempt when using
+            exponential backoff.
+
+    Returns:
+        The calculated retry interval in seconds, after applying backoff and jitter.
+
+    Raises:
+        ValueError: If attempt_number is negative or if exponential_factor is not greater than 0.
+
+    """
+
+    if attempt_number < 0:
+        raise ValueError("attempt_number shall be a non-negative integer")
 
     bounded_base = max(0.0, base_interval)
-    bounded_max = max(0.0, max_interval)
+
+    # The maximum interval should be at least as large as the base interval to ensure that the backoff strategy
+    # can function properly. If the max_interval is smaller than the base_interval, we will use the base_interval as
+    # the effective maximum to prevent invalid intervals.
+    bounded_max = max(bounded_base, max_interval)
 
     if backoff_strategy == BackoffStrategy.EXPONENTIAL:
         if exponential_factor <= 0.0:
             raise ValueError("exponential_factor must be > 0")
         interval = min(bounded_base * (exponential_factor**attempt_number), bounded_max)
     elif backoff_strategy == BackoffStrategy.LINEAR:
-        interval = min(bounded_base + attempt_number, bounded_max)
+        interval = min(bounded_base * (attempt_number + 1), bounded_max)
     else:
         interval = min(bounded_base, bounded_max)
 

--- a/libs/cgse-common/src/egse/backoff.py
+++ b/libs/cgse-common/src/egse/backoff.py
@@ -1,0 +1,56 @@
+"""Shared backoff and jitter strategies used for retry logic."""
+
+import random
+from enum import Enum
+
+
+class BackoffStrategy(Enum):
+    """Strategy for increasing delay between retry attempts."""
+
+    EXPONENTIAL = "exponential"
+    LINEAR = "linear"
+    FIXED = "fixed"
+
+
+class JitterStrategy(Enum):
+    """Strategy for adding randomization to retry delays."""
+
+    NONE = "none"
+    FULL = "full"
+    EQUAL = "equal"
+    PERCENT_10 = "10%"
+
+
+def calculate_retry_interval(
+    attempt_number: int,
+    base_interval: float,
+    max_interval: float,
+    backoff_strategy: BackoffStrategy = BackoffStrategy.EXPONENTIAL,
+    jitter_strategy: JitterStrategy = JitterStrategy.EQUAL,
+    exponential_factor: float = 2.0,
+) -> float:
+    """Calculate the next retry interval using backoff and optional jitter."""
+
+    bounded_base = max(0.0, base_interval)
+    bounded_max = max(0.0, max_interval)
+
+    if backoff_strategy == BackoffStrategy.EXPONENTIAL:
+        if exponential_factor <= 0.0:
+            raise ValueError("exponential_factor must be > 0")
+        interval = min(bounded_base * (exponential_factor**attempt_number), bounded_max)
+    elif backoff_strategy == BackoffStrategy.LINEAR:
+        interval = min(bounded_base + attempt_number, bounded_max)
+    else:
+        interval = min(bounded_base, bounded_max)
+
+    if jitter_strategy == JitterStrategy.NONE:
+        return interval
+    if jitter_strategy == JitterStrategy.FULL:
+        return random.uniform(0.0, interval)
+    if jitter_strategy == JitterStrategy.EQUAL:
+        return interval / 2 + random.uniform(0.0, interval / 2)
+    if jitter_strategy == JitterStrategy.PERCENT_10:
+        jitter_amount = interval * 0.1
+        return interval + random.uniform(-jitter_amount, jitter_amount)
+
+    return interval

--- a/libs/cgse-common/src/egse/socketdevice.py
+++ b/libs/cgse-common/src/egse/socketdevice.py
@@ -6,8 +6,13 @@ import asyncio
 import select
 import socket
 import time
+from collections.abc import Callable
 from typing import Optional
+from typing import TypeVar
 
+from egse.backoff import BackoffStrategy
+from egse.backoff import JitterStrategy
+from egse.backoff import calculate_retry_interval
 from egse.device import AsyncDeviceInterface
 from egse.device import AsyncDeviceTransport
 from egse.device import DeviceConnectionError
@@ -22,6 +27,8 @@ VERBOSE_DEBUG = bool_env("VERBOSE_DEBUG", default=False)
 
 SEPARATOR = b"\x03"
 SEPARATOR_STR = SEPARATOR.decode()
+
+_T = TypeVar("_T")
 
 
 class SocketDevice(DeviceConnectionInterface, DeviceTransport):
@@ -118,9 +125,11 @@ class SocketDevice(DeviceConnectionInterface, DeviceTransport):
             if self.is_connection_open:
                 logger.debug(f"Disconnecting from {self.hostname}")
                 self.socket.close()
-                self.is_connection_open = False
         except Exception as e_exc:
             raise ConnectionError(f"{self.device_name}: Could not close socket to {self.hostname}") from e_exc
+        finally:
+            self.socket = None
+            self.is_connection_open = False
 
     def is_connected(self) -> bool:
         """
@@ -141,6 +150,106 @@ class SocketDevice(DeviceConnectionInterface, DeviceTransport):
         if self.is_connection_open:
             self.disconnect()
         self.connect()
+
+    def _reset_socket_state(self):
+        """Best-effort socket reset to recover from broken or half-open connections."""
+
+        if self.socket is not None:
+            try:
+                self.socket.close()
+            except Exception:
+                pass
+
+        self.socket = None
+        self.is_connection_open = False
+
+    def connect_with_retry(
+        self,
+        attempts: int = 5,
+        initial_delay: float = 0.5,
+        backoff_factor: float = 2.0,
+        max_delay: float = 5.0,
+        backoff_strategy: BackoffStrategy | None = None,
+        jitter_strategy: JitterStrategy = JitterStrategy.NONE,
+    ):
+        """
+        Try connecting multiple times with exponential backoff.
+
+        This is useful for devices that temporarily refuse connections while restarting
+        their command server.
+        """
+
+        if attempts < 1:
+            raise ValueError("attempts must be >= 1")
+
+        base_interval = max(0.0, initial_delay)
+        last_exc: Exception | None = None
+
+        for attempt in range(1, attempts + 1):
+            self._reset_socket_state()
+            try:
+                self.connect()
+                if attempt > 1:
+                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt}/{attempts}")
+                return
+            except (ConnectionError, TimeoutError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt == attempts:
+                    break
+
+                strategy = backoff_strategy or (
+                    BackoffStrategy.FIXED if backoff_factor == 1.0 else BackoffStrategy.EXPONENTIAL
+                )
+                delay = calculate_retry_interval(
+                    attempt_number=attempt - 1,
+                    base_interval=base_interval,
+                    max_interval=max_delay,
+                    backoff_strategy=strategy,
+                    jitter_strategy=jitter_strategy,
+                    exponential_factor=backoff_factor,
+                )
+
+                logger.warning(
+                    f"{self.device_name}: connect attempt {attempt}/{attempts} failed "
+                    f"({type_name(exc)}: {exc}), retrying in {delay:.2f}s"
+                )
+                time.sleep(delay)
+
+        raise DeviceConnectionError(
+            self.device_name,
+            f"Failed to connect after {attempts} attempts to {self.hostname}:{self.port}",
+        ) from last_exc
+
+    def execute_with_reconnect(
+        self,
+        operation_name: str,
+        func: Callable[[], _T],
+        reconnect_attempts: int = 5,
+        reconnect_initial_delay: float = 0.5,
+        reconnect_backoff: float = 2.0,
+        reconnect_max_delay: float = 5.0,
+        reconnect_jitter: JitterStrategy = JitterStrategy.NONE,
+    ) -> _T:
+        """
+        Execute a socket operation once, reconnecting and retrying once when a recoverable I/O
+        failure is detected.
+        """
+
+        try:
+            return func()
+        except (BrokenPipeError, ConnectionResetError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
+            logger.warning(
+                f"{self.device_name}: {operation_name} failed ({type_name(exc)}: {exc}), attempting reconnect"
+            )
+            self._reset_socket_state()
+            self.connect_with_retry(
+                attempts=reconnect_attempts,
+                initial_delay=reconnect_initial_delay,
+                backoff_factor=reconnect_backoff,
+                max_delay=reconnect_max_delay,
+                jitter_strategy=reconnect_jitter,
+            )
+            return func()
 
     def read(self) -> bytes:
         """
@@ -336,7 +445,7 @@ class AsyncSocketDevice(AsyncDeviceInterface, AsyncDeviceTransport):
             await self._cleanup()
             logger.debug(f"{self.device_name}: disconnected ({peer=})")
 
-    def is_connected(self) -> bool:
+    async def is_connected(self) -> bool:
         return bool(self.is_connection_open and self.writer and not self.writer.is_closing())
 
     async def _cleanup(self) -> None:

--- a/libs/cgse-common/src/egse/socketdevice.py
+++ b/libs/cgse-common/src/egse/socketdevice.py
@@ -6,6 +6,7 @@ import asyncio
 import select
 import socket
 import time
+from collections.abc import Awaitable
 from collections.abc import Callable
 from typing import Optional
 from typing import TypeVar
@@ -428,6 +429,11 @@ class AsyncSocketDevice(AsyncDeviceInterface, AsyncDeviceTransport):
             logger.warning(f"{self.device_name}: connect failed: {type_name(exc)} – {exc}")
             raise DeviceConnectionError(self.device_name, f"Failed to connect to {self.hostname}:{self.port}") from exc
 
+    async def reconnect(self) -> None:
+        if await self.is_connected():
+            await self.disconnect()
+        await self.connect()
+
     async def disconnect(self) -> None:
         logger.debug(f"{self.device_name}: disconnect() called; writer_exists={bool(self.writer)}")
         peer = None
@@ -452,6 +458,99 @@ class AsyncSocketDevice(AsyncDeviceInterface, AsyncDeviceTransport):
         self.reader = None
         self.writer = None
         self.is_connection_open = False
+
+    async def _reset_socket_state(self) -> None:
+        """Best-effort stream reset to recover from broken or half-open async connections."""
+
+        try:
+            if self.writer and not self.writer.is_closing():
+                self.writer.close()
+                try:
+                    await asyncio.wait_for(self.writer.wait_closed(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    logger.debug(f"{self.device_name}: wait_closed() timed out during reset")
+        finally:
+            await self._cleanup()
+
+    async def connect_with_retry(
+        self,
+        attempts: int = 5,
+        initial_delay: float = 0.5,
+        backoff_factor: float = 2.0,
+        max_delay: float = 5.0,
+        backoff_strategy: BackoffStrategy | None = None,
+        jitter_strategy: JitterStrategy = JitterStrategy.NONE,
+    ) -> None:
+        """Try connecting multiple times with async backoff and optional jitter."""
+
+        if attempts < 1:
+            raise ValueError("attempts must be >= 1")
+
+        base_interval = max(0.0, initial_delay)
+        last_exc: Exception | None = None
+
+        for attempt in range(1, attempts + 1):
+            await self._reset_socket_state()
+            try:
+                await self.connect()
+                if attempt > 1:
+                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt}/{attempts}")
+                return
+            except (ConnectionError, TimeoutError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
+                last_exc = exc
+                if attempt == attempts:
+                    break
+
+                strategy = backoff_strategy or (
+                    BackoffStrategy.FIXED if backoff_factor == 1.0 else BackoffStrategy.EXPONENTIAL
+                )
+                delay = calculate_retry_interval(
+                    attempt_number=attempt - 1,
+                    base_interval=base_interval,
+                    max_interval=max_delay,
+                    backoff_strategy=strategy,
+                    jitter_strategy=jitter_strategy,
+                    exponential_factor=backoff_factor,
+                )
+
+                logger.warning(
+                    f"{self.device_name}: connect attempt {attempt}/{attempts} failed "
+                    f"({type_name(exc)}: {exc}), retrying in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+
+        raise DeviceConnectionError(
+            self.device_name,
+            f"Failed to connect after {attempts} attempts to {self.hostname}:{self.port}",
+        ) from last_exc
+
+    async def execute_with_reconnect(
+        self,
+        operation_name: str,
+        func: Callable[[], Awaitable[_T]],
+        reconnect_attempts: int = 5,
+        reconnect_initial_delay: float = 0.5,
+        reconnect_backoff: float = 2.0,
+        reconnect_max_delay: float = 5.0,
+        reconnect_jitter: JitterStrategy = JitterStrategy.NONE,
+    ) -> _T:
+        """Execute an async operation once, reconnecting and retrying once on recoverable I/O failures."""
+
+        try:
+            return await func()
+        except (BrokenPipeError, ConnectionResetError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
+            logger.warning(
+                f"{self.device_name}: {operation_name} failed ({type_name(exc)}: {exc}), attempting reconnect"
+            )
+            await self._reset_socket_state()
+            await self.connect_with_retry(
+                attempts=reconnect_attempts,
+                initial_delay=reconnect_initial_delay,
+                backoff_factor=reconnect_backoff,
+                max_delay=reconnect_max_delay,
+                jitter_strategy=reconnect_jitter,
+            )
+            return await func()
 
     async def read(self) -> bytes:
         if not self.reader:

--- a/libs/cgse-common/src/egse/socketdevice.py
+++ b/libs/cgse-common/src/egse/socketdevice.py
@@ -186,23 +186,23 @@ class SocketDevice(DeviceConnectionInterface, DeviceTransport):
         base_interval = max(0.0, initial_delay)
         last_exc: Exception | None = None
 
-        for attempt in range(1, attempts + 1):
+        for attempt in range(attempts):
             self._reset_socket_state()
             try:
                 self.connect()
-                if attempt > 1:
-                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt}/{attempts}")
+                if attempt > 0:
+                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt + 1}/{attempts}")
                 return
             except (ConnectionError, TimeoutError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
                 last_exc = exc
-                if attempt == attempts:
+                if attempt == attempts - 1:
                     break
 
                 strategy = backoff_strategy or (
                     BackoffStrategy.FIXED if backoff_factor == 1.0 else BackoffStrategy.EXPONENTIAL
                 )
                 delay = calculate_retry_interval(
-                    attempt_number=attempt - 1,
+                    attempt_number=attempt,
                     base_interval=base_interval,
                     max_interval=max_delay,
                     backoff_strategy=strategy,
@@ -211,7 +211,7 @@ class SocketDevice(DeviceConnectionInterface, DeviceTransport):
                 )
 
                 logger.warning(
-                    f"{self.device_name}: connect attempt {attempt}/{attempts} failed "
+                    f"{self.device_name}: connect attempt {attempt + 1}/{attempts} failed "
                     f"({type_name(exc)}: {exc}), retrying in {delay:.2f}s"
                 )
                 time.sleep(delay)
@@ -489,23 +489,23 @@ class AsyncSocketDevice(AsyncDeviceInterface, AsyncDeviceTransport):
         base_interval = max(0.0, initial_delay)
         last_exc: Exception | None = None
 
-        for attempt in range(1, attempts + 1):
+        for attempt in range(attempts):
             await self._reset_socket_state()
             try:
                 await self.connect()
-                if attempt > 1:
-                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt}/{attempts}")
+                if attempt > 0:
+                    logger.info(f"{self.device_name}: reconnect succeeded on attempt {attempt + 1}/{attempts}")
                 return
             except (ConnectionError, TimeoutError, DeviceConnectionError, DeviceTimeoutError, OSError) as exc:
                 last_exc = exc
-                if attempt == attempts:
+                if attempt == attempts - 1:
                     break
 
                 strategy = backoff_strategy or (
                     BackoffStrategy.FIXED if backoff_factor == 1.0 else BackoffStrategy.EXPONENTIAL
                 )
                 delay = calculate_retry_interval(
-                    attempt_number=attempt - 1,
+                    attempt_number=attempt,
                     base_interval=base_interval,
                     max_interval=max_delay,
                     backoff_strategy=strategy,
@@ -514,7 +514,7 @@ class AsyncSocketDevice(AsyncDeviceInterface, AsyncDeviceTransport):
                 )
 
                 logger.warning(
-                    f"{self.device_name}: connect attempt {attempt}/{attempts} failed "
+                    f"{self.device_name}: connect attempt {attempt + 1}/{attempts} failed "
                     f"({type_name(exc)}: {exc}), retrying in {delay:.2f}s"
                 )
                 await asyncio.sleep(delay)

--- a/libs/cgse-common/tests/test_backoff.py
+++ b/libs/cgse-common/tests/test_backoff.py
@@ -1,0 +1,106 @@
+import pytest
+
+from egse.backoff import BackoffStrategy
+from egse.backoff import JitterStrategy
+from egse.backoff import calculate_retry_interval
+
+
+def test_calculate_retry_interval_exponential_without_jitter():
+    interval = calculate_retry_interval(
+        attempt_number=3,
+        base_interval=0.5,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.EXPONENTIAL,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    assert interval == 4.0
+
+
+def test_calculate_retry_interval_exponential_with_custom_factor():
+    interval = calculate_retry_interval(
+        attempt_number=3,
+        base_interval=0.5,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.EXPONENTIAL,
+        jitter_strategy=JitterStrategy.NONE,
+        exponential_factor=1.5,
+    )
+
+    assert interval == pytest.approx(1.6875)
+
+
+def test_calculate_retry_interval_linear_without_jitter():
+    interval = calculate_retry_interval(
+        attempt_number=3,
+        base_interval=0.5,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.LINEAR,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    assert interval == 3.5
+
+
+def test_calculate_retry_interval_fixed_without_jitter():
+    interval = calculate_retry_interval(
+        attempt_number=9,
+        base_interval=0.5,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.FIXED,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    assert interval == 0.5
+
+
+def test_calculate_retry_interval_caps_at_max_interval():
+    interval = calculate_retry_interval(
+        attempt_number=8,
+        base_interval=1.0,
+        max_interval=5.0,
+        backoff_strategy=BackoffStrategy.EXPONENTIAL,
+        jitter_strategy=JitterStrategy.NONE,
+    )
+
+    assert interval == 5.0
+
+
+def test_calculate_retry_interval_equal_jitter_uses_upper_half(monkeypatch):
+    monkeypatch.setattr("egse.backoff.random.uniform", lambda low, high: high)
+
+    interval = calculate_retry_interval(
+        attempt_number=2,
+        base_interval=1.0,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.EXPONENTIAL,
+        jitter_strategy=JitterStrategy.EQUAL,
+    )
+
+    assert interval == 4.0
+
+
+def test_calculate_retry_interval_percent10_jitter_boundaries(monkeypatch):
+    monkeypatch.setattr("egse.backoff.random.uniform", lambda low, high: low)
+
+    interval = calculate_retry_interval(
+        attempt_number=2,
+        base_interval=1.0,
+        max_interval=10.0,
+        backoff_strategy=BackoffStrategy.EXPONENTIAL,
+        jitter_strategy=JitterStrategy.PERCENT_10,
+    )
+
+    assert interval == pytest.approx(3.6)
+
+
+def test_calculate_retry_interval_rejects_non_positive_exponential_factor():
+    with pytest.raises(ValueError, match="exponential_factor"):
+        calculate_retry_interval(
+            attempt_number=1,
+            base_interval=1.0,
+            max_interval=5.0,
+            backoff_strategy=BackoffStrategy.EXPONENTIAL,
+            jitter_strategy=JitterStrategy.NONE,
+            exponential_factor=0.0,
+        )

--- a/libs/cgse-common/tests/test_backoff.py
+++ b/libs/cgse-common/tests/test_backoff.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import pytest
 
 from egse.backoff import BackoffStrategy
@@ -5,16 +7,31 @@ from egse.backoff import JitterStrategy
 from egse.backoff import calculate_retry_interval
 
 
-def test_calculate_retry_interval_exponential_without_jitter():
-    interval = calculate_retry_interval(
-        attempt_number=3,
-        base_interval=0.5,
-        max_interval=10.0,
-        backoff_strategy=BackoffStrategy.EXPONENTIAL,
-        jitter_strategy=JitterStrategy.NONE,
-    )
+@pytest.mark.parametrize(
+    "attempt_number,base_interval,max_interval,expected",
+    [
+        (-1, 0, 0, pytest.raises(ValueError, match="attempt_number shall be a non-negative integer")),
+        (0, 1.0, 10.0, nullcontext(1.0)),
+        (1, 1.0, 10.0, nullcontext(2.0)),
+        (2, 1.0, 10.0, nullcontext(4.0)),
+        (3, 1.0, 10.0, nullcontext(8.0)),
+        (4, 1.0, 10.0, nullcontext(10.0)),
+        (10, 1.0, 10.0, nullcontext(10.0)),
+        (11, 1.0, 10.0, nullcontext(10.0)),
+    ],
+)
+def test_calculate_retry_interval_exponential_without_jitter(attempt_number, base_interval, max_interval, expected):
 
-    assert interval == 4.0
+    with expected as expected_interval:
+        interval = calculate_retry_interval(
+            attempt_number=attempt_number,
+            base_interval=base_interval,
+            max_interval=max_interval,
+            backoff_strategy=BackoffStrategy.EXPONENTIAL,
+            jitter_strategy=JitterStrategy.NONE,
+        )
+
+        assert interval == expected_interval
 
 
 def test_calculate_retry_interval_exponential_with_custom_factor():
@@ -30,16 +47,29 @@ def test_calculate_retry_interval_exponential_with_custom_factor():
     assert interval == pytest.approx(1.6875)
 
 
-def test_calculate_retry_interval_linear_without_jitter():
-    interval = calculate_retry_interval(
-        attempt_number=3,
-        base_interval=0.5,
-        max_interval=10.0,
-        backoff_strategy=BackoffStrategy.LINEAR,
-        jitter_strategy=JitterStrategy.NONE,
-    )
+@pytest.mark.parametrize(
+    "attempt_number,base_interval,max_interval,expected",
+    [
+        (-1, 0, 0, pytest.raises(ValueError, match="attempt_number shall be a non-negative integer")),
+        (0, 1.0, 10.0, nullcontext(1.0)),
+        (1, 1.0, 10.0, nullcontext(2.0)),
+        (2, 1.0, 10.0, nullcontext(3.0)),
+        (10, 1.0, 10.0, nullcontext(10.0)),
+        (11, 1.0, 10.0, nullcontext(10.0)),
+    ],
+)
+def test_calculate_retry_interval_linear_without_jitter(attempt_number, base_interval, max_interval, expected):
 
-    assert interval == 3.5
+    with expected as expected_interval:
+        interval = calculate_retry_interval(
+            attempt_number=attempt_number,
+            base_interval=base_interval,
+            max_interval=max_interval,
+            backoff_strategy=BackoffStrategy.LINEAR,
+            jitter_strategy=JitterStrategy.NONE,
+        )
+        print(f"Calculated interval: {interval}, Expected interval: {expected_interval}")
+        assert interval == expected_interval
 
 
 def test_calculate_retry_interval_fixed_without_jitter():

--- a/libs/cgse-common/tests/test_socketdevice.py
+++ b/libs/cgse-common/tests/test_socketdevice.py
@@ -244,7 +244,7 @@ async def test_async_connect_write_trans_and_disconnect(async_echo_server):
     dev = AsyncSocketDevice(hostname=host, port=port, connect_timeout=1.0, read_timeout=1.0)
 
     await dev.connect()
-    assert dev.is_connected() is True
+    assert await dev.is_connected() is True
 
     # trans should return bytes that end with ETX and contain the echoed payload
     got = await dev.trans("CMD-ASYNC")
@@ -265,7 +265,7 @@ async def test_async_connect_write_trans_and_disconnect(async_echo_server):
 
     # disconnect
     await dev.disconnect()
-    assert dev.is_connected() is False
+    assert await dev.is_connected() is False
 
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_async_cleanup_on_broken_connection(async_echo_server):
 
     # connect and then shut down server to simulate connection drop
     await dev.connect()
-    assert dev.is_connected() is True
+    assert await dev.is_connected() is True
 
     logger.info("Before server close")
 
@@ -326,4 +326,4 @@ async def test_async_cleanup_on_broken_connection(async_echo_server):
     with pytest.raises(DeviceConnectionError):
         await dev.write("X")
 
-    assert dev.is_connected() is False
+    assert await dev.is_connected() is False

--- a/libs/cgse-common/tests/test_socketdevice.py
+++ b/libs/cgse-common/tests/test_socketdevice.py
@@ -208,7 +208,8 @@ def test_sync_connect_failures():
 
     # dev = SocketDevice(hostname="10.255.255.1", port=25)
     # dev = SocketDevice(hostname="10.255.255.0", port=20)
-    dev = SocketDevice(hostname="10.0.0.0", port=1)
+    # dev = SocketDevice(hostname="10.0.0.0", port=1)
+    dev = SocketDevice(hostname="192.0.0.0", port=1)
     with pytest.raises(TimeoutError):
         dev.connect()
 

--- a/libs/cgse-common/tests/test_socketdevice.py
+++ b/libs/cgse-common/tests/test_socketdevice.py
@@ -327,3 +327,60 @@ async def test_async_cleanup_on_broken_connection(async_echo_server):
         await dev.write("X")
 
     assert await dev.is_connected() is False
+
+
+@pytest.mark.asyncio
+async def test_async_connect_with_retry_succeeds_after_transient_failures(async_echo_server):
+    host, port, _server, _active_writers = async_echo_server
+    dev = AsyncSocketDevice(hostname=host, port=port, connect_timeout=1.0, read_timeout=1.0)
+
+    original_connect = dev.connect
+    attempts = 0
+
+    async def flaky_connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise DeviceConnectionError(dev.device_name, "simulated transient connect failure")
+        await original_connect()
+
+    dev.connect = flaky_connect  # type: ignore[method-assign]
+
+    await dev.connect_with_retry(attempts=5, initial_delay=0.01, backoff_factor=1.0, max_delay=0.01)
+
+    assert attempts == 3
+    assert await dev.is_connected() is True
+
+    await dev.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_async_execute_with_reconnect_retries_once(async_echo_server):
+    host, port, _server, _active_writers = async_echo_server
+    dev = AsyncSocketDevice(hostname=host, port=port, connect_timeout=1.0, read_timeout=1.0)
+
+    await dev.connect()
+    assert await dev.is_connected() is True
+
+    calls = 0
+
+    async def op() -> bytes:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise BrokenPipeError("simulated broken pipe")
+        return await dev.trans("AFTER-RECONNECT")
+
+    response = await dev.execute_with_reconnect(
+        operation_name="test-op",
+        func=op,
+        reconnect_attempts=3,
+        reconnect_initial_delay=0.01,
+        reconnect_backoff=1.0,
+        reconnect_max_delay=0.01,
+    )
+
+    assert calls == 2
+    assert b"RESP:AFTER-RECONNECT" in response
+
+    await dev.disconnect()

--- a/libs/cgse-core/src/egse/connect.py
+++ b/libs/cgse-core/src/egse/connect.py
@@ -1,9 +1,11 @@
-import random
 import threading
 import time
 from enum import Enum
 from typing import Any
 
+from egse.backoff import BackoffStrategy
+from egse.backoff import JitterStrategy
+from egse.backoff import calculate_retry_interval
 from egse.env import bool_env
 from egse.log import logging
 from egse.system import type_name
@@ -67,113 +69,6 @@ class ConnectionState(Enum):
     CONNECTING = "connecting"
     CONNECTED = "connected"
     CIRCUIT_OPEN = "circuit_open"  # Temporarily stopped trying
-
-
-class BackoffStrategy(Enum):
-    """
-    Specifies the strategy for increasing the delay between retry attempts
-    in backoff algorithms to reduce load and avoid overwhelming services.
-
-    Strategies:
-        EXPONENTIAL:
-            The delay doubles with each retry attempt (e.g., 1s, 2s, 4s, 8s).
-            This is the most widely used approach because it quickly reduces load on struggling systems.
-        LINEAR:
-            The delay increases by a fixed amount each time (e.g., 1s, 2s, 3s, 4s).
-            This provides a more gradual reduction in request rate.
-        FIXED:
-            Uses the same delay between all retry attempts.
-            Simple but less adaptive to system conditions.
-
-    References:
-        - AWS Architecture Blog: Exponential Backoff And Jitter
-    """
-
-    EXPONENTIAL = "exponential"
-    """The delay doubles with each retry attempt (e.g., 1s, 2s, 4s, 8s). 
-    This is the most widely used approach because it quickly reduces load on struggling systems."""
-    LINEAR = "linear"
-    """The delay increases by a fixed amount each time (e.g., 1s, 2s, 3s, 4s). 
-    This provides a more gradual reduction in request rate."""
-    FIXED = "fixed"
-    """Uses the same delay between all retry attempts. Simple but less adaptive to system conditions."""
-
-
-class JitterStrategy(Enum):
-    """
-    Specifies the strategy for applying jitter (randomization) to retry intervals
-    in backoff algorithms to avoid synchronized retries and reduce load spikes.
-
-    Strategies:
-        NONE:
-            No jitter is applied. The retry interval is deterministic.
-        FULL:
-            Applies full jitter by selecting a random value uniformly between 0 and the calculated interval.
-            This maximizes randomness but can result in very short delays.
-        EQUAL:
-            Applies "equal jitter" as described in the AWS Architecture Blog.
-            The interval is randomized within [interval/2, interval], ensuring a minimum delay of half the interval.
-            Note: This is not the same as "a jitter of 50% around interval" (which would be [0.5 * interval, 1.5 * interval]).
-        PERCENT_10:
-            Applies a jitter of ±10% around the base interval, resulting in a random interval within [0.9 * interval, 1.1 * interval].
-
-    References:
-        - AWS Architecture Blog: Exponential Backoff And Jitter
-    """
-
-    NONE = "none"
-    """No jitter is applied to the backoff."""
-    FULL = "full"
-    """Maximum distribution but can be too random with very short intervals."""
-    EQUAL = "equal"
-    """Best balance, maintains backoff properties while preventing synchronization."""
-    PERCENT_10 = "10%"
-    """Add a jitter of 10% around the base interval."""
-
-
-def calculate_retry_interval(
-    attempt_number,
-    base_interval,
-    max_interval,
-    backoff_strategy: BackoffStrategy = BackoffStrategy.EXPONENTIAL,
-    jitter_strategy: JitterStrategy = JitterStrategy.EQUAL,
-):
-    """
-    Calculates the next retry interval based on the given backoff and jitter strategies.
-
-    Args:
-        attempt_number (int): The current retry attempt (starting from 0).
-        base_interval (float): The initial interval in seconds.
-        max_interval (float): The maximum allowed interval in seconds.
-        backoff_strategy (BackoffStrategy): Strategy for increasing the delay (exponential, linear, or fixed).
-        jitter_strategy (JitterStrategy): Strategy for randomizing the delay to avoid synchronization.
-
-    Returns:
-        float: The computed retry interval in seconds.
-
-    Notes:
-        - See the docstrings for BackoffStrategy and JitterStrategy for details on each strategy.
-        - Based on best practices from the AWS Architecture Blog: Exponential Backoff And Jitter.
-    """
-
-    if backoff_strategy == BackoffStrategy.EXPONENTIAL:
-        interval = min(base_interval * (2**attempt_number), max_interval)
-    elif backoff_strategy == BackoffStrategy.LINEAR:
-        interval = min(base_interval + attempt_number, max_interval)
-    else:
-        interval = base_interval
-
-    if jitter_strategy == JitterStrategy.NONE:
-        return interval
-    elif jitter_strategy == JitterStrategy.FULL:
-        return random.uniform(0, interval)
-    elif jitter_strategy == JitterStrategy.EQUAL:
-        return interval / 2 + random.uniform(0, interval / 2)
-    elif jitter_strategy == JitterStrategy.PERCENT_10:
-        jitter_amount = interval * 0.1
-        return interval + random.uniform(-jitter_amount, jitter_amount)
-
-    return interval
 
 
 class AsyncServiceConnector:
@@ -302,7 +197,7 @@ class AsyncServiceConnector:
             try:
                 # ensure the state is updated by disconnect hook (disconnect_from_service should set DISCONNECTED)
                 await self.disconnect_from_service()
-            except Exception as exc:
+            except Exception:
                 if VERBOSE_DEBUG:
                     logger.debug(f"Couldn't disconnect from {self.service_name}")
 


### PR DESCRIPTION
This pull request introduces socket reconnection with backoff strategy. This uses the same classes and functions that are available in the `egse.connect` module in the `cgse-core`. Since we do not want a dependency from `cgse-common` to `cgse-core`, we moved these functions into their own module `egse.backoff` in `cgse-common` and updated the classes and functions in `egse.connect` to use this common functionality.

Note that `SocketDevice` and `AsyncSocketDevice` can be used as base classes for any device interface implementation based on sockets.

