### PR TITLE
Release/v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.22.0] - 2026-04-09
+
+- Enhance InfluxDB and DuckDB repository implementations with context management and improved line protocol handling
+- Improve Metrics Hub performance with configurable high-water marks and load testing script
+  - `CGSE_METRICS_BATCH_SIZE` , (setting: `BATCH_SIZE`) now defaults to 1_000
+  - `CGSE_METRICS_MAX_BATCH_SIZE` (setting: `MAX_BATCH_SIZE`) is new and defaults to 5_000
+  - `CGSE_METRICS_BATCH_DRAIN_LIMIT` (settings: `BATCH_DRAIN_LIMIT`) is new and defaults to 1_000
+  - `CGSE_METRICS_FLUSH_CONCURRENCY` (setting: `FLUSH_CONCURRENCY`) is new and defaults to 8
+  - `CGSE_METRICS_QUEUE_MAXSIZE` (setting: `QUEUE_MAXSIZE`) is now configurable and defaults to 10_000
+  - `CGSE_METRICS_COLLECTOR_RCVHWM` (setting: `COLLECTOR_RCVHWM`) is new and defaults to 10_000
+  - `CGSE_METRICS_COLLECTOR_YIELD_EVERY` (settings: `COLLECTOR_YIELD_EVERY`) is new and defaults to 250
+
+- The `(async)MetricsHubSender` now accepts a new argument `sndhwm` (Send High-Water-Mark) to increase the ZeroMQ send buffer [defaults to 500]
+
+
 ## [0.21.1] - 2026-04-03
 
 - It can happen that the configuration manager is not registered to the storage manager and could also not connect to the storage manager during startup. When that happens, you can now use the `cgse cm register-to-storage` command to register the CM and obsid to the storage manager without having to restart the core services.
@@ -366,7 +381,8 @@ This release is mainly on maintenance and improvements to the `cgse-common` pack
 - Renamed `cgse` subcommands `registry` →  `reg`, `notify` →  `not`.
 
 
-[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/IvS-KULeuven/cgse/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.20.5...v0.21.0
 [0.20.5]: https://github.com/IvS-KULeuven/cgse/compare/v0.20.4...v0.20.5

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.21.1"
+version = "0.22.0"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.21.1"
+version = "0.22.0"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.21.1"
+version = "0.22.0"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.21.1"
+version = "0.22.0"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.21.1"
+version = "0.22.0"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.21.1"
+version = "0.22.0"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.21.1"
+version = "0.22.0"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.21.1"
+version = "0.22.0"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.21.1"
+version = "0.22.0"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.21.1"
+version = "0.22.0"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.21.1"
+version = "0.22.0"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.21.1"
+version = "0.22.0"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.21.1"
+version = "0.22.0"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.21.1"
+version = "0.22.0"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.21.1"
+version = "0.22.0"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.21.1"
+version = "0.22.0"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.21.1"
+version = "0.22.0"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
- Enhance InfluxDB and DuckDB repository implementations with context management and improved line protocol handling
- Improve Metrics Hub performance with configurable high-water marks and load testing script
  - `CGSE_METRICS_BATCH_SIZE` , (setting: `BATCH_SIZE`) now defaults to 1_000
  - `CGSE_METRICS_MAX_BATCH_SIZE` (setting: `MAX_BATCH_SIZE`) is new and defaults to 5_000
  - `CGSE_METRICS_BATCH_DRAIN_LIMIT` (settings: `BATCH_DRAIN_LIMIT`) is new and defaults to 1_000
  - `CGSE_METRICS_FLUSH_CONCURRENCY` (setting: `FLUSH_CONCURRENCY`) is new and defaults to 8
  - `CGSE_METRICS_QUEUE_MAXSIZE` (setting: `QUEUE_MAXSIZE`) is now configurable and defaults to 10_000
  - `CGSE_METRICS_COLLECTOR_RCVHWM` (setting: `COLLECTOR_RCVHWM`) is new and defaults to 10_000
  - `CGSE_METRICS_COLLECTOR_YIELD_EVERY` (settings: `COLLECTOR_YIELD_EVERY`) is new and defaults to 250

- The `(async)MetricsHubSender` now accepts a new argument `sndhwm` (Send High-Water-Mark) to increase the ZeroMQ send buffer [defaults to 500]
