### PR TITLE
Fix obsid table unknown function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ venv
 # Packaging
 
 uv.lock
+libs/test_service_registry.db
+libs/cgse-core/metrics.duckdb
+install_influxdb3.sh
+.pylintrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+- The `obsid-table.txt` file now contains the function name and args + kwargs of the parent function. Previously, when `start_observation()` was used instead of `execute()`, the `obsid-table.txt` would contain `unknown_function()` which was rather confusing.
 - Enhance ServiceMessaging class with detailed documentation and examples; add tests for fake user, email, order, and analytics services. The ServiceMessaging class is a convenience wrapper for publishing and subscribing to events that can also be used as a context manager.
 
 ## [0.22.0] - 2026-04-09

--- a/libs/cgse-core/src/egse/confman/__init__.py
+++ b/libs/cgse-core/src/egse/confman/__init__.py
@@ -630,8 +630,15 @@ class ConfigurationManagerController(ConfigurationManagerInterface):
                 response,
             )
 
+        # Retrieve and remove the description from the function info, since `stringify_function_call` will
+        # use description and ignore the function name and arguments when description is present.
         description = function_info.pop("description", "")
+
         cmd = stringify_function_call(function_info).replace("\n", " ")
+
+        # In case no function metadata is available, we want to have a more meaningful command than `unknown_function()`
+        if cmd == "unknown_function()":
+            cmd = "start_observation()"
 
         if description:
             cmd += f" [{description}]"

--- a/libs/cgse-core/src/egse/observation.py
+++ b/libs/cgse-core/src/egse/observation.py
@@ -176,9 +176,53 @@ def execute(func: Callable, description=None, *args, **kwargs):
     return response
 
 
-def start_observation(description: str):
+def get_parent_function_call_info() -> tuple[str, list, dict]:
+    import inspect
+
+    parent_frame = inspect.currentframe().f_back.f_back
+    arg_info = inspect.getargvalues(parent_frame)
+    parent_func_name = parent_frame.f_code.co_name
+
+    if parent_func_name == "<module>":
+        return "<main>", [], {}
+
+    code = parent_frame.f_code
+    positional_param_count = code.co_posonlyargcount + code.co_argcount
+    kwonly_names = code.co_varnames[positional_param_count : positional_param_count + code.co_kwonlyargcount]
+
+    positional_arg_names = arg_info.args[:positional_param_count]
+    parent_args = [arg_info.locals[name] for name in positional_arg_names]
+    if arg_info.varargs:
+        parent_args.extend(arg_info.locals[arg_info.varargs])
+
+    parent_kwargs = {name: arg_info.locals[name] for name in kwonly_names}
+    if arg_info.keywords:
+        parent_kwargs.update(arg_info.locals[arg_info.keywords])
+
+    return parent_func_name, parent_args, parent_kwargs
+
+
+def start_observation(description: str, derive_parent_function_call: bool = True):
+
+    if derive_parent_function_call:
+        parent_func_name, parent_args, parent_kwargs = get_parent_function_call_info()
+    else:
+        parent_func_name = None
+        parent_args = []
+        parent_kwargs = {}
+
     try:
-        ObservationContext().start_observation({"description": description})
+        if parent_func_name is None:
+            ObservationContext().start_observation({"description": description})
+        else:
+            ObservationContext().start_observation(
+                {
+                    "description": description,
+                    "func_name": parent_func_name,
+                    "args": parent_args,
+                    "kwargs": parent_kwargs,
+                }
+            )
 
         obsid = request_obsid()
         logger.info(f"Observation started with obsid={obsid}, level={ObservationContext().get_level()}")

--- a/libs/cgse-core/tests/test_observation.py
+++ b/libs/cgse-core/tests/test_observation.py
@@ -4,6 +4,8 @@ from collections import deque
 from unittest.mock import patch
 
 import pytest
+from egse.response import Failure
+from egse.response import Success
 
 from egse.observation import ObservationContext
 from egse.observation import building_block
@@ -13,8 +15,6 @@ from egse.observation import request_obsid
 from egse.observation import start_observation
 from egse.observation import stringify_args
 from egse.observation import stringify_kwargs
-from egse.response import Failure
-from egse.response import Success
 
 
 @pytest.fixture
@@ -253,6 +253,24 @@ def test_execute_calls_end_observation_on_exception(mock_start, mock_end, mock_o
 @patch("egse.observation.ObservationContext.start_observation")
 def test_start_observation_wrapper_returns_obsid(mock_start, mock_obsid):
     assert start_observation("testing") == 999
+
+
+@patch("egse.observation.request_obsid", return_value=999)
+@patch("egse.observation.ObservationContext.start_observation")
+def test_start_observation_wrapper_passes_parent_call_values(mock_start, mock_obsid):
+    def caller(alpha, beta=2, *extra, gamma=3, **more):
+        return start_observation("testing")
+
+    assert caller(10, 20, 30, gamma=40, delta=50) == 999
+
+    mock_start.assert_called_once_with(
+        {
+            "description": "testing",
+            "func_name": "caller",
+            "args": [10, 20, 30],
+            "kwargs": {"gamma": 40, "delta": 50},
+        }
+    )
 
 
 @patch("egse.observation.logger.error")


### PR DESCRIPTION
The `obsid-table.txt ` now contains the function info of the parent instead of `unknown_function()`. The function name and arguments are automatically derived. When the observation is started from the REPL or from the top-level of a module, `<main>()` is printed to the `obsid-table.txt`.