### PR TITLE
Enhance Joran and Puna control server functionality with device ID support and improve error handling

### DIFF
--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/__init__.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/__init__.py
@@ -86,7 +86,9 @@ def get_hexapod_controller_pars(device_id: str) -> HexapodInfo:
         device_name: str = HEXAPOD_SETTINGS[device_id]["DEVICE_NAME"]
         device_type: str = HEXAPOD_SETTINGS[device_id]["DEVICE_TYPE"]
     except (KeyError, AttributeError) as exc:
-        raise SettingsError("The Settings do not contain proper controller parameters for the Hexapod.") from exc
+        raise SettingsError(
+            f"The Settings do not contain proper controller parameters for the Hexapod with ID {device_id}."
+        ) from exc
 
     logger.debug(f"{hostname=}, {port=}, {device_id=}, {device_name=}, {device_type=}, {controller_type=}")
     return HexapodInfo(hostname, port, device_id, device_name, device_type, controller_type)

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran.py
@@ -6,6 +6,7 @@ Symétrie.
 
 import logging
 import math
+import random
 import time
 
 from egse.device import DeviceInterface
@@ -111,6 +112,9 @@ class JoranSimulator(HexapodSimulator, DeviceInterface):
     @property
     def device_id(self):
         return self._device_id
+
+    def get_temperature(self) -> list[float]:
+        return [random.random() for _ in range(6)]
 
 
 class JoranProxy(DynamicProxy, JoranInterface):

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_cs.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_cs.py
@@ -16,27 +16,22 @@ all device behavior correctly, e.g. timing, error conditions, etc.
 """
 
 import logging
-
-from egse.process import SubProcess
-
-if __name__ != "__main__":
-    import multiprocessing
-
-    multiprocessing.current_process().name = "joran_cs"
-
+import multiprocessing
 import sys
+from typing import Annotated
 
 import click
 import rich
+import typer
 import zmq
-
-from egse.control import ControlServer
-from egse.control import is_control_server_active
-from egse.hexapod.symetrie.joran import JoranProxy
-from egse.hexapod.symetrie.joran_protocol import JoranProtocol
+from egse.control import ControlServer, is_control_server_active
+from egse.process import SubProcess
 from egse.settings import Settings
 from egse.zmq_ser import connect_address
 from prometheus_client import start_http_server
+
+from egse.hexapod.symetrie.joran import JoranProxy
+from egse.hexapod.symetrie.joran_protocol import JoranProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -61,10 +56,12 @@ class JoranControlServer(ControlServer):
 
     """
 
-    def __init__(self):
+    def __init__(self, device_id: str, simulator: bool = False):
         super().__init__()
 
-        self.device_protocol = JoranProtocol(self)
+        multiprocessing.current_process().name = "joran_cs"
+
+        self.device_protocol = JoranProtocol(self, device_id=device_id, simulator=simulator)
 
         self.logger.debug(f"Binding ZeroMQ socket to {self.device_protocol.get_bind_address()}")
 
@@ -94,32 +91,32 @@ class JoranControlServer(ControlServer):
         start_http_server(CTRL_SETTINGS["METRICS_PORT"])
 
 
-@click.group()
-def cli():
-    pass
+app = typer.Typer()
 
 
-@cli.command()
-@click.option("--simulator", "--sim", is_flag=True, help="Start the Hexapod Joran Simulator as the backend.")
-def start(simulator):
-    """Start the Hexapod Joran Control Server."""
-
-    if simulator:
-        Settings.set_simulation_mode(True)
+@app.command()
+def start(
+    device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")],
+    simulator: Annotated[
+        bool, typer.Option("--simulator", "--sim", help="start the hexapod JORAN Control Server in simulator mode")
+    ] = False,
+):
+    """Start the Hexapod JORAN Control Server."""
 
     try:
-        controller = JoranControlServer()
+        controller = JoranControlServer(device_id=device_id, simulator=simulator)
         controller.serve()
 
     except KeyboardInterrupt:
         print("Shutdown requested...exiting")
 
-    except SystemExit as exit_code:
+    except SystemExit as exc:
+        exit_code = exc.code if hasattr(exc, "code") else 0
         print("System Exit with code {}.".format(exit_code))
         sys.exit(exit_code)
 
     except Exception:
-        logger.exception("Cannot start the Hexapod Joran Control Server")
+        logger.exception("Cannot start the Hexapod JORAN Control Server")
 
         # The above line does exactly the same as the traceback, but on the logger
         # import traceback
@@ -128,29 +125,20 @@ def start(simulator):
     return 0
 
 
-@cli.command()
-@click.option("--simulator", "--sim", is_flag=True, help="Start the Hexapod Joran Simulator as the backend.")
-def start_bg(simulator):
-    """Start the JORAN Control Server in the background."""
-    sim = "--simulator" if simulator else ""
-    proc = SubProcess("joran_cs", ["joran_cs", "start", sim])
-    proc.execute()
-
-
-@cli.command()
-def stop():
+@app.command()
+def stop(device_id: str):
     """Send a 'quit_server' command to the Hexapod Joran Control Server."""
 
     try:
-        with JoranProxy() as proxy:
+        with JoranProxy(device_id) as proxy:
             sp = proxy.get_service_proxy()
             sp.quit_server()
     except ConnectionError:
         rich.print("[red]Couldn't connect to 'joran_cs', process probably not running. ")
 
 
-@cli.command()
-def status():
+@app.command()
+def status(device_id: str):
     """Request status information from the Control Server."""
 
     protocol = CTRL_SETTINGS["PROTOCOL"]
@@ -161,7 +149,7 @@ def status():
 
     if is_control_server_active(endpoint):
         rich.print("JORAN Hexapod: [green]active")
-        with JoranProxy() as joran:
+        with JoranProxy(device_id) as joran:
             sim = joran.is_simulator()
             connected = joran.is_connected()
             ip = joran.get_ip_address()
@@ -176,4 +164,4 @@ def status():
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG, format=Settings.LOG_FORMAT_FULL)
 
-    sys.exit(cli())
+    sys.exit(app())

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_protocol.py
@@ -24,13 +24,15 @@ class JoranCommand(ClientServerCommand):
 
 
 class JoranProtocol(CommandProtocol):
-    def __init__(self, control_server: ControlServer):
+    def __init__(self, control_server: ControlServer, device_id: str, simulator: bool = False):
         super().__init__(control_server)
+        self.simulator = simulator
+        self.device_id = device_id
 
         self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)
 
-        if Settings.simulation_mode():
-            self.hexapod = JoranSimulator()
+        if self.simulator:
+            self.hexapod = JoranSimulator(self.device_id)
         else:
             self.hexapod = JoranController()
 
@@ -54,7 +56,7 @@ class JoranProtocol(CommandProtocol):
     def get_status(self):
         status = super().get_status()
 
-        if self.state == DeviceConnectionState.DEVICE_NOT_CONNECTED and not Settings.simulation_mode():
+        if self.state == DeviceConnectionState.DEVICE_NOT_CONNECTED and not self.simulator:
             return status
 
         mach_positions = self.hexapod.get_machine_positions()
@@ -69,7 +71,7 @@ class JoranProtocol(CommandProtocol):
         result = dict()
         result["timestamp"] = format_datetime()
 
-        if self.state == DeviceConnectionState.DEVICE_NOT_CONNECTED and not Settings.simulation_mode():
+        if self.state == DeviceConnectionState.DEVICE_NOT_CONNECTED and not self.simulator:
             return result
 
         mach_positions = self.hexapod.get_machine_positions()

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_cs.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_cs.py
@@ -87,10 +87,7 @@ class PunaControlServer(ControlServer):
         return CTRL_SETTINGS["MONITORING_PORT"]
 
     def get_storage_mnemonic(self):
-        try:
-            return CTRL_SETTINGS["STORAGE_MNEMONIC"]
-        except AttributeError:
-            return "PUNA"
+        return CTRL_SETTINGS.get("STORAGE_MNEMONIC", "PUNA")
 
     def is_storage_manager_active(self):
         from egse.storage import is_storage_manager_active

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_protocol.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_protocol.py
@@ -34,7 +34,7 @@ class PunaProtocol(CommandProtocol):
         # self.hk_conversion_table = read_conversion_dict(self.control_server.get_storage_mnemonic(), use_site=True)
 
         if self.simulator:
-            self.hexapod = PunaSimulator()
+            self.hexapod = PunaSimulator(device_id)
         else:
             *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
 

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_ui.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_ui.py
@@ -292,7 +292,7 @@ class PunaUIModel(HexapodUIModel):
             device = ControllerFactory().create(dev_name, device_id=dev_id)
             device.connect()
         elif connection_type == "simulator":
-            device = PunaSimulator()
+            device = PunaSimulator(device_id)
         else:
             raise ValueError(f"Unknown type of Hexapod implementation passed into the model: {connection_type}")
 

--- a/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
+++ b/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
@@ -21,7 +21,7 @@ def start_hexapod_cs_process(device_name, device_id, simulator):
 
     rich.print(f"Starting the {device_name} hexapod control server for {device_id} – {simulator = }")
 
-    out = redirect_output_to_log(f".{device_name.lower()}_cs.{device_id.lower()}.start.log")
+    out = redirect_output_to_log(f"{device_name.lower()}_cs.{device_id.lower()}.start.log")
 
     cmd = [sys.executable, "-m", f"egse.hexapod.symetrie.{device_name.lower()}_cs", "start", device_id]
     if simulator:
@@ -35,7 +35,7 @@ def stop_hexapod_cs_process(device_name, device_id):
 
     rich.print(f"Terminating hexapod {device_name} control server for {device_id}...")
 
-    out = redirect_output_to_log(f".{device_name.lower()}_cs.{device_id.lower()}.stop.log")
+    out = redirect_output_to_log(f"{device_name.lower()}_cs.{device_id.lower()}.stop.log")
 
     cmd = [sys.executable, "-m", f"egse.hexapod.symetrie.{device_name.lower()}_cs", "stop", device_id]
 
@@ -84,13 +84,13 @@ def start_puna_sim(device_id: str):
     rich.print(
         textwrap.dedent(
             f"""\
-            [orange3]The PUNA simulator is in development, for now use the `--sim` option when starting the control 
+            [orange3]The PUNA simulator is in development, for now use the `--sim` option when starting the control
             server.[/]
-            
+
             The `--sim` option will use a Controller clas that doesn't send commands to the device, but simulates
-            the requests by performing actions on the reference frames defined in the hexapod. This means you are 
+            the requests by performing actions on the reference frames defined in the hexapod. This means you are
             not exercising the actual device commanding, but the net result or outcome is the same.
-            
+
             usage: cgse puna start --sim {device_id}
             """
         )
@@ -99,7 +99,7 @@ def start_puna_sim(device_id: str):
 
     rich.print("Starting service PUNA Simulator")
 
-    out = redirect_output_to_log(f".puna_sim.{device_id.lower()}.start.log")
+    out = redirect_output_to_log(f"puna_sim.{device_id.lower()}.start.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.hexapod.symetrie.puna_sim", "start", device_id],
@@ -115,7 +115,7 @@ def stop_puna_sim(device_id: str):
     """Stop the PUNA Hexapod Simulator."""
     rich.print("Terminating the PUNA simulator.")
 
-    out = redirect_output_to_log(f".puna_sim.{device_id.lower()}.stop.log")
+    out = redirect_output_to_log(f"puna_sim.{device_id.lower()}.stop.log")
 
     subprocess.Popen(
         [sys.executable, "-m", "egse.hexapod.symetrie.puna_sim", "stop", device_id],


### PR DESCRIPTION
The Joran control server and protocol were not yet adapted to take and use the device_id. Also, the PunaSimulator was not always passed the device_id.