### PR TITLE
Release/v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-05-05
+
+- Service Registry now enforces unique service types by default (`UNIQUE_SERVICE_TYPES=true`). This prevents accidental duplicate registrations for the same service type.
+- Service registration now supports explicit duplicate policy flags:
+  - `singleton=True` to require uniqueness for a specific registration
+  - `allow_duplicate_service_type=True` to override global uniqueness enforcement for a specific registration
+  - invalid combinations are now rejected early (`singleton` and `allow_duplicate_service_type` cannot both be true)
+- Improved Symetrie hexapod connectivity and control-server behavior:
+  - Joran and Puna control server flows now consistently use device IDs
+  - proxy connection handling and error reporting were improved when discovering/connecting to control servers
+  - control-server start/stop logging and storage mnemonic handling were cleaned up for more predictable operations
+- Symetrie hexapod package now declares Python compatibility as `>=3.10,<3.13`.
+
 ## [0.22.2] - 2026-04-29
 
 - Fix hexapod simulator: Rename rotation configuration variable for clarity and fix reference_frame → ref
@@ -396,7 +409,8 @@ This release is mainly on maintenance and improvements to the `cgse-common` pack
 - Renamed `cgse` subcommands `registry` →  `reg`, `notify` →  `not`.
 
 
-[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.2...HEAD
+[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.2...v0.23.0
 [0.22.2]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.21.1...v0.22.0

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.22.2"
+version = "0.23.0"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.22.2"
+version = "0.23.0"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.22.2"
+version = "0.23.0"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.22.2"
+version = "0.23.0"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.22.2"
+version = "0.23.0"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.22.2"
+version = "0.23.0"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.22.2"
+version = "0.23.0"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.22.2"
+version = "0.23.0"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.22.2"
+version = "0.23.0"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.22.2"
+version = "0.23.0"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.22.2"
+version = "0.23.0"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.22.2"
+version = "0.23.0"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.22.2"
+version = "0.23.0"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.22.2"
+version = "0.23.0"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.22.2"
+version = "0.23.0"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.22.2"
+version = "0.23.0"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.22.2"
+version = "0.23.0"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
- Service Registry now enforces unique service types by default (`UNIQUE_SERVICE_TYPES=true`). This prevents accidental duplicate registrations for the same service type.
- Service registration now supports explicit duplicate policy flags:
  - `singleton=True` to require uniqueness for a specific registration
  - `allow_duplicate_service_type=True` to override global uniqueness enforcement for a specific registration
  - invalid combinations are now rejected early (`singleton` and `allow_duplicate_service_type` cannot both be true)
- Improved Symetrie hexapod connectivity and control-server behavior:
  - Joran and Puna control server flows now consistently use device IDs
  - proxy connection handling and error reporting were improved when discovering/connecting to control servers
  - control-server start/stop logging and storage mnemonic handling were cleaned up for more predictable operations
- Symetrie hexapod package now declares Python compatibility as `>=3.10,<3.13`.
