### PR TITLE
Include main and develop branches in GH Workflow

### DIFF
--- a/.github/workflows/ruff-format-check.yaml
+++ b/.github/workflows/ruff-format-check.yaml
@@ -3,6 +3,10 @@ name: Ruff Formatting Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   ruff-format:


### PR DESCRIPTION
The current Ruff GitHub workflow runs on PRs. I would argue it's a good idea to also run the workflow when pushing to the `main` and `develop` branches. This is helpful when we push directly to those branches (but of course we all follow only the best of the best git habits, so this will never happen ...) and it's also good to see the check state on the branch directly.