### PR TITLE
Implement unique service type enforcement in registry

### DIFF
--- a/libs/cgse-core/src/cgse_core/_start.py
+++ b/libs/cgse-core/src/cgse_core/_start.py
@@ -2,17 +2,23 @@ import subprocess
 import sys
 
 import rich
-
 from egse.system import redirect_output_to_log
 
 
-def start_rm_cs(log_level: str):
+def start_rm_cs(log_level: str, enforce_unique_service_types: bool | None = None):
     rich.print("Starting the service registry manager core service...")
 
     out = redirect_output_to_log("rm_cs.start.log")
 
+    command = [sys.executable, "-m", "egse.registry.server", "start", "--log-level", log_level]
+
+    if enforce_unique_service_types is True:
+        command.append("--enforce-unique-service-types")
+    elif enforce_unique_service_types is False:
+        command.append("--no-enforce-unique-service-types")
+
     subprocess.Popen(
-        [sys.executable, "-m", "egse.registry.server", "start", "--log-level", log_level],
+        command,
         stdout=out,
         stderr=out,
         stdin=subprocess.DEVNULL,

--- a/libs/cgse-core/src/cgse_core/services.py
+++ b/libs/cgse-core/src/cgse_core/services.py
@@ -1,17 +1,16 @@
 import asyncio
 import datetime
-import logging
 import time
 from pathlib import Path
 
 import rich
 import typer
-
-from egse.registry.client import AsyncRegistryClient
 from egse.signal import DEFAULT_SIGNAL_DIR
 from egse.signal import create_signal_command_file
 from egse.system import TyperAsyncCommand
 from egse.system import format_datetime
+
+from egse.registry.client import AsyncRegistryClient
 
 from ._start import start_cm_cs
 from ._start import start_log_cs
@@ -43,12 +42,19 @@ core = typer.Typer(
 
 
 @core.command(name="start")
-def start_core_services(log_level: str = "WARNING"):
+def start_core_services(
+    log_level: str = "WARNING",
+    enforce_unique_service_types: bool | None = typer.Option(
+        None,
+        "--enforce-unique-service-types/--allow-duplicate-service-types",
+        help="Override registry startup mode: enforce one service per type, or allow duplicates for pooling.",
+    ),
+):
     """Start the core services in the background."""
 
     rich.print("[green]Starting the core services...[/]")
 
-    start_rm_cs(log_level)
+    start_rm_cs(log_level, enforce_unique_service_types)
     start_log_cs()
     start_notifyhub()
     start_metricshub()
@@ -104,9 +110,16 @@ rm_cs = typer.Typer(
 
 
 @rm_cs.command(name="start")
-def rm_cs_start(log_level: str = "WARNING"):
+def rm_cs_start(
+    log_level: str = "WARNING",
+    enforce_unique_service_types: bool | None = typer.Option(
+        None,
+        "--enforce-unique-service-types/--allow-duplicate-service-types",
+        help="Override registry startup mode: enforce one service per type, or allow duplicates for pooling.",
+    ),
+):
     """Start the Service Registry Manager."""
-    start_rm_cs(log_level)
+    start_rm_cs(log_level, enforce_unique_service_types)
 
 
 @rm_cs.command(name="stop")

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -4,7 +4,7 @@ PACKAGES:
 Service Registry:
 
     CLEANUP_INTERVAL:                30
-    UNIQUE_SERVICE_TYPES:         false
+    UNIQUE_SERVICE_TYPES:          true
     REQUESTER_PORT:                6100
     PUBLISHER_PORT:                6101
     HEARTBEAT_PORT:                6102

--- a/libs/cgse-core/src/cgse_core/settings.yaml
+++ b/libs/cgse-core/src/cgse_core/settings.yaml
@@ -4,6 +4,7 @@ PACKAGES:
 Service Registry:
 
     CLEANUP_INTERVAL:                30
+    UNIQUE_SERVICE_TYPES:         false
     REQUESTER_PORT:                6100
     PUBLISHER_PORT:                6101
     HEARTBEAT_PORT:                6102

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -242,6 +242,7 @@ class RegistryClient:
         metadata: dict[str, Any] | None = None,
         ttl: int = 30,
         singleton: bool = False,
+        allow_duplicate_service_type: bool = False,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -256,10 +257,16 @@ class RegistryClient:
             singleton: When True, reject registration if another service with the same
                 service_type is already registered, regardless of the server's global
                 enforce_unique_service_types setting.
+            allow_duplicate_service_type: When True, allow registration even if another
+                service with the same service_type is already registered while the
+                server enforces unique service types globally.
 
         Returns:
             The service ID if successful, None otherwise
         """
+        if singleton and allow_duplicate_service_type:
+            raise ValueError("singleton and allow_duplicate_service_type cannot both be True")
+
         # Prepare service info
         service_info: dict[str, str | int | dict | list] = {"name": name, "host": host, "port": port}
 
@@ -272,6 +279,9 @@ class RegistryClient:
 
         if singleton:
             service_info["singleton"] = True
+
+        if allow_duplicate_service_type:
+            service_info["allow_duplicate_service_type"] = True
 
         # Prepare tags for easier discovery
         tags = []
@@ -754,6 +764,7 @@ class AsyncRegistryClient:
         metadata: dict[str, Any] | None = None,
         ttl: int = 30,
         singleton: bool = False,
+        allow_duplicate_service_type: bool = False,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -768,10 +779,16 @@ class AsyncRegistryClient:
             singleton: When True, reject registration if another service with the same
                 service_type is already registered, regardless of the server's global
                 enforce_unique_service_types setting.
+            allow_duplicate_service_type: When True, allow registration even if another
+                service with the same service_type is already registered while the
+                server enforces unique service types globally.
 
         Returns:
             The service ID if successful, None otherwise
         """
+        if singleton and allow_duplicate_service_type:
+            raise ValueError("singleton and allow_duplicate_service_type cannot both be True")
+
         # Prepare service info
         service_info: dict[str, Any] = {"name": name, "host": host, "port": port}
 
@@ -784,6 +801,9 @@ class AsyncRegistryClient:
 
         if singleton:
             service_info["singleton"] = True
+
+        if allow_duplicate_service_type:
+            service_info["allow_duplicate_service_type"] = True
 
         # Prepare tags for easier discovery
         tags = []

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -241,6 +241,7 @@ class RegistryClient:
         service_type: str | None = None,
         metadata: dict[str, Any] | None = None,
         ttl: int = 30,
+        singleton: bool = False,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -252,6 +253,9 @@ class RegistryClient:
             service_type: Service type (for discovery)
             metadata: Additional service metadata
             ttl: Time-to-live in seconds
+            singleton: When True, reject registration if another service with the same
+                service_type is already registered, regardless of the server's global
+                enforce_unique_service_types setting.
 
         Returns:
             The service ID if successful, None otherwise
@@ -265,6 +269,9 @@ class RegistryClient:
 
         if metadata:
             service_info["metadata"] = metadata
+
+        if singleton:
+            service_info["singleton"] = True
 
         # Prepare tags for easier discovery
         tags = []
@@ -746,6 +753,7 @@ class AsyncRegistryClient:
         service_type: str | None = None,
         metadata: dict[str, Any] | None = None,
         ttl: int = 30,
+        singleton: bool = False,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -757,6 +765,9 @@ class AsyncRegistryClient:
             service_type: Service type (for discovery)
             metadata: Additional service metadata
             ttl: Time-to-live in seconds
+            singleton: When True, reject registration if another service with the same
+                service_type is already registered, regardless of the server's global
+                enforce_unique_service_types setting.
 
         Returns:
             The service ID if successful, None otherwise
@@ -770,6 +781,9 @@ class AsyncRegistryClient:
 
         if metadata:
             service_info["metadata"] = metadata
+
+        if singleton:
+            service_info["singleton"] = True
 
         # Prepare tags for easier discovery
         tags = []

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -75,7 +75,7 @@ class AsyncRegistryServer:
         self.db_path = db_path
         self.cleanup_interval = cleanup_interval or settings.get("CLEANUP_INTERVAL", 10)
         self.enforce_unique_service_types = (
-            bool_env("UNIQUE_SERVICE_TYPES", False)
+            bool_env("UNIQUE_SERVICE_TYPES", True)
             if enforce_unique_service_types is None
             else enforce_unique_service_types
         )
@@ -97,14 +97,19 @@ class AsyncRegistryServer:
         self._tasks = set()
 
     async def _reject_on_duplicate_service_type(
-        self, service_id: str, service_type: str | None, singleton: bool = False
+        self,
+        service_id: str,
+        service_type: str | None,
+        singleton: bool = False,
+        allow_duplicate_service_type: bool = False,
     ) -> dict[str, Any] | None:
         """Return an error response if unique-type enforcement is enabled and a conflict exists.
 
-        Uniqueness is enforced when either the server-wide ``enforce_unique_service_types`` flag is
-        set *or* the individual registration requests it via ``singleton=True``.
+        Uniqueness is enforced when either the server-wide `enforce_unique_service_types` flag is
+        set *or* the individual registration requests it via `singleton=True`.
+        Individual registrations can opt out via `allow_duplicate_service_type=True`.
         """
-        if (not self.enforce_unique_service_types and not singleton) or not service_type:
+        if allow_duplicate_service_type or (not self.enforce_unique_service_types and not singleton) or not service_type:
             return None
 
         # Clean expired services first so stale entries do not block valid registrations.
@@ -397,7 +402,20 @@ class AsyncRegistryServer:
 
         service_type = service_info.get("type") or service_info.get("metadata", {}).get("type")
         singleton = bool(service_info.get("singleton", False))
-        duplicate_conflict = await self._reject_on_duplicate_service_type(service_id, service_type, singleton)
+        allow_duplicate_service_type = bool(service_info.get("allow_duplicate_service_type", False))
+        if singleton and allow_duplicate_service_type:
+            return {
+                "success": False,
+                "error": "invalid_service_type_policy",
+                "message": "singleton and allow_duplicate_service_type cannot both be true.",
+            }
+
+        duplicate_conflict = await self._reject_on_duplicate_service_type(
+            service_id,
+            service_type,
+            singleton=singleton,
+            allow_duplicate_service_type=allow_duplicate_service_type,
+        )
         if duplicate_conflict:
             return duplicate_conflict
 
@@ -604,7 +622,7 @@ async def start(
     hb_port: int = DEFAULT_RS_HB_PORT,
     db_path: str = DEFAULT_RS_DB_PATH,
     cleanup_interval: int = 0,
-    enforce_unique_service_types: bool = settings.get("UNIQUE_SERVICE_TYPES", False),
+    enforce_unique_service_types: bool = settings.get("UNIQUE_SERVICE_TYPES", True),
     log_level: str = "WARNING",
 ):
     """Run the registry server with signal handling."""

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -56,6 +56,7 @@ class AsyncRegistryServer:
         backend: a registry backend, [default=AsyncSQLiteBackend]
         db_path: Path to the SQLite database file [default='service_registry.db']
         cleanup_interval: How often to clean up expired services (seconds) [default=10]
+        enforce_unique_service_types: Whether only one service per service_type is allowed.
     """
 
     def __init__(
@@ -66,12 +67,18 @@ class AsyncRegistryServer:
         backend: AsyncRegistryBackend | None = None,
         db_path: str = DEFAULT_RS_DB_PATH,
         cleanup_interval: int = 0,
+        enforce_unique_service_types: bool | None = None,
     ):
         self.req_port = req_port
         self.pub_port = pub_port
         self.hb_port = hb_port
         self.db_path = db_path
         self.cleanup_interval = cleanup_interval or settings.get("CLEANUP_INTERVAL", 10)
+        self.enforce_unique_service_types = (
+            bool_env("UNIQUE_SERVICE_TYPES", False)
+            if enforce_unique_service_types is None
+            else enforce_unique_service_types
+        )
         self.logger = logger
 
         self.context = None
@@ -88,6 +95,36 @@ class AsyncRegistryServer:
 
         # Tasks
         self._tasks = set()
+
+    async def _reject_on_duplicate_service_type(
+        self, service_id: str, service_type: str | None, singleton: bool = False
+    ) -> dict[str, Any] | None:
+        """Return an error response if unique-type enforcement is enabled and a conflict exists.
+
+        Uniqueness is enforced when either the server-wide ``enforce_unique_service_types`` flag is
+        set *or* the individual registration requests it via ``singleton=True``.
+        """
+        if (not self.enforce_unique_service_types and not singleton) or not service_type:
+            return None
+
+        # Clean expired services first so stale entries do not block valid registrations.
+        await self.backend.clean_expired_services()
+        services = await self.backend.list_services(service_type=service_type)
+
+        for registered_service in services:
+            registered_service_id = registered_service.get("id")
+            if registered_service_id and registered_service_id != service_id:
+                return {
+                    "success": False,
+                    "error": "duplicate_service_type",
+                    "message": (
+                        f"Service type '{service_type}' is already registered by service_id '{registered_service_id}'."
+                    ),
+                    "service_type": service_type,
+                    "existing_service_id": registered_service_id,
+                }
+
+        return None
 
     async def setup_sockets(self):
         """Set up the communication sockets."""
@@ -358,6 +395,12 @@ class AsyncRegistryServer:
         # Get TTL
         ttl = request.get("ttl", 30)
 
+        service_type = service_info.get("type") or service_info.get("metadata", {}).get("type")
+        singleton = bool(service_info.get("singleton", False))
+        duplicate_conflict = await self._reject_on_duplicate_service_type(service_id, service_type, singleton)
+        if duplicate_conflict:
+            return duplicate_conflict
+
         # Register the service
         success = await self.backend.register(service_id, service_info, ttl)
 
@@ -527,6 +570,7 @@ class AsyncRegistryServer:
             "req_port": self.req_port,
             "pub_port": self.pub_port,
             "hb_port": self.hb_port,
+            "enforce_unique_service_types": self.enforce_unique_service_types,
             "services": services,
         }
 
@@ -560,6 +604,7 @@ async def start(
     hb_port: int = DEFAULT_RS_HB_PORT,
     db_path: str = DEFAULT_RS_DB_PATH,
     cleanup_interval: int = 0,
+    enforce_unique_service_types: bool = settings.get("UNIQUE_SERVICE_TYPES", False),
     log_level: str = "WARNING",
 ):
     """Run the registry server with signal handling."""
@@ -571,6 +616,7 @@ async def start(
             hb_port=hb_port,
             db_path=db_path,
             cleanup_interval=cleanup_interval,
+            enforce_unique_service_types=enforce_unique_service_types,
         )
 
         # Set up signal handlers
@@ -611,6 +657,7 @@ async def status(
                 Requests port: {response["req_port"]}
                 Notifications port: {response["pub_port"]}
                 Heartbeat port: {response["hb_port"]}
+                Unique service types: {response.get("enforce_unique_service_types", False)}
                 Registrations: {", ".join([f"({x['name']}, {x['health']})" for x in response["services"]])}\
             """
         )

--- a/libs/cgse-core/src/egse/registry/server.py
+++ b/libs/cgse-core/src/egse/registry/server.py
@@ -109,7 +109,11 @@ class AsyncRegistryServer:
         set *or* the individual registration requests it via `singleton=True`.
         Individual registrations can opt out via `allow_duplicate_service_type=True`.
         """
-        if allow_duplicate_service_type or (not self.enforce_unique_service_types and not singleton) or not service_type:
+        if (
+            allow_duplicate_service_type
+            or (not self.enforce_unique_service_types and not singleton)
+            or not service_type
+        ):
             return None
 
         # Clean expired services first so stale entries do not block valid registrations.

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -528,6 +528,90 @@ async def test_server_register_singleton_overrides_permissive_global(server, req
 
 
 @pytest.mark.asyncio
+async def test_server_register_allow_duplicate_overrides_strict_global(server, req_socket):
+    """A registration with allow_duplicate_service_type=True can pool even when global
+    uniqueness enforcement is enabled."""
+    server.enforce_unique_service_types = True
+
+    try:
+        first = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "pool-id-1",
+                    "name": "pool-a",
+                    "host": "localhost",
+                    "port": 8481,
+                    "type": "pool-type",
+                    "allow_duplicate_service_type": True,
+                },
+            },
+        )
+        second = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "pool-id-2",
+                    "name": "pool-b",
+                    "host": "localhost",
+                    "port": 8482,
+                    "type": "pool-type",
+                    "allow_duplicate_service_type": True,
+                },
+            },
+        )
+        non_pooled_duplicate = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "pool-id-3",
+                    "name": "pool-c",
+                    "host": "localhost",
+                    "port": 8483,
+                    "type": "pool-type",
+                },
+            },
+        )
+
+        assert first["success"] is True
+        assert second["success"] is True
+        assert non_pooled_duplicate["success"] is False
+        assert non_pooled_duplicate["error"] == "duplicate_service_type"
+    finally:
+        server.enforce_unique_service_types = False
+
+
+@pytest.mark.asyncio
+async def test_server_register_rejects_conflicting_service_type_policy_flags(server, req_socket):
+    """A registration cannot request both singleton and allow_duplicate_service_type."""
+    response = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {
+                "id": "conflict-policy-id",
+                "name": "conflict-svc",
+                "host": "localhost",
+                "port": 8581,
+                "type": "conflict-type",
+                "singleton": True,
+                "allow_duplicate_service_type": True,
+            },
+        },
+    )
+
+    assert response["success"] is False
+    assert response["error"] == "invalid_service_type_policy"
+
+
+@pytest.mark.asyncio
 async def test_server_get_service(server, req_socket):
     """Test getting a service by ID."""
 

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -240,7 +240,7 @@ async def client(server, zmq_context):
     """
     Function-scoped fixture for AsyncRegistryClient with proper setup and teardown.
     """
-    with AsyncRegistryClient(
+    async with AsyncRegistryClient(
         registry_req_endpoint=f"tcp://localhost:{TEST_REQ_PORT}",
         registry_sub_endpoint=f"tcp://localhost:{TEST_PUB_PORT}",
         timeout=5000,  # 5 second timeout
@@ -377,6 +377,154 @@ async def test_server_register_service(server, req_socket, sub_socket):
     assert event["type"] == "register"
     assert "service_id" in event["data"]
     assert event["data"]["service_info"]["name"] == "test-service"
+
+
+@pytest.mark.asyncio
+async def test_server_register_duplicate_service_type_allowed_by_default(server, req_socket):
+    """Duplicate service types are allowed when uniqueness enforcement is disabled."""
+    server.enforce_unique_service_types = False
+
+    first = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {"name": "svc-a", "host": "localhost", "port": 8181, "type": "shared-type"},
+        },
+    )
+    second = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {"name": "svc-b", "host": "localhost", "port": 8182, "type": "shared-type"},
+        },
+    )
+
+    assert first["success"] is True
+    assert second["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_server_register_duplicate_service_type_rejected_in_unique_mode(server, req_socket):
+    """Duplicate service types are rejected when uniqueness enforcement is enabled."""
+    server.enforce_unique_service_types = True
+
+    try:
+        first = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "fixed-id-1",
+                    "name": "svc-a",
+                    "host": "localhost",
+                    "port": 8281,
+                    "type": "singleton-type",
+                },
+            },
+        )
+        second = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "fixed-id-2",
+                    "name": "svc-b",
+                    "host": "localhost",
+                    "port": 8282,
+                    "type": "singleton-type",
+                },
+            },
+        )
+        update_same_id = await send_request(
+            MessageType.REQUEST_WITH_REPLY,
+            req_socket,
+            {
+                "action": "register",
+                "service_info": {
+                    "id": "fixed-id-1",
+                    "name": "svc-a-updated",
+                    "host": "localhost",
+                    "port": 8283,
+                    "type": "singleton-type",
+                },
+            },
+        )
+
+        assert first["success"] is True
+        assert second["success"] is False
+        assert second["error"] == "duplicate_service_type"
+        assert second["service_type"] == "singleton-type"
+        assert second["existing_service_id"] == "fixed-id-1"
+        assert update_same_id["success"] is True
+    finally:
+        server.enforce_unique_service_types = False
+
+
+@pytest.mark.asyncio
+async def test_server_register_singleton_overrides_permissive_global(server, req_socket):
+    """A registration with singleton=True is rejected for duplicate types even when the global
+    enforce_unique_service_types flag is False."""
+    server.enforce_unique_service_types = False
+
+    first = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {
+                "id": "singleton-id-1",
+                "name": "svc-a",
+                "host": "localhost",
+                "port": 8381,
+                "type": "exclusive-type",
+                "singleton": True,
+            },
+        },
+    )
+    second = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {
+                "id": "singleton-id-2",
+                "name": "svc-b",
+                "host": "localhost",
+                "port": 8382,
+                "type": "exclusive-type",
+                "singleton": True,
+            },
+        },
+    )
+    # A non-singleton with the same type is also blocked because the first registrant claimed
+    # exclusivity; but if the second service does NOT set singleton it should still be blocked
+    # by the server if the first one did. No — the server only checks per-request; test that a
+    # non-singleton duplicate is allowed when the global flag is off.
+    non_singleton_duplicate = await send_request(
+        MessageType.REQUEST_WITH_REPLY,
+        req_socket,
+        {
+            "action": "register",
+            "service_info": {
+                "id": "non-singleton-id-3",
+                "name": "svc-c",
+                "host": "localhost",
+                "port": 8383,
+                "type": "exclusive-type",
+            },
+        },
+    )
+
+    assert first["success"] is True
+    assert second["success"] is False
+    assert second["error"] == "duplicate_service_type"
+    assert second["existing_service_id"] == "singleton-id-1"
+    # Non-singleton with same type is allowed when global flag is off
+    assert non_singleton_duplicate["success"] is True
 
 
 @pytest.mark.asyncio

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -14,14 +14,14 @@ import pytest
 import pytest_asyncio
 import zmq
 import zmq.asyncio
+from egse.log import logger
+from egse.system import type_name
 from fixtures.helpers import is_service_registry_running
 
-from egse.log import logger
 from egse.registry import MessageType
 from egse.registry.backend import AsyncInMemoryBackend
 from egse.registry.client import AsyncRegistryClient
 from egse.registry.server import AsyncRegistryServer
-from egse.system import type_name
 
 # Constants for testing
 TEST_REQ_PORT = 15556
@@ -153,6 +153,7 @@ async def server_health_check(zmq_context) -> bool:
 
                 if len(message_parts) >= 2:
                     message_type = MessageType(message_parts[0])
+                    assert message_type == MessageType.RESPONSE, f"Expected RESPONSE, got {message_type}"
                     message_data = message_parts[1]
 
                     response = json.loads(message_data)

--- a/projects/generic/symetrie-hexapod/tests/test_puna.py
+++ b/projects/generic/symetrie-hexapod/tests/test_puna.py
@@ -68,7 +68,6 @@ def skip_unavailable_proxy(exc: ConnectionError):
     indirect=True,
 )
 def test_context_manager_proxy_no_control_server(hexapod):
-
     print()
 
     dev = get_device(hexapod, "proxy")
@@ -85,7 +84,6 @@ def test_context_manager_proxy_no_control_server(hexapod):
     indirect=True,
 )
 def test_context_manager_simulator(hexapod):
-
     print()
 
     sim = get_device(hexapod, "simulator")
@@ -139,7 +137,6 @@ def test_connection_and_homing(hexapod, backend):
     indirect=True,
 )
 def test_hexapod_connect_and_ping(hexapod):
-
     def check_connect_hexapod(device):
         device.connect_cs()
         assert not device.ping()
@@ -160,7 +157,6 @@ def test_hexapod_connect_and_ping(hexapod):
 )
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_goto_position(hexapod, backend):
-
     dev = get_device(hexapod, backend)
 
     try:
@@ -272,7 +268,6 @@ def test_absolute_movement(hexapod, backend):
 )
 @pytest.mark.parametrize("backend", BACKENDS)
 def test_coordinates_systems(hexapod, backend):
-
     dev = get_device(hexapod, backend)
 
     try:

--- a/projects/generic/symetrie-hexapod/tests/test_puna_simulator.py
+++ b/projects/generic/symetrie-hexapod/tests/test_puna_simulator.py
@@ -47,7 +47,6 @@ def wait_until(condition, interval=0.1, timeout=1, *args):
     indirect=True,
 )
 def test_goto_zero_position(hexapod):
-
     try:
         rc = hexapod.goto_zero_position()
 


### PR DESCRIPTION
This pull request implements the possibility to have unique service types for all services in the registry service.  There can be multiple services with the same service types e.g. for pooling and load balancing, but the default now is set to strictly unique service types.

This update was inspired by the Hexapod update on `device_id` where the `device_id` is used as a `service_type` during registration and shall be unique in order to ensure the unique addressing of the correct hexapod controller/device.

Changes:
- Added a UNIQUE_SERVICE_TYPES flag in Settings, by default this flag is set to True (enforcing unique service types), but it can be changed in local settings.
- Updated start_rm_cs to accept enforce_unique_service_types/allow_duplicate_service_type parameter.
- Modified core services to pass enforce_unique_service_types option.
- Enhanced AsyncRegistryServer to handle unique service type enforcement.
- Added singleton option to service registration methods in RegistryClient.
- Added allow_duplicate_service_type option to service registration methods in RegistryClient.
- Introduced tests for duplicate and unique service type registration behavior.
