### PR TITLE
dt8874: Don't use fixed header parsing in digilent.py

### DIFF
--- a/projects/generic/digilent/src/egse/digilent/digilent.py
+++ b/projects/generic/digilent/src/egse/digilent/digilent.py
@@ -320,6 +320,17 @@ def to_date(response: str) -> datetime.datetime:
     return datetime.datetime.strptime(response, "%Y,%m,%d")
 
 
+def _extract_ieee_block_payload(response: bytes) -> bytes:
+    """Return the payload bytes of an IEEE 488.2 definite-length block."""
+    if response.startswith(b"#") and len(response) >= 2:
+        num_length_digits = int(chr(response[1]))
+        header_len = 2 + num_length_digits
+        payload_len = int(response[2:header_len].decode())
+        return response[header_len:header_len + payload_len]
+
+    return response.rstrip(b"\r\n")
+
+
 def parse_error(response: str) -> tuple[int, str]:
     """Converts the given response string of a tuple of an error code and the corresponding error message.
 
@@ -348,7 +359,7 @@ def parse_single_measurement(response: bytes) -> tuple[float, ...]:
     endian_char = ">"
     offset = 0
 
-    binary_data = response[3:-1]
+    binary_data = _extract_ieee_block_payload(response)
 
     values = []
 
@@ -375,11 +386,7 @@ def parse_scan_records(response: bytes) -> ScanRecords:
 
     # Skip the header
 
-    if response.startswith(b"#"):
-        header_end = 6
-        binary_data = response[header_end:-1]  # -1 to skip trailing newline
-    else:
-        binary_data = response
+    binary_data = _extract_ieee_block_payload(response)
 
     endian_char = ">"
     offset = 0

--- a/projects/generic/digilent/src/egse/digilent/digilent.py
+++ b/projects/generic/digilent/src/egse/digilent/digilent.py
@@ -326,7 +326,7 @@ def _extract_ieee_block_payload(response: bytes) -> bytes:
         num_length_digits = int(chr(response[1]))
         header_len = 2 + num_length_digits
         payload_len = int(response[2:header_len].decode())
-        return response[header_len:header_len + payload_len]
+        return response[header_len : header_len + payload_len]
 
     return response.rstrip(b"\r\n")
 

--- a/projects/generic/digilent/src/egse/digilent/measurpoint/digilent_devif.py
+++ b/projects/generic/digilent/src/egse/digilent/measurpoint/digilent_devif.py
@@ -255,18 +255,13 @@ class DigilentEthernetInterface(DeviceConnectionInterface, DeviceTransport):
             for idx in range(100):
                 time.sleep(0.001)  # Give the device time to fill the buffer
                 data = self._sock.recv(buf_size)
-                n = len(data)
-                if n == 0:
+                if not data or len(data) == 0:
                     break
 
                 chunks.extend(data)
 
-                # Text responses are line-terminated.
-                if chunks.endswith(b"\n"):
-                    break
-
-                # Binary measurement responses use an IEEE 488.2 definite-length
-                # block header: "#<ndigits><length><payload><LF>".
+                # Binary SCPI responses use an IEEE 488.2 definite-length block:
+                # "#<ndigits><length><payload><LF>".
                 if chunks.startswith(b"#") and len(chunks) >= 2:
                     try:
                         num_length_digits = int(chr(chunks[1]))
@@ -283,6 +278,11 @@ class DigilentEthernetInterface(DeviceConnectionInterface, DeviceTransport):
                                 break
                             if len(chunks) >= total_len + 2 and chunks[total_len : total_len + 2] == b"\r\n":
                                 break
+                            continue
+
+                # Plain-text responses are line-terminated.
+                if chunks.endswith(b"\n"):
+                    break
 
         except socket.timeout:
             logger.warning(f"Socket timeout error for {self.hostname}:{self.port}")


### PR DESCRIPTION
#347 didn't fully solve the temperature sensor readout. It resolved the fixed header readout from the packet, but the same change also needed to be implemented in `digilent.py`. Additionally, I moved the `if chunks.endswith(b"\n"):` in `digilent_devif.py` to after the first chunk reading code. If a partial binary block happened to end on a payload byte equal to newline, read() would stop too early and return an incomplete response.