### PR TITLE
Refactor hexapod connection handling and improve device ID usage

### DIFF
--- a/libs/cgse-core/src/egse/proxy.py
+++ b/libs/cgse-core/src/egse/proxy.py
@@ -94,13 +94,16 @@ class ControlServerConnectionInterface:
 
 
 class BaseProxy(ControlServerConnectionInterface):
-    def __init__(self, endpoint: str, timeout: float = REQUEST_TIMEOUT):
+    def __init__(self, endpoint: str, timeout: float = REQUEST_TIMEOUT, *, connect: bool = True):
         """
         The endpoint is a string that is constructed from the protocol, hostname
          and port number and has the format: `protocol://hostname:port`.
 
         The `timeout` argument specifies the number of fractional seconds to wait
         for a reply from the control server.
+
+        When `connect` is `False`, the proxy is constructed without establishing a connection.
+        Call `connect_cs()` explicitly when ready to connect.
         """
 
         self._logger = logger
@@ -111,9 +114,12 @@ class BaseProxy(ControlServerConnectionInterface):
         self._endpoint = endpoint
         self._timeout = timeout
 
-        self.connect_cs()
+        if connect:
+            self.connect_cs()
 
     def __enter__(self):
+        if self._socket is None:
+            self.connect_cs()
         if not self.ping():
             raise ConnectionError(f"Proxy is not connected to endpoint ({self._endpoint}) when entering the context.")
 
@@ -127,14 +133,22 @@ class BaseProxy(ControlServerConnectionInterface):
         if VERBOSE_DEBUG:
             self._logger.debug(f"Trying to connect {self.__class__.__name__} to {self._endpoint}")
 
+        if self._socket:
+            self._logger.warning(
+                f"{self.__class__.__name__} is already connected to {self._endpoint}, disconnecting first."
+            )
+            self.disconnect_cs()
+
         self._socket = self._ctx.socket(zmq.REQ)
         self._socket.connect(self._endpoint)
         self._poller.register(self._socket, zmq.POLLIN)
 
     def disconnect_cs(self):
-        self._socket.setsockopt(zmq.LINGER, 0)
-        self._socket.close()
-        self._poller.unregister(self._socket)
+        if self._socket:
+            self._socket.setsockopt(zmq.LINGER, 0)
+            self._socket.close()
+            self._poller.unregister(self._socket)
+            self._socket = None
 
     def reconnect_cs(self):
         if VERBOSE_DEBUG:
@@ -289,7 +303,7 @@ class Proxy(BaseProxy, ControlServerConnectionInterface):
     during initialization, a ConnectionError will be raised.
     """
 
-    def __init__(self, endpoint, timeout: float = REQUEST_TIMEOUT):
+    def __init__(self, endpoint, timeout: float = REQUEST_TIMEOUT, *, connect: bool = True):
         """
         During initialization, the Proxy will connect to the control server and send a
         handshaking `Ping` command. When that succeeds the Proxy will request and load the
@@ -298,22 +312,28 @@ class Proxy(BaseProxy, ControlServerConnectionInterface):
         can fix the problem with the control server and call `connect_cs()`, followed by a call to
         `load_commands()`.
 
-        The `timeout` argument specifies the number of seconds
+        The `timeout` argument specifies the number of seconds.
+
+        When `connect` is `False`, the proxy is constructed without establishing a connection.
+        Call `connect_cs()` explicitly when ready to connect.
         """
 
-        super().__init__(endpoint, timeout)
+        super().__init__(endpoint, timeout, connect=connect)
 
         self._commands = {}
 
-        if self.ping():
-            self.load_commands()
-        else:
-            self._logger.warning(
-                f"{self.__class__.__name__} could not connect to its control server at {endpoint}. "
-                f"No commands have been loaded."
-            )
+        if connect:
+            if self.ping():
+                self.load_commands()
+            else:
+                self._logger.warning(
+                    f"{self.__class__.__name__} could not connect to its control server at {endpoint}. "
+                    f"No commands have been loaded."
+                )
 
     def __enter__(self):
+        if self._socket is None:
+            self.connect_cs()
         if not self.ping():
             raise ConnectionError("Proxy is not connected when entering the context.")
 

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -10,7 +10,7 @@ maintainers = [
     {name = "Sara Regibo", email = "sara.regibo@kuleuven.be"}
 ]
 readme = {"file" = "README.md", "content-type" = "text/markdown"}
-requires-python = ">=3.10"
+requires-python = ">=3.10, <3.13"
 license = "MIT"
 keywords = [
     "CGSE",

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/__init__.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/__init__.py
@@ -24,17 +24,17 @@ hardware.
 
 For the PUNA:
     >>> from egse.hexapod.symetrie.puna import PunaProxy
-    >>> puna = PunaProxy()
+    >>> puna = PunaProxy("MY_PUNA_DEVICE_ID")
 
 For the ZONDA:
 
     >>> from egse.hexapod.symetrie.zonda import ZondaProxy
-    >>> zonda = ZondaProxy()
+    >>> zonda = ZondaProxy("MY_ZONDA_DEVICE_ID")
 
 For the JORAN:
 
     >>> from egse.hexapod.symetrie.joran import JoranProxy
-    >>> joran = JoranProxy()
+    >>> joran = JoranProxy("MY_JORAN_DEVICE_ID")
 
 These classes will connect to their control servers and provide all commands to
 control the hexapod and monitor its positions and status.
@@ -46,7 +46,6 @@ import logging
 from typing import NamedTuple
 
 from egse.device import DeviceFactoryInterface
-from egse.registry.client import RegistryClient
 from egse.settings import Settings
 from egse.settings import SettingsError
 
@@ -97,46 +96,35 @@ class ProxyFactory(DeviceFactoryInterface):
     """
     A factory class that will create the Proxy that matches the given device name and identifier.
 
-    The device name is matched against the string 'puna' or 'zonda'. If the device name doesn't contain
+    The device name is matched against the string 'puna', 'zonda', or 'joran'. If the device name doesn't contain
     one of these names, a ValueError will be raised.
     """
 
     def create(self, device_type: str, *, device_id: str = None, **_ignored):
         logger.debug(f"{device_type=}, {device_id=}")
 
-        with RegistryClient() as reg:
-            service = reg.discover_service(device_id)
-
-            if service:
-                protocol = service.get("protocol", "tcp")
-                hostname = service["host"]
-                port = service["port"]
-
-            else:
-                raise RuntimeError(f"No service registered as {device_id}")
-
         if "puna" in device_type.lower():
             controller_type = HEXAPOD_SETTINGS[device_id]["CONTROLLER_TYPE"]
             if controller_type.lower() == "alpha":
                 from egse.hexapod.symetrie.puna import PunaProxy
 
-                return PunaProxy(protocol, hostname, port)
+                return PunaProxy(device_id)
             elif controller_type == "alpha_plus":
                 from egse.hexapod.symetrie.punaplus import PunaPlusProxy
 
-                return PunaPlusProxy(protocol, hostname, port)
+                return PunaPlusProxy(device_id)
             else:
                 raise ValueError(f"Unknown controller_type ({controller_type}) for {device_type} – {device_id}")
 
         elif "zonda" in device_type.lower():
             from egse.hexapod.symetrie.zonda import ZondaProxy
 
-            return ZondaProxy(protocol, hostname, port)
+            return ZondaProxy(device_id)
 
         elif "joran" in device_type.lower():
             from egse.hexapod.symetrie.joran import JoranProxy
 
-            return JoranProxy(protocol, hostname, port)
+            return JoranProxy(device_id)
 
         else:
             raise ValueError(f"Unknown device type: {device_type}")

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran.py
@@ -8,20 +8,24 @@ import logging
 import math
 import time
 
-from egse.hexapod.symetrie.alpha import AlphaPlusControllerInterface
-from egse.hexapod.symetrie.dynalpha import AlphaPlusTelnetInterface, decode_validation_error
+from egse.device import DeviceInterface
 from egse.mixin import DynamicCommandMixin
 from egse.proxy import DynamicProxy
+from egse.registry.client import RegistryClient
 from egse.settings import Settings
-from egse.system import Timer
-from egse.system import wait_until
+from egse.system import Timer, wait_until
 from egse.zmq_ser import connect_address
+
+from egse.hexapod.symetrie.alpha import AlphaPlusControllerInterface
+from egse.hexapod.symetrie.dynalpha import AlphaPlusTelnetInterface, decode_validation_error
+from egse.hexapod.symetrie.hexapod import HexapodSimulator
 
 logger = logging.getLogger(__name__)
 
 JORAN_SETTINGS = Settings.load("Hexapod Controller")["JORAN"]
-CTRL_SETTINGS = Settings.load("Hexapod Control Server")["JORAN"]
 DEVICE_SETTINGS = Settings.load(filename="joran.yaml")
+
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s by default
 
 
 class JoranInterface(AlphaPlusControllerInterface):
@@ -86,7 +90,7 @@ class JoranController(JoranInterface, DynamicCommandMixin):
         raise NotImplementedError
 
 
-class JoranSimulator(JoranInterface):
+class JoranSimulator(HexapodSimulator, DeviceInterface):
     """
     HexapodSimulator simulates the Symétrie Hexapod JORAN. The class is heavily based on the
     ReferenceFrames in the `egse.coordinates` package.
@@ -100,80 +104,50 @@ class JoranSimulator(JoranInterface):
     This class simulates all the movements and status of the Hexapod.
     """
 
-    def __init__(self):
+    def __init__(self, device_id: str):
         super().__init__()
+        self._device_id = device_id
 
-        # Keep a record if the homing() command has been executed.
-
-        self.homing_done = False
-        self.control_loop = False
-        self._virtual_homing = False
-        self._virtual_homing_position = None
-
-    def is_simulator(self):
-        return True
-
-    def connect(self):
-        pass
-
-    def reconnect(self):
-        pass
-
-    def disconnect(self):
-        # TODO:
-        #   Should I keep state in this class to check if it has been disconnected?
-        #
-        # TODO:
-        #   What happens when I re-connect to this Simulator? Shall it be in Homing position or
-        #   do I have to keep state via a persistence mechanism?
-        pass
-
-    def is_connected(self):
-        return True
-
-    def clear_error(self):
-        return 0
-
-    def homing(self):
-        self.goto_zero_position()
-        self.homing_done = True
-        self._virtual_homing = False
-        self._virtual_homing_position = None
-        return 0
-
-    def is_homing_done(self):
-        return self.homing_done
-
-    def activate_control_loop(self):
-        self.control_loop = True
-        return self.control_loop
-
-    def deactivate_control_loop(self):
-        self.control_loop = False
-        return self.control_loop
-
-    pass
+    @property
+    def device_id(self):
+        return self._device_id
 
 
 class JoranProxy(DynamicProxy, JoranInterface):
     """The JoranProxy class is used to connect to the control server and send commands to the
-    Hexapod JORAN remotely."""
+    Hexapod JORAN remotely.
 
-    def __init__(
-        self,
-        protocol=CTRL_SETTINGS["PROTOCOL"],
-        hostname=CTRL_SETTINGS["HOSTNAME"],
-        port=CTRL_SETTINGS["COMMANDING_PORT"],
-    ):
-        """
-        Args:
-            protocol: the transport protocol [default is taken from settings file]
-            hostname: location of the control server (IP address) [default is taken from settings
-            file]
-            port: TCP port on which the control server is listening for commands [default is
-            taken from settings file]
-        """
-        super().__init__(connect_address(protocol, hostname, port))
+    The control server is discovered from the service registry using ``device_id`` as the
+    service type key, which is the same identifier used when the control server was started.
+
+    Args:
+        device_id: identifier of the hexapod control server as registered in the service registry
+        timeout: how long to wait for a response from the control server before giving up
+    """
+
+    def __init__(self, device_id: str, *, timeout: float = PROXY_TIMEOUT):
+        self._device_id = device_id
+        super().__init__("", timeout=timeout, connect=False)
+
+    @property
+    def device_id(self):
+        return self._device_id
+
+    def connect_cs(self):
+        with RegistryClient() as reg:
+            service = reg.discover_service(self._device_id)
+
+        if not service:
+            raise ConnectionError(f"No control server registered as '{self._device_id}'.")
+
+        protocol = service.get("protocol", "tcp")
+        hostname = service["host"]
+        port = service["port"]
+
+        self._endpoint = connect_address(protocol, hostname, port)
+        logger.info(f"JoranProxy connecting to {self._device_id!r} at {self._endpoint}")
+
+        super().connect_cs()
 
 
 if __name__ == "__main__":

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna.py
@@ -24,8 +24,10 @@ from egse.settings import Settings
 from egse.zmq_ser import connect_address
 
 DEVICE_SETTINGS = Settings.load(filename="puna.yaml")
+CTRL_SETTINGS = Settings.load("Hexapod Control Server")
 
 NUM_OF_DECIMALS = 6  # used for rounding numbers before sending to PMAC
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s by default
 
 
 class PunaInterface(AlphaControllerInterface, DeviceInterface):
@@ -613,37 +615,48 @@ class PunaSimulator(HexapodSimulator, DeviceInterface):
     This class simulates all the movements and status of the Hexapod.
     """
 
-    def __init__(self):
+    def __init__(self, device_id: str):
         super().__init__()
+        self._device_id = device_id
+
+    @property
+    def device_id(self):
+        return self._device_id
 
 
 class PunaProxy(Proxy, PunaInterface):
     """The PunaProxy class is used to connect to the control server and send commands to the
     Hexapod PUNA remotely.
 
-    Args:
-        protocol: the transport protocol
-        hostname: location of the control server (IP address)
-        port: TCP port on which the control server is listening for commands
+    The control server is discovered from the service registry using ``device_id`` as the
+    service type key, which is the same identifier used when the control server was started.
 
+    Args:
+        device_id: identifier of the hexapod control server as registered in the service registry
+        timeout: how long to wait for a response from the control server before giving up
     """
 
-    def __init__(self, protocol: str, hostname: str, port: int):
-        super().__init__(connect_address(protocol, hostname, port))
+    def __init__(self, device_id: str, *, timeout: float = PROXY_TIMEOUT):
+        self._device_id = device_id
+        super().__init__("", timeout=timeout, connect=False)
 
-    @classmethod
-    def from_identifier(cls, device_id: str):
+    @property
+    def device_id(self):
+        return self._device_id
+
+    def connect_cs(self):
         with RegistryClient() as reg:
-            service = reg.discover_service(device_id)
+            service = reg.discover_service(self._device_id)
 
-            if service:
-                protocol = service.get("protocol", "tcp")
-                hostname = service["host"]
-                port = service["port"]
+        if not service:
+            raise ConnectionError(f"No control server registered as '{self._device_id}'.")
 
-            else:
-                raise RuntimeError(f"No service registered as {device_id}")
+        protocol = service.get("protocol", "tcp")
+        hostname = service["host"]
+        port = service["port"]
 
-        logger.info(f"{protocol=}:{hostname=}:{port=}")
+        self._endpoint = connect_address(protocol, hostname, port)
+        logger.info(f"PunaProxy connecting to {self._device_id!r} at {self._endpoint}")
 
-        return cls(protocol, hostname, port)
+        super().connect_cs()
+        self.load_commands()

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/punaplus.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/punaplus.py
@@ -9,6 +9,8 @@ from egse.proxy import DynamicProxy
 from egse.registry.client import RegistryClient
 from egse.zmq_ser import connect_address
 
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s by default
+
 
 class PunaPlusInterface(AlphaPlusControllerInterface):
     """
@@ -50,32 +52,33 @@ class PunaPlusProxy(DynamicProxy, PunaPlusInterface):
     The PunaPlusProxy class is used to connect to the control server and send commands to the
     Hexapod PUNA remotely. The device controller for that PUNA hexapod is an Alpha+ controller.
 
-    Args:
-        protocol: the transport protocol
-        hostname: location of the control server (IP address)
-        port: TCP port on which the control server is listening for commands
+    The control server is discovered from the service registry using ``device_id`` as the
+    service type key, which is the same identifier used when the control server was started.
 
+    Args:
+        device_id: identifier of the hexapod control server as registered in the service registry
+        timeout: how long to wait for a response from the control server before giving up
     """
 
-    def __init__(self, protocol: str, hostname: str, port: int):
-        super().__init__(connect_address(protocol, hostname, port))
+    def __init__(self, device_id: str, *, timeout: float = PROXY_TIMEOUT):
+        self._device_id = device_id
+        super().__init__("", timeout=timeout, connect=False)
 
-    @classmethod
-    def from_identifier(cls, device_id: str):
+    def connect_cs(self):
         with RegistryClient() as reg:
-            service = reg.discover_service(device_id)
+            service = reg.discover_service(self._device_id)
 
-            if service:
-                protocol = service.get("protocol", "tcp")
-                hostname = service["host"]
-                port = service["port"]
+        if not service:
+            raise ConnectionError(f"No control server registered as '{self._device_id}'.")
 
-            else:
-                raise RuntimeError(f"No service registered as {device_id}")
+        protocol = service.get("protocol", "tcp")
+        hostname = service["host"]
+        port = service["port"]
 
-        logger.info(f"{protocol=}:{hostname=}:{port=}")
+        self._endpoint = connect_address(protocol, hostname, port)
+        logger.info(f"PunaPlusProxy connecting to {self._device_id!r} at {self._endpoint}")
 
-        return cls(protocol, hostname, port)
+        super().connect_cs()
 
 
 if __name__ == "__main__":

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda.py
@@ -26,6 +26,9 @@ from numpy import loadtxt
 from time import sleep
 
 DEVICE_SETTINGS = Settings.load(filename="zonda.yaml")
+CTRL_SETTINGS = Settings.load("Hexapod Control Server")
+
+PROXY_TIMEOUT = 10.0  # don't wait longer than 10s by default
 
 HOME_COMPLETE = 6
 IN_POSITION = 3
@@ -681,8 +684,13 @@ class ZondaSimulator(HexapodSimulator, DeviceInterface):
     This class simulates all the movements and status of the Hexapod.
     """
 
-    def __init__(self):
+    def __init__(self, device_id: str):
         super().__init__()
+        self._device_id = device_id
+
+    @property
+    def device_id(self):
+        return self._device_id
 
     def get_temperature(self) -> list[float]:
         return [random.random() for _ in range(6)]
@@ -692,32 +700,38 @@ class ZondaProxy(Proxy, ZondaInterface):
     """The ZondaProxy class is used to connect to the control server and send commands to the
     Hexapod ZONDA remotely.
 
-    Args:
-        protocol: the transport protocol
-        hostname: location of the control server (IP address)
-        port: TCP port on which the control server is listening for commands
+    The control server is discovered from the service registry using ``device_id`` as the
+    service type key, which is the same identifier used when the control server was started.
 
+    Args:
+        device_id: identifier of the hexapod control server as registered in the service registry
+        timeout: how long to wait for a response from the control server before giving up
     """
 
-    def __init__(self, protocol: str, hostname: str, port: int):
-        super().__init__(connect_address(protocol, hostname, port))
+    def __init__(self, device_id: str, *, timeout: float = PROXY_TIMEOUT):
+        self._device_id = device_id
+        super().__init__("", timeout=timeout, connect=False)
 
-    @classmethod
-    def from_identifier(cls, device_id: str):
+    @property
+    def device_id(self):
+        return self._device_id
+
+    def connect_cs(self):
         with RegistryClient() as reg:
-            service = reg.discover_service(device_id)
+            service = reg.discover_service(self._device_id)
 
-            if service:
-                protocol = service.get("protocol", "tcp")
-                hostname = service["host"]
-                port = service["port"]
+        if not service:
+            raise ConnectionError(f"No control server registered as '{self._device_id}'.")
 
-            else:
-                raise RuntimeError(f"No service registered as {device_id}")
+        protocol = service.get("protocol", "tcp")
+        hostname = service["host"]
+        port = service["port"]
 
-        logger.info(f"{protocol=}:{hostname=}:{port=}")
+        self._endpoint = connect_address(protocol, hostname, port)
+        logger.info(f"ZondaProxy connecting to {self._device_id!r} at {self._endpoint}")
 
-        return cls(protocol, hostname, port)
+        super().connect_cs()
+        self.load_commands()
 
 
 def decode_validation_error(value) -> Dict:

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_protocol.py
@@ -33,7 +33,7 @@ class ZondaProtocol(CommandProtocol):
         # self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)
 
         if self.simulator:
-            self.hexapod = ZondaSimulator()
+            self.hexapod = ZondaSimulator(device_id)
         else:
             *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
 

--- a/projects/generic/symetrie-hexapod/tests/script_test_for_pierre.py
+++ b/projects/generic/symetrie-hexapod/tests/script_test_for_pierre.py
@@ -1,0 +1,15 @@
+from egse.hexapod.symetrie.joran import JoranProxy, JoranSimulator
+
+print("HEX 1 - CONNECING TO Joran Hexapod")
+hex1id = "JORAN_01"
+hex1hw = JoranProxy(hex1id)
+try:
+    hex1hw.connect_cs()
+    print(f"HEX 1 - CONNECTED TO REAL HARDWARE : {hex1hw.device_id}")
+except ConnectionError:
+    hex1hw = JoranSimulator(hex1id)
+    print(f"HEX 1 - CONNECTED TO SIMULATOR : {hex1hw.device_id}")
+
+if isinstance(hex1hw, JoranProxy):
+    hex1hw.disconnect_cs()
+    print(f"HEX 1 - DISCONNECTED FROM REAL HARDWARE : {hex1hw.device_id}")

--- a/projects/generic/symetrie-hexapod/tests/test_puna.py
+++ b/projects/generic/symetrie-hexapod/tests/test_puna.py
@@ -4,10 +4,21 @@ import numpy as np
 import pytest
 from pytest import approx
 
-from egse.hexapod import HexapodError
-from egse.hexapod.symetrie.puna import PunaController
+from egse.hexapod.symetrie.hexapod import HexapodSimulator
+from egse.hexapod.symetrie.puna import PunaProxy
 from egse.hexapod.symetrie.puna import PunaSimulator
+from egse.hexapod.symetrie.zonda import ZondaProxy, ZondaSimulator
+from egse.hexapod.symetrie.joran import JoranProxy, JoranSimulator
 from egse.system import wait_until
+
+
+HEXAPODS = [
+    ("PUNA", "PUNA_01"),
+    ("ZONDA", "ZONDA_01"),
+    ("JORAN", "JORAN_01"),
+]
+
+BACKENDS = ["simulator", "proxy"]
 
 
 # When the 'real' Hexapod controller is connected, the pytest can be run with the
@@ -16,147 +27,268 @@ from egse.system import wait_until
 
 @pytest.fixture
 @lru_cache
-def hexapod():
-    # hexapod = PunaController("127.0.0.1", 1025)  # Use the correct IP address here
-    hexapod = PunaSimulator()
-    return hexapod
+def hexapod(request):
+    device, device_id = request.param
+
+    def get_simulator():
+        if device == "PUNA":
+            return PunaSimulator(device_id)
+        elif device == "ZONDA":
+            return ZondaSimulator(device_id)
+        elif device == "JORAN":
+            return JoranSimulator(device_id)
+
+    def get_proxy():
+        if device == "PUNA":
+            return PunaProxy(device_id)
+        elif device == "ZONDA":
+            return ZondaProxy(device_id)
+        elif device == "JORAN":
+            return JoranProxy(device_id)
+
+    return get_simulator(), get_proxy()
 
 
-def test_context_manager(hexapod):
+def get_device(hexapod, backend):
+    sim, dev = hexapod
+    if backend == "simulator":
+        return sim
+    if backend == "proxy":
+        return dev
+    raise ValueError(f"Unknown backend: {backend}")
+
+
+def skip_unavailable_proxy(exc: ConnectionError):
+    pytest.skip(f"Control server not available — skipping proxy backend: {exc}")
+
+
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_context_manager_proxy_no_control_server(hexapod):
+
     print()
 
-    with hexapod:
-        print(hexapod.info())
+    dev = get_device(hexapod, "proxy")
+
+    with pytest.raises(ConnectionError) as exc_info:
+        with dev:
+            print(dev.info())
+    assert str(exc_info.value) == f"No control server registered as '{dev._device_id}'."
 
 
-def test_connection(hexapod):
-    with hexapod:
-        hexapod.connect()
-        hexapod.info()
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_context_manager_simulator(hexapod):
 
-        # FIXME: The controller might be in a bad state due to previous failures.
-        #        We need some way to fix & reset the controller at the beginning of the unit tests.
+    print()
 
-        hexapod.clear_error()
+    sim = get_device(hexapod, "simulator")
 
-        if hexapod.is_simulator():
-            hexapod.reset(wait=False, verbose=False)  # Wait is not needed
-        else:
-            hexapod.reset(wait=True, verbose=False)  # Wait is definitely needed
-
-        hexapod.homing()
-
-        if wait_until(hexapod.is_homing_done, interval=0.5, timeout=300):
-            assert False
-        if wait_until(hexapod.is_in_position, interval=0.5, timeout=300):
-            assert False
-
-        assert hexapod.is_homing_done()
+    with sim:
+        print(sim.info())
 
 
-def test_goto_position(hexapod):
-    with hexapod:
-        hexapod.connect()
-        rc = hexapod.goto_specific_position(1)
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_connection_and_homing(hexapod, backend):
+    dev = get_device(hexapod, backend)
 
-        assert rc in [0, -1, -2]  # FIXME: How can we do proper checking here?
+    try:
+        with dev:
+            dev.info()
 
-        rc = hexapod.goto_specific_position(5)
+            # FIXME: The controller might be in a bad state due to previous failures.
+            #        We need some way to fix & reset the controller at the beginning of the unit tests.
 
-        assert rc in [0, -1, -2]  # FIXME: How can we do proper checking here?
+            dev.clear_error()
 
+            if dev.is_simulator():
+                dev.reset(wait=False, verbose=False)  # Wait is not needed
+            else:
+                dev.reset(wait=True, verbose=False)  # Wait is definitely needed
 
-def test_absolute_movement(hexapod):
-    with hexapod:
-        hexapod.connect()
+            dev.homing()
 
-        tx_u, ty_u, tz_u = 0, 0, 0
-        rx_u, ry_u, rz_u = 0, 0, 0
-        tx_o, ty_o, tz_o = 0, 0, 0
-        rx_o, ry_o, rz_o = 0, 0, 0
+            if wait_until(dev.is_homing_done, interval=0.5, timeout=300):
+                assert False
+            if wait_until(dev.is_in_position, interval=0.5, timeout=300):
+                assert False
 
-        hexapod.configure_coordinates_systems(tx_u, ty_u, tz_u, rx_u, ry_u, rz_u, tx_o, ty_o, tz_o, rx_o, ry_o, rz_o)
-        hexapod.homing()
-
-        if wait_until(hexapod.is_homing_done, interval=0.5, timeout=300):
-            assert False
-        if wait_until(hexapod.is_in_position, interval=1, timeout=300):
-            assert False
-
-        tx_u, ty_u, tz_u = -2, -2, -2
-        rx_u, ry_u, rz_u = -3, -4, -5
-
-        tx_o, ty_o, tz_o = 0, 0, 3
-        rx_o, ry_o, rz_o = np.rad2deg(np.pi / 6.0), np.rad2deg(np.pi / 6.0), 0
-
-        hexapod.configure_coordinates_systems(tx_u, ty_u, tz_u, rx_u, ry_u, rz_u, tx_o, ty_o, tz_o, rx_o, ry_o, rz_o)
-
-        out = hexapod.get_user_positions()
-        check_positions(out, (2.162431533, 1.9093265385, 4.967732082, 34.01008683, 33.65884585, 7.22137656))
-
-        out = hexapod.get_machine_positions()
-        check_positions(out, (0.00000, 0.00000, 0.00000, 0.00000, 0.00000, 0.00000))
-
-        tx, ty, tz = [1, 3, 4]
-        rx, ry, rz = [35, 25, 10]
-
-        rc = hexapod.move_absolute(tx, ty, tz, rx, ry, rz)
-        assert rc == 0
-
-        if wait_until(hexapod.is_in_position, interval=1, timeout=300):
-            assert False
-
-        out = hexapod.get_user_positions()
-        check_positions(out, (1.00000, 3.00000, 4.00000, 35.00000, 25.00000, 10.00000))
-
-        out = hexapod.get_machine_positions()
-        check_positions(out, (-0.5550577685, 1.2043056694, -1.0689145898, 1.0195290202, -8.466485292, 2.79932335))
-
-        # Test the move relative object
-
-        tx, ty, tz = -1, -1, -1
-        rx, ry, rz = 1, 7, -1
-
-        hexapod.move_relative_object(tx, ty, tz, rx, ry, rz)
-
-        if wait_until(hexapod.is_in_position, interval=1, timeout=300):
-            assert False
-
-        out = hexapod.get_user_positions()
-        check_positions(out, (-0.4295447122, 2.49856887, 3.160383195, 37.82597474, 31.25750377, 13.736721917))
-
-        out = hexapod.get_machine_positions()
-        check_positions(out, (-2.317005597, 0.8737649564, -2.006061295, 3.052233715, -1.9466592653, 4.741402017))
-
-        # Test the move relative user
-
-        tx, ty, tz = -2, -2, -2
-        rx, ry, rz = 1, 7, -1
-
-        hexapod.move_relative_user(tx, ty, tz, rx, ry, rz)
-
-        if wait_until(hexapod.is_in_position, interval=1, timeout=300):
-            assert False
-
-        out = hexapod.get_user_positions()
-        check_positions(out, (-2.429542106, 0.4985648, 1.1603886537, 41.37225134, 37.32309944, 18.14008525))
-
-        out = hexapod.get_machine_positions()
-        check_positions(out, (-4.710341626, -0.97799175, -4.017462423, 5.310002306, 4.496313461, 6.918574645))
+            assert dev.is_homing_done()
+            assert dev.is_in_position()
+    except ConnectionError as exc:
+        assert not isinstance(dev, HexapodSimulator), (
+            f"ConnectionError should only occur for proxies, but got for {type(dev).__name__}: {exc}"
+        )
+        skip_unavailable_proxy(exc)
 
 
-def test_coordinates_systems(hexapod):
-    with hexapod:
-        hexapod.connect()
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_hexapod_connect_and_ping(hexapod):
 
-        rc = hexapod.configure_coordinates_systems(1.2, 2.1, 1.3, 0.4, 0.3, 0.2, 1.3, 2.2, 1.2, 0.1, 0.2, 0.3)
+    def check_connect_hexapod(device):
+        device.connect_cs()
+        assert not device.ping()
+        device.disconnect_cs()
 
-        assert rc >= 0
+    dev = get_device(hexapod, "proxy")
 
-        out = hexapod.get_coordinates_systems()
+    try:
+        check_connect_hexapod(dev)
+    except ConnectionError as exc:
+        skip_unavailable_proxy(exc)
 
-        check_positions(out[:6], (1.2, 2.1, 1.3, 0.4, 0.3, 0.2))
-        check_positions(out[6:], (1.3, 2.2, 1.2, 0.1, 0.2, 0.3))
+
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_goto_position(hexapod, backend):
+
+    dev = get_device(hexapod, backend)
+
+    try:
+        with dev:
+            rc = dev.goto_specific_position(1)
+            assert rc in [0, -1, -2]  # FIXME: How can we do proper checking here?
+
+            rc = dev.goto_specific_position(5)
+            assert rc in [0, -1, -2]  # FIXME: How can we do proper checking here?
+    except ConnectionError as exc:
+        assert backend == "proxy"
+        skip_unavailable_proxy(exc)
+
+
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_absolute_movement(hexapod, backend):
+    dev = get_device(hexapod, backend)
+
+    try:
+        with dev:
+            tx_u, ty_u, tz_u = 0, 0, 0
+            rx_u, ry_u, rz_u = 0, 0, 0
+            tx_o, ty_o, tz_o = 0, 0, 0
+            rx_o, ry_o, rz_o = 0, 0, 0
+
+            dev.configure_coordinates_systems(tx_u, ty_u, tz_u, rx_u, ry_u, rz_u, tx_o, ty_o, tz_o, rx_o, ry_o, rz_o)
+            dev.homing()
+
+            if wait_until(dev.is_homing_done, interval=0.5, timeout=300):
+                assert False
+            if wait_until(dev.is_in_position, interval=1, timeout=300):
+                assert False
+
+            tx_u, ty_u, tz_u = -2, -2, -2
+            rx_u, ry_u, rz_u = -3, -4, -5
+
+            tx_o, ty_o, tz_o = 0, 0, 3
+            rx_o, ry_o, rz_o = np.rad2deg(np.pi / 6.0), np.rad2deg(np.pi / 6.0), 0
+
+            dev.configure_coordinates_systems(tx_u, ty_u, tz_u, rx_u, ry_u, rz_u, tx_o, ty_o, tz_o, rx_o, ry_o, rz_o)
+
+            out = dev.get_user_positions()
+            check_positions(out, (2.162431533, 1.9093265385, 4.967732082, 34.01008683, 33.65884585, 7.22137656))
+
+            out = dev.get_machine_positions()
+            check_positions(out, (0.00000, 0.00000, 0.00000, 0.00000, 0.00000, 0.00000))
+
+            tx, ty, tz = [1, 3, 4]
+            rx, ry, rz = [35, 25, 10]
+
+            rc = dev.move_absolute(tx, ty, tz, rx, ry, rz)
+            assert rc == 0
+
+            if wait_until(dev.is_in_position, interval=1, timeout=300):
+                assert False
+
+            out = dev.get_user_positions()
+            check_positions(out, (1.00000, 3.00000, 4.00000, 35.00000, 25.00000, 10.00000))
+
+            out = dev.get_machine_positions()
+            check_positions(out, (-0.5550577685, 1.2043056694, -1.0689145898, 1.0195290202, -8.466485292, 2.79932335))
+
+            # Test the move relative object
+
+            tx, ty, tz = -1, -1, -1
+            rx, ry, rz = 1, 7, -1
+
+            dev.move_relative_object(tx, ty, tz, rx, ry, rz)
+
+            if wait_until(dev.is_in_position, interval=1, timeout=300):
+                assert False
+
+            out = dev.get_user_positions()
+            check_positions(out, (-0.4295447122, 2.49856887, 3.160383195, 37.82597474, 31.25750377, 13.736721917))
+
+            out = dev.get_machine_positions()
+            check_positions(out, (-2.317005597, 0.8737649564, -2.006061295, 3.052233715, -1.9466592653, 4.741402017))
+
+            # Test the move relative user
+
+            tx, ty, tz = -2, -2, -2
+            rx, ry, rz = 1, 7, -1
+
+            dev.move_relative_user(tx, ty, tz, rx, ry, rz)
+
+            if wait_until(dev.is_in_position, interval=1, timeout=300):
+                assert False
+
+            out = dev.get_user_positions()
+            check_positions(out, (-2.429542106, 0.4985648, 1.1603886537, 41.37225134, 37.32309944, 18.14008525))
+
+            out = dev.get_machine_positions()
+            check_positions(out, (-4.710341626, -0.97799175, -4.017462423, 5.310002306, 4.496313461, 6.918574645))
+
+    except ConnectionError as exc:
+        assert backend == "proxy"
+        skip_unavailable_proxy(exc)
+
+
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_coordinates_systems(hexapod, backend):
+
+    dev = get_device(hexapod, backend)
+
+    try:
+        with dev:
+            rc = dev.configure_coordinates_systems(1.2, 2.1, 1.3, 0.4, 0.3, 0.2, 1.3, 2.2, 1.2, 0.1, 0.2, 0.3)
+
+            assert rc >= 0
+
+            out = dev.get_coordinates_systems()
+
+            check_positions(out[:6], (1.2, 2.1, 1.3, 0.4, 0.3, 0.2))
+            check_positions(out[6:], (1.3, 2.2, 1.2, 0.1, 0.2, 0.3))
+
+    except ConnectionError as exc:
+        assert backend == "proxy"
+        skip_unavailable_proxy(exc)
 
 
 def check_positions(out, expected, rel=0.0001, abs=0.0001):

--- a/projects/generic/symetrie-hexapod/tests/test_puna_simulator.py
+++ b/projects/generic/symetrie-hexapod/tests/test_puna_simulator.py
@@ -4,9 +4,32 @@ import numpy as np
 import logging
 
 from egse.hexapod import HexapodError
-from egse.hexapod.symetrie.puna import PunaSimulator as Hexapod
+from egse.hexapod.symetrie.puna import PunaSimulator
+from egse.hexapod.symetrie.zonda import ZondaSimulator
+from egse.hexapod.symetrie.joran import JoranSimulator
 
 _LOGGER = logging.getLogger(__name__)
+
+HEXAPODS = [
+    ("PUNA", "PUNA_01"),
+    ("ZONDA", "ZONDA_01"),
+    ("JORAN", "JORAN_01"),
+]
+
+
+@pytest.fixture
+def hexapod(request):
+    device, device_id = request.param
+
+    def get_simulator():
+        if device == "PUNA":
+            return PunaSimulator(device_id)
+        elif device == "ZONDA":
+            return ZondaSimulator(device_id)
+        elif device == "JORAN":
+            return JoranSimulator(device_id)
+
+    return get_simulator()
 
 
 def wait_until(condition, interval=0.1, timeout=1, *args):
@@ -18,8 +41,12 @@ def wait_until(condition, interval=0.1, timeout=1, *args):
         time.sleep(interval)
 
 
-def test_goto_zero_position():
-    hexapod = Hexapod()
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_goto_zero_position(hexapod):
 
     try:
         rc = hexapod.goto_zero_position()
@@ -38,9 +65,12 @@ def test_goto_zero_position():
         hexapod.disconnect()
 
 
-def test_position_after_homing():
-    hexapod = Hexapod()
-
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_position_after_homing(hexapod):
     try:
         hexapod.move_absolute(5, 0, 0, 0, 0, 0)
 
@@ -73,17 +103,25 @@ def test_position_after_homing():
         hexapod.disconnect()
 
 
-def test_construction():
-    hexapod = Hexapod()
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_construction(hexapod):
     assert hexapod.is_simulator()
     assert not hexapod.is_homing_done()
 
 
-def test_absolute_movement2():
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_absolute_movement2(hexapod):
     """
     This test originated from a problem with the values of Machine positions after a simple rotation.
     """
-    hexapod = Hexapod()
 
     try:
         tx, ty, tz = [0, 10, 0]
@@ -104,9 +142,12 @@ def test_absolute_movement2():
         hexapod.disconnect()
 
 
-def test_absolute_movement1():
-    hexapod = Hexapod()
-
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_absolute_movement1(hexapod):
     try:
         tx, ty, tz = [1, 3, 4]
         rx, ry, rz = [35, 25, 10]
@@ -123,9 +164,12 @@ def test_absolute_movement1():
         hexapod.disconnect()
 
 
-def test_absolute_movement():
-    hexapod = Hexapod()
-
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_absolute_movement(hexapod):
     try:
         tx_u, ty_u, tz_u = -2, -2, -2
         rx_u, ry_u, rz_u = -3, -4, -5
@@ -191,9 +235,12 @@ def test_absolute_movement():
         hexapod.disconnect()
 
 
-def test_coordinates_systems():
-    hexapod = Hexapod()
-
+@pytest.mark.parametrize(
+    "hexapod",
+    HEXAPODS,
+    indirect=True,
+)
+def test_coordinates_systems(hexapod):
     try:
         rc = hexapod.configure_coordinates_systems(1.2, 2.1, 1.3, 0.4, 0.3, 0.2, 1.3, 2.2, 1.2, 0.1, 0.2, 0.3)
 


### PR DESCRIPTION
- Updated `pyproject.toml` to restrict Python version to <3.13. Because of telnetlib.
- Modified `__init__.py` to require device IDs for Puna, Zonda, and Joran proxies.
- Refactored `ProxyFactory` to remove registry client usage and directly use device IDs.
- Enhanced `Joran`, `Puna`, `Zonda`, and `PunaPlus` classes to accept device IDs and connect to control servers.
- Added timeout handling for proxy connections.
- Created tests for hexapod connection, homing, and movement functionalities, supporting both simulator and proxy backends.
- Improved test structure to handle multiple hexapod types and backends dynamically.