### PR TITLE
Implement service registration error handling and enhance metadata retrieval for hexapod control servers

### DIFF
--- a/libs/cgse-core/src/egse/connect.py
+++ b/libs/cgse-core/src/egse/connect.py
@@ -64,6 +64,51 @@ def get_endpoint(
     return endpoint
 
 
+def get_metadata_port(
+    service_type: str,
+    metadata_key: str,
+    static_port: int = 0,
+    protocol: str = "tcp",
+    hostname: str = "localhost",
+) -> tuple[str, str, int]:
+    """Return `(protocol, hostname, port)` for a port stored in service registry metadata.
+
+    If `static_port` is non-zero the values are returned immediately without
+    consulting the registry.  When it is 0 the registry is queried and the port
+    is read from `metadata[metadata_key]`.
+
+    Args:
+        service_type: Service type to look up when `static_port` is 0.
+        metadata_key: Key inside the service metadata dict, e.g. `"service_port"`.
+        static_port: Pre-configured port; skips registry when non-zero.
+        protocol: Protocol to use for the static case.
+        hostname: Hostname to use for the static case.
+
+    Returns:
+        A `(protocol, hostname, port)` tuple.
+
+    Raises:
+        RuntimeError: If `static_port` is 0 and the service is not registered or
+            the metadata key is missing.
+    """
+    if static_port:
+        return protocol, hostname, static_port
+
+    from egse.registry.client import RegistryClient
+
+    with RegistryClient() as reg:
+        service = reg.discover_service(service_type)
+
+    if not service:
+        raise RuntimeError(f"No service registered as '{service_type}' and no static port provided.")
+
+    port = service.get("metadata", {}).get(metadata_key)
+    if not port:
+        raise RuntimeError(f"Service '{service_type}' has no '{metadata_key}' in its metadata.")
+
+    return service.get("protocol", "tcp"), service.get("host", "localhost"), port
+
+
 class ConnectionState(Enum):
     DISCONNECTED = "disconnected"
     CONNECTING = "connecting"

--- a/libs/cgse-core/src/egse/control.py
+++ b/libs/cgse-core/src/egse/control.py
@@ -92,6 +92,10 @@ def is_control_server_active(endpoint: str = None, timeout: float = 0.5) -> bool
     return return_code
 
 
+class ServiceRegistrationError(RuntimeError):
+    """Raised when a control server fails to register itself with the service registry."""
+
+
 class ControlServer(metaclass=abc.ABCMeta):
     """Base class for all device control servers and for the Storage Manager and Configuration Manager.
 
@@ -133,6 +137,9 @@ class ControlServer(metaclass=abc.ABCMeta):
 
         self.registry = RegistryClient()
         self.registry.connect()
+
+        self.service_id: str | None = None
+        """The service ID of this Control Server, as registered in the Service Registry."""
 
         # These instance variables will probably be overwritten by the subclass __init__
         self.service_type = camel_to_kebab(type(self).__name__)
@@ -675,13 +682,21 @@ class ControlServer(metaclass=abc.ABCMeta):
         self.signaling.start_monitoring()
         self.signaling.register_handler("reregister", self.reregister_service)
 
+    def can_operate_without_registry(self) -> bool:
+        """Returns True when this server can still operate without being registered.
+
+        The default is strict: registration is required. Subclasses with explicitly
+        configured, externally known endpoints may override this policy hook.
+        """
+        return False
+
     def register_service(self, service_type: str) -> None:
         self.logger.info(f"Registering service {self.service_name} as type {service_type}")
 
         self.service_type = service_type
 
         self.registry.stop_heartbeat()
-        self.registry.register(
+        self._service_id = self.registry.register(
             name=self.service_name,
             host=get_host_ip() or "127.0.0.1",
             port=get_port_number(self.dev_ctrl_cmd_sock),
@@ -691,10 +706,25 @@ class ControlServer(metaclass=abc.ABCMeta):
                 "monitoring_port": get_port_number(self.dev_ctrl_mon_sock),
             },
         )
-        self.registry.start_heartbeat()
+        if self._service_id:
+            self.registry.start_heartbeat()
+        elif self.can_operate_without_registry():
+            self.logger.warning(
+                f"Failed to register '{self.service_name}' as service type '{service_type}'. "
+                f"Continuing because this server is configured to operate without the registry."
+            )
+        else:
+            raise ServiceRegistrationError(
+                f"Failed to register '{self.service_name}' as service type '{service_type}'. "
+                f"The registry may be unavailable or this service type is already registered."
+            )
 
     def deregister_service(self):
-        if self.registry:
+        self.logger.info(
+            f"De-registering control server {self.service_name} from service registry "
+            f"(service type = {self.service_type})."
+        )
+        if self._service_id:
             self.registry.stop_heartbeat()
             self.registry.deregister()
 

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_cs.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/joran_cs.py
@@ -24,10 +24,12 @@ import click
 import rich
 import typer
 import zmq
+from egse.connect import get_endpoint
+from egse.connect import get_metadata_port
 from egse.control import ControlServer, is_control_server_active
 from egse.process import SubProcess
+from egse.services import ServiceProxy
 from egse.settings import Settings
-from egse.zmq_ser import connect_address
 from prometheus_client import start_http_server
 
 from egse.hexapod.symetrie.joran import JoranProxy
@@ -36,6 +38,12 @@ from egse.hexapod.symetrie.joran_protocol import JoranProtocol
 logger = logging.getLogger(__name__)
 
 CTRL_SETTINGS = Settings.load("Hexapod Control Server")["JORAN"]
+
+PROTOCOL = CTRL_SETTINGS.get("PROTOCOL", "tcp")
+HOSTNAME = CTRL_SETTINGS.get("HOSTNAME", "localhost")
+COMMANDING_PORT = CTRL_SETTINGS.get("COMMANDING_PORT", 0)
+SERVICE_PORT = CTRL_SETTINGS.get("SERVICE_PORT", 0)
+MONITORING_PORT = CTRL_SETTINGS.get("MONITORING_PORT", 0)
 
 
 class JoranControlServer(ControlServer):
@@ -69,23 +77,27 @@ class JoranControlServer(ControlServer):
 
         self.poller.register(self.dev_ctrl_cmd_sock, zmq.POLLIN)
 
+        self.service_name = "joran_cs"
+        self.service_type = device_id
+        self.register_service(service_type=self.service_type)
+
     def get_communication_protocol(self):
-        return CTRL_SETTINGS["PROTOCOL"]
+        return PROTOCOL
 
     def get_commanding_port(self):
-        return CTRL_SETTINGS["COMMANDING_PORT"]
+        return COMMANDING_PORT
 
     def get_service_port(self):
-        return CTRL_SETTINGS["SERVICE_PORT"]
+        return SERVICE_PORT
 
     def get_monitoring_port(self):
-        return CTRL_SETTINGS["MONITORING_PORT"]
+        return MONITORING_PORT
+
+    def can_operate_without_registry(self) -> bool:
+        return bool(COMMANDING_PORT and SERVICE_PORT and MONITORING_PORT)
 
     def get_storage_mnemonic(self):
-        try:
-            return CTRL_SETTINGS["STORAGE_MNEMONIC"]
-        except AttributeError:
-            return "JORAN"
+        return CTRL_SETTINGS.get("STORAGE_MNEMONIC", "JORAN")
 
     def before_serve(self):
         start_http_server(CTRL_SETTINGS["METRICS_PORT"])
@@ -130,22 +142,53 @@ def stop(device_id: str):
     """Send a 'quit_server' command to the Hexapod Joran Control Server."""
 
     try:
-        with JoranProxy(device_id) as proxy:
-            sp = proxy.get_service_proxy()
-            sp.quit_server()
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError as exc:
+        rich.print(f"[red]{exc}")
+        return
+
+    proxy = ServiceProxy(protocol=PROTOCOL, hostname=hostname, port=service_port)
+    try:
+        proxy.quit_server()
     except ConnectionError:
-        rich.print("[red]Couldn't connect to 'joran_cs', process probably not running. ")
+        rich.print("[red]Couldn't connect to 'joran_cs', process probably not running.")
 
 
 @app.command()
 def status(device_id: str):
     """Request status information from the Control Server."""
 
-    protocol = CTRL_SETTINGS["PROTOCOL"]
-    hostname = CTRL_SETTINGS["HOSTNAME"]
-    port = CTRL_SETTINGS["COMMANDING_PORT"]
+    try:
+        endpoint = get_endpoint(service_type=device_id, protocol=PROTOCOL, hostname=HOSTNAME, port=COMMANDING_PORT)
+        commanding_port = int(endpoint.rsplit(":", maxsplit=1)[-1])
 
-    endpoint = connect_address(protocol, hostname, port)
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+        _, _, monitoring_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="monitoring_port",
+            static_port=MONITORING_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError:
+        rich.print(
+            f"[red]The JORAN CS '{device_id}' isn't registered as a service. I cannot contact the control "
+            f"server without the required info from the service registry.[/]"
+        )
+        rich.print("JORAN Hexapod: [red]not active")
+        return
 
     if is_control_server_active(endpoint):
         rich.print("JORAN Hexapod: [green]active")
@@ -156,7 +199,9 @@ def status(device_id: str):
             rich.print(f"type: ALPHA+")
             rich.print(f"mode: {'simulator' if sim else 'device'}{'' if connected else ' not'} connected")
             rich.print(f"hostname: {ip}")
-            rich.print(f"commanding port: {port}")
+            rich.print(f"commanding port: {commanding_port}")
+            rich.print(f"service port: {service_port}")
+            rich.print(f"monitoring port: {monitoring_port}")
     else:
         rich.print("JORAN Hexapod: [red]not active")
 

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_cs.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/puna_cs.py
@@ -24,19 +24,25 @@ import typer
 import zmq
 from prometheus_client import start_http_server
 
+from egse.connect import get_endpoint
+from egse.connect import get_metadata_port
 from egse.control import ControlServer
 from egse.control import is_control_server_active
 from egse.hexapod.symetrie import ProxyFactory
 from egse.hexapod.symetrie import get_hexapod_controller_pars
 from egse.hexapod.symetrie import logger
 from egse.hexapod.symetrie.puna_protocol import PunaProtocol
-from egse.registry.client import RegistryClient
 from egse.services import ServiceProxy
 from egse.settings import Settings
 from egse.storage import store_housekeeping_information
-from egse.zmq_ser import connect_address
 
 CTRL_SETTINGS = Settings.load("Hexapod Control Server")["PUNA"]
+
+PROTOCOL = CTRL_SETTINGS.get("PROTOCOL", "tcp")
+HOSTNAME = CTRL_SETTINGS.get("HOSTNAME", "localhost")
+COMMANDING_PORT = CTRL_SETTINGS.get("COMMANDING_PORT", 0)
+SERVICE_PORT = CTRL_SETTINGS.get("SERVICE_PORT", 0)
+MONITORING_PORT = CTRL_SETTINGS.get("MONITORING_PORT", 0)
 
 
 class PunaControlServer(ControlServer):
@@ -72,19 +78,24 @@ class PunaControlServer(ControlServer):
 
         self.poller.register(self.dev_ctrl_cmd_sock, zmq.POLLIN)
 
-        self.register_service(service_type=f"{device_id}")
+        self.service_name = "puna_cs"
+        self.service_type = device_id
+        self.register_service(service_type=self.service_type)
 
     def get_communication_protocol(self):
-        return CTRL_SETTINGS["PROTOCOL"]
+        return PROTOCOL
 
     def get_commanding_port(self):
-        return CTRL_SETTINGS["COMMANDING_PORT"]
+        return COMMANDING_PORT
 
     def get_service_port(self):
-        return CTRL_SETTINGS["SERVICE_PORT"]
+        return SERVICE_PORT
 
     def get_monitoring_port(self):
-        return CTRL_SETTINGS["MONITORING_PORT"]
+        return MONITORING_PORT
+
+    def can_operate_without_registry(self) -> bool:
+        return bool(COMMANDING_PORT and SERVICE_PORT and MONITORING_PORT)
 
     def get_storage_mnemonic(self):
         return CTRL_SETTINGS.get("STORAGE_MNEMONIC", "PUNA")
@@ -151,8 +162,10 @@ def start(
         print(f"System Exit with code {exc.code}")
         sys.exit(exit_code)
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Cannot start the Hexapod Puna Control Server")
+
+        rich.print(f"[red]ERROR: Cannot start the Hexapod PUNA Control Server: {exc}")
 
         # The above line does exactly the same as the traceback, but on the logger
         # import traceback
@@ -165,23 +178,23 @@ def start(
 def stop(device_id: str):
     """Send a 'quit_server' command to the Hexapod Puna Control Server."""
 
-    with RegistryClient() as reg:
-        service = reg.discover_service(device_id)
-        rich.print("service = ", service)
+    try:
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError as exc:
+        rich.print(f"[red]{exc}")
+        return
 
-        if service:
-            proxy = ServiceProxy(protocol="tcp", hostname=service["host"], port=service["metadata"]["service_port"])
-            proxy.quit_server()
-        else:
-            *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
-
-            factory = ProxyFactory()
-            try:
-                with factory.create(device_type, device_id=device_id) as proxy:
-                    sp = proxy.get_service_proxy()
-                    sp.quit_server()
-            except ConnectionError:
-                rich.print("[red]Couldn't connect to 'puna_cs', process probably not running. ")
+    proxy = ServiceProxy(protocol=PROTOCOL, hostname=hostname, port=service_port)
+    try:
+        proxy.quit_server()
+    except ConnectionError:
+        rich.print("[red]Couldn't connect to 'puna_cs', process probably not running.")
 
 
 @app.command()
@@ -190,38 +203,46 @@ def status(device_id: str):
 
     *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
 
-    with RegistryClient() as reg:
-        service = reg.discover_service(device_id)
-        # rich.print("service = ", service)
+    try:
+        endpoint = get_endpoint(service_type=device_id, protocol=PROTOCOL, hostname=HOSTNAME, port=COMMANDING_PORT)
+        commanding_port = int(endpoint.rsplit(":", maxsplit=1)[-1])
 
-        if service:
-            protocol = service.get("protocol", "tcp")
-            hostname = service["host"]
-            port = service["port"]
-            service_port = service["metadata"]["service_port"]
-            monitoring_port = service["metadata"]["monitoring_port"]
-            endpoint = connect_address(protocol, hostname, port)
-            # rich.print(f"{endpoint = }")
-        else:
-            rich.print(
-                f"[red]The PUNA CS '{device_id}' isn't registered as a service. I cannot contact the control "
-                f"server without the required info from the service registry.[/]"
-            )
-            rich.print("PUNA Hexapod: [red]not active")
-            return
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+        _, _, monitoring_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="monitoring_port",
+            static_port=MONITORING_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError:
+        rich.print(
+            f"[red]The PUNA CS '{device_id}' isn't registered as a service. I cannot contact the control "
+            f"server without the required info from the service registry.[/]"
+        )
+        rich.print("PUNA Hexapod: [red]not active")
+        return
 
     factory = ProxyFactory()
 
     if is_control_server_active(endpoint):
         rich.print("PUNA Hexapod: [green]active")
-        with factory.create(device_type, device_id=device_id, protocol=protocol, hostname=hostname, port=port) as puna:
+        with factory.create(
+            device_type, device_id=device_id, protocol=PROTOCOL, hostname=hostname, port=commanding_port
+        ) as puna:
             sim = puna.is_simulator()
             connected = puna.is_connected()
             ip = puna.get_ip_address()
             rich.print(f"type: {controller_type}")
             rich.print(f"mode: {'simulator' if sim else 'device'}{'' if connected else ' not'} connected")
             rich.print(f"hostname: {ip}")
-            rich.print(f"commanding port: {port}")
+            rich.print(f"commanding port: {commanding_port}")
             rich.print(f"service port: {service_port}")
             rich.print(f"monitoring port: {monitoring_port}")
     else:

--- a/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_cs.py
+++ b/projects/generic/symetrie-hexapod/src/egse/hexapod/symetrie/zonda_cs.py
@@ -24,19 +24,25 @@ import typer
 import zmq
 from prometheus_client import start_http_server
 
+from egse.connect import get_endpoint
+from egse.connect import get_metadata_port
 from egse.control import ControlServer
 from egse.control import is_control_server_active
 from egse.hexapod.symetrie import ProxyFactory
 from egse.hexapod.symetrie import get_hexapod_controller_pars
 from egse.hexapod.symetrie import logger
 from egse.hexapod.symetrie.zonda_protocol import ZondaProtocol
-from egse.registry.client import RegistryClient
 from egse.services import ServiceProxy
 from egse.settings import Settings
 from egse.storage import store_housekeeping_information
-from egse.zmq_ser import connect_address
 
 CTRL_SETTINGS = Settings.load("Hexapod Control Server")["ZONDA"]
+
+PROTOCOL = CTRL_SETTINGS.get("PROTOCOL", "tcp")
+HOSTNAME = CTRL_SETTINGS.get("HOSTNAME", "localhost")
+COMMANDING_PORT = CTRL_SETTINGS.get("COMMANDING_PORT", 0)
+SERVICE_PORT = CTRL_SETTINGS.get("SERVICE_PORT", 0)
+MONITORING_PORT = CTRL_SETTINGS.get("MONITORING_PORT", 0)
 
 
 class ZondaControlServer(ControlServer):
@@ -74,22 +80,22 @@ class ZondaControlServer(ControlServer):
         self.register_service(service_type=f"{device_id}")
 
     def get_communication_protocol(self):
-        return CTRL_SETTINGS["PROTOCOL"]
+        return PROTOCOL
 
     def get_commanding_port(self):
-        return CTRL_SETTINGS["COMMANDING_PORT"]
+        return COMMANDING_PORT
 
     def get_service_port(self):
-        return CTRL_SETTINGS["SERVICE_PORT"]
+        return SERVICE_PORT
 
     def get_monitoring_port(self):
-        return CTRL_SETTINGS["MONITORING_PORT"]
+        return MONITORING_PORT
+
+    def can_operate_without_registry(self) -> bool:
+        return bool(COMMANDING_PORT and SERVICE_PORT and MONITORING_PORT)
 
     def get_storage_mnemonic(self):
-        try:
-            return CTRL_SETTINGS["STORAGE_MNEMONIC"]
-        except AttributeError:
-            return "ZONDA"
+        return CTRL_SETTINGS.get("STORAGE_MNEMONIC", "ZONDA")
 
     def is_storage_manager_active(self):
         from egse.storage import is_storage_manager_active
@@ -165,23 +171,23 @@ def start(
 def stop(device_id: str):
     """Send a 'quit_server' command to the Hexapod Zonda Control Server."""
 
-    with RegistryClient() as reg:
-        service = reg.discover_service(device_id)
-        rich.print("service = ", service)
+    try:
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError as exc:
+        rich.print(f"[red]{exc}")
+        return
 
-        if service:
-            proxy = ServiceProxy(protocol="tcp", hostname=service["host"], port=service["metadata"]["service_port"])
-            proxy.quit_server()
-        else:
-            *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
-
-            factory = ProxyFactory()
-            try:
-                with factory.create(device_type, device_id=device_id) as proxy:
-                    sp = proxy.get_service_proxy()
-                    sp.quit_server()
-            except ConnectionError:
-                rich.print("[red]Couldn't connect to 'zonda_cs', process probably not running. ")
+    proxy = ServiceProxy(protocol=PROTOCOL, hostname=hostname, port=service_port)
+    try:
+        proxy.quit_server()
+    except ConnectionError:
+        rich.print("[red]Couldn't connect to 'zonda_cs', process probably not running.")
 
 
 @app.command()
@@ -190,38 +196,46 @@ def status(device_id: str):
 
     *_, device_type, controller_type = get_hexapod_controller_pars(device_id)
 
-    with RegistryClient() as reg:
-        service = reg.discover_service(device_id)
-        # rich.print("service = ", service)
+    try:
+        endpoint = get_endpoint(service_type=device_id, protocol=PROTOCOL, hostname=HOSTNAME, port=COMMANDING_PORT)
+        commanding_port = int(endpoint.rsplit(":", maxsplit=1)[-1])
 
-        if service:
-            protocol = service.get("protocol", "tcp")
-            hostname = service["host"]
-            port = service["port"]
-            service_port = service["metadata"]["service_port"]
-            monitoring_port = service["metadata"]["monitoring_port"]
-            endpoint = connect_address(protocol, hostname, port)
-            # rich.print(f"{endpoint = }")
-        else:
-            rich.print(
-                f"[red]The ZONDA CS '{device_id}' isn't registered as a service. I cannot contact the control "
-                f"server without the required info from the service registry.[/]"
-            )
-            rich.print("ZONDA Hexapod: [red]inactive")
-            return
+        _, hostname, service_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="service_port",
+            static_port=SERVICE_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+        _, _, monitoring_port = get_metadata_port(
+            service_type=device_id,
+            metadata_key="monitoring_port",
+            static_port=MONITORING_PORT,
+            protocol=PROTOCOL,
+            hostname=HOSTNAME,
+        )
+    except RuntimeError:
+        rich.print(
+            f"[red]The ZONDA CS '{device_id}' isn't registered as a service. I cannot contact the control "
+            f"server without the required info from the service registry.[/]"
+        )
+        rich.print("ZONDA Hexapod: [red]inactive")
+        return
 
     factory = ProxyFactory()
 
     if is_control_server_active(endpoint):
         rich.print("ZONDA Hexapod: [green]active")
-        with factory.create(device_type, device_id=device_id, protocol=protocol, hostname=hostname, port=port) as zonda:
+        with factory.create(
+            device_type, device_id=device_id, protocol=PROTOCOL, hostname=hostname, port=commanding_port
+        ) as zonda:
             sim = zonda.is_simulator()
             connected = zonda.is_connected()
             ip = zonda.get_ip_address()
             rich.print(f"type: {controller_type}")
             rich.print(f"mode: {'simulator' if sim else 'device'}{'' if connected else ' not'} connected")
             rich.print(f"hostname: {ip}")
-            rich.print(f"commanding port: {port}")
+            rich.print(f"commanding port: {commanding_port}")
             rich.print(f"service port: {service_port}")
             rich.print(f"monitoring port: {monitoring_port}")
 

--- a/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
+++ b/projects/generic/symetrie-hexapod/src/symetrie_hexapod/cgse_services.py
@@ -160,3 +160,39 @@ def status_zonda(device_id: str):
         from egse.hexapod.symetrie import zonda_cs
 
         zonda_cs.status(device_id)
+
+
+# ---------- JORAN Commands --------------------------------------------------------------------------------------------
+
+
+@joran.command(name="start")
+def start_joran(
+    device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")],
+    simulator: Annotated[
+        bool, typer.Option("--simulator", "--sim", help="use a device simulator as the backend")
+    ] = False,
+):
+    """
+    Start the JORAN hexapod control server. The control server is always started in the background.
+    """
+
+    start_hexapod_cs_process("JORAN", device_id, simulator)
+
+
+@joran.command(name="stop")
+def stop_joran(
+    device_id: Annotated[str, typer.Argument(help="the device identifier, identifies the hardware controller")],
+):
+    """Stop the JORAN hexapod control server."""
+
+    stop_hexapod_cs_process("JORAN", device_id)
+
+
+@joran.command(name="status")
+def status_joran(device_id: str):
+    """Print status information on the JORAN hexapod control server."""
+
+    with all_logging_disabled():
+        from egse.hexapod.symetrie import joran_cs
+
+        joran_cs.status(device_id)

--- a/projects/generic/symetrie-hexapod/src/symetrie_hexapod/settings.yaml
+++ b/projects/generic/symetrie-hexapod/src/symetrie_hexapod/settings.yaml
@@ -2,40 +2,47 @@ PACKAGES:
     SYMETRIE_HEXAPOD: Device driver for the Symétrie Hexapods PUNA, ZONDA, and JORAN
 
 Hexapod Controller:
+    PUNA:
+        HOSTNAME:           localhost
+        PORT:               1025
+        CONTROLLER_TYPE:    alpha
+        DEVICE_NAME:        Puna Hexapod
+        DEVICE_TYPE:        PUNA
+
     PUNA_PLUS:
-        HOSTNAME: localhost
-        PORT: 1025
-        CONTROLLER_TYPE: alpha_plus
-        DEVICE_NAME: Puna Hexapod
-        DEVICE_TYPE: PUNA
-        user_name: provide username in local settings
-        password: provide password in local settings
+        HOSTNAME:           localhost
+        PORT:               1025
+        CONTROLLER_TYPE:    alpha_plus
+        DEVICE_NAME:        Puna Hexapod
+        DEVICE_TYPE:        PUNA
+        user_name:          provide username in local settings
+        password:           provide password in local settings
 
     ZONDA:
-        HOSTNAME: localhost
-        PORT: 1025
-        CONTROLLER_TYPE: alpha_plus
-        DEVICE_NAME: Zonda Hexapod
-        DEVICE_TYPE: ZONDA
+        HOSTNAME:           localhost
+        PORT:               1025
+        CONTROLLER_TYPE:    alpha_plus
+        DEVICE_NAME:        Zonda Hexapod
+        DEVICE_TYPE:        ZONDA
 
     JORAN:
-        HOSTNAME: localhost
-        PORT: 1025
-        CONTROLLER_TYPE: alpha_plus
-        DEVICE_NAME: Joran Hexapod
-        DEVICE_TYPE: JORAN
+        HOSTNAME:           localhost
+        PORT:               1025
+        CONTROLLER_TYPE:    alpha_plus
+        DEVICE_NAME:        Joran Hexapod
+        DEVICE_TYPE:        JORAN
 
 Hexapod Control Server:
     PUNA:
-        SERVICE_TYPE: puna
-        PROTOCOL: tcp
-        HOSTNAME: localhost
-        COMMANDING_PORT: 0
-        MONITORING_PORT: 0
-        SERVICE_PORT: 0
-        METRICS_PORT: 0
-    PUNA_PLUS:
         SERVICE_TYPE:       puna
+        PROTOCOL:           tcp
+        HOSTNAME:           localhost
+        COMMANDING_PORT:    0
+        MONITORING_PORT:    0
+        SERVICE_PORT:       0
+        METRICS_PORT:       0
+    PUNA_PLUS:
+        SERVICE_TYPE:       puna-plus
         PROTOCOL:           tcp
         HOSTNAME:           localhost
         COMMANDING_PORT:    0


### PR DESCRIPTION
**Service registration error handling & hexapod metadata retrieval**

- Add `get_metadata_port()` helper to `connect.py` for looking up ports from service registry metadata, with static-port fallback.
- Add `ServiceRegistrationError` to `control.py`; `ControlServer.register_service()` now raises it on failure unless `can_operate_without_registry()` returns `True`.
- `deregister_service()` guards against deregistering a server that was never registered.
- Override `can_operate_without_registry()` in `PunaControlServer`, `ZondaControlServer`, and `JoranControlServer` to allow static-port operation.
- Refactor `stop`/`status` CLI commands in all three hexapod CS modules to use the new helpers instead of raw `RegistryClient` calls; add user-friendly error messages.
- Add missing JORAN start/stop/status commands to `cgse_services.py`.
- Fix duplicate/missing `PUNA`/`PUNA_PLUS` entries in `settings.yaml` and correct `SERVICE_TYPE` for `PUNA_PLUS`.