### PR TITLE
root cgse archive (sdist and wheel) now carry a minimal set of files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,15 @@ extend-select = ["E", "W"]
 [tool.ruff.lint.isort]
 force-single-line = true
 
+
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+    "bump.py"
+]
+
 [tool.hatch.build.targets.wheel]
 only-include = ["bump.py", "README.md"]
 


### PR DESCRIPTION
For a monorepo root like the `cgse`, the sdist should not bundle the member package source trees. Each package under libs and projects already has its own sdist/wheel; the root project is just the meta package.