### PR TITLE
feature: Introduce line protocol schema support for QuestDB

### DIFF
--- a/libs/cgse-common/src/egse/plugins/metrics/duckdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/duckdb.py
@@ -22,7 +22,7 @@ class DuckDBRepository(TimeSeriesRepository):
 
     DuckDB stores time-series data in a table with columns for:
     - measurement: The measurement name (like table name in InfluxDB)
-    - timestamp: Time column
+    - time: Time column
     - tags: JSON object storing tag key-value pairs
     - fields: JSON object storing field key-value pairs
     """
@@ -50,7 +50,7 @@ class DuckDBRepository(TimeSeriesRepository):
                 f"""
                 CREATE TABLE IF NOT EXISTS {self.table_name} (
                     measurement VARCHAR NOT NULL,
-                    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+                    time TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
                     tags JSON,
                     fields JSON,
                     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
@@ -68,8 +68,8 @@ class DuckDBRepository(TimeSeriesRepository):
 
             self.conn.execute(
                 f"""
-                CREATE INDEX IF NOT EXISTS idx_{self.table_name}_timestamp
-                ON {self.table_name}(timestamp)
+                CREATE INDEX IF NOT EXISTS idx_{self.table_name}_time
+                ON {self.table_name}(time)
             """
             )
 
@@ -79,7 +79,7 @@ class DuckDBRepository(TimeSeriesRepository):
                 CREATE OR REPLACE VIEW {self.table_name}_flat AS
                 SELECT
                     measurement,
-                    timestamp,
+                    time,
                     tags,
                     fields,
                     created_at,
@@ -193,7 +193,7 @@ class DuckDBRepository(TimeSeriesRepository):
             return
 
         table = self._quote_identifier(measurement)
-        columns = ["timestamp TIMESTAMPTZ"]
+        columns = ["time TIMESTAMPTZ"]
         for column in schema.tags:
             columns.append(f"{self._quote_identifier(column.name)} {self._duckdb_type(column.data_type)}")
         for column in schema.fields:
@@ -213,7 +213,7 @@ class DuckDBRepository(TimeSeriesRepository):
         assert self.conn is not None
 
         table = self._quote_identifier(measurement)
-        column_names = ["timestamp"]
+        column_names = ["time"]
         column_names.extend(column.name for column in schema.tags)
         column_names.extend(column.name for column in schema.fields)
 
@@ -279,7 +279,7 @@ class DuckDBRepository(TimeSeriesRepository):
                 generic_data.append(
                     {
                         "measurement": measurement,
-                        "timestamp": timestamp,
+                        "time": timestamp,
                         "tags": json.dumps(tags) if isinstance(tags, dict) else tags,
                         "fields": json.dumps(fields) if isinstance(fields, dict) else fields,
                     }
@@ -292,11 +292,11 @@ class DuckDBRepository(TimeSeriesRepository):
             placeholders = ", ".join(["(?, ?, ?, ?)"] * len(generic_data))
             values = []
             for row in generic_data:
-                values.extend([row["measurement"], row["timestamp"], row["tags"], row["fields"]])
+                values.extend([row["measurement"], row["time"], row["tags"], row["fields"]])
 
             self.conn.execute(
                 f"""
-                INSERT INTO {self.table_name} (measurement, timestamp, tags, fields)
+                INSERT INTO {self.table_name} (measurement, time, tags, fields)
                 VALUES {placeholders}
                 """,
                 values,
@@ -344,7 +344,7 @@ class DuckDBRepository(TimeSeriesRepository):
             # Get basic schema
             columns = [
                 {"column_name": "measurement", "data_type": "VARCHAR", "is_nullable": "NO"},
-                {"column_name": "timestamp", "data_type": "TIMESTAMPTZ", "is_nullable": "YES"},
+                {"column_name": "time", "data_type": "TIMESTAMPTZ", "is_nullable": "YES"},
                 {"column_name": "tags", "data_type": "JSON", "is_nullable": "YES"},
                 {"column_name": "fields", "data_type": "JSON", "is_nullable": "YES"},
                 {"column_name": "created_at", "data_type": "TIMESTAMPTZ", "is_nullable": "YES"},
@@ -426,7 +426,7 @@ class DuckDBRepository(TimeSeriesRepository):
             col_name = col["column_name"]
             col_type = col.get("column_type", "")
 
-            if col_name == "timestamp":
+            if col_name == "time":
                 schema["time_column"] = col
             elif col_type == "tag" or col_name.startswith("tag_"):
                 schema["tag_columns"].append(col)
@@ -475,10 +475,10 @@ class DuckDBRepository(TimeSeriesRepository):
             assert self.conn.description is not None  # for type checker
 
             query = f"""
-                SELECT measurement, timestamp, tags, fields, created_at
+                SELECT measurement, time, tags, fields, created_at
                 FROM {self.table_name}
                 WHERE measurement = ?
-                ORDER BY timestamp DESC, created_at DESC
+                ORDER BY time DESC, created_at DESC
                 LIMIT ?
             """
 
@@ -516,8 +516,8 @@ class DuckDBRepository(TimeSeriesRepository):
                 SELECT
                     measurement,
                     COUNT(*) as record_count,
-                    MIN(timestamp) as earliest_timestamp,
-                    MAX(timestamp) as latest_timestamp,
+                    MIN(time) as earliest_timestamp,
+                    MAX(time) as latest_timestamp,
                     COUNT(DISTINCT json_object_keys(json(tags))) as unique_tag_keys,
                     COUNT(DISTINCT json_object_keys(json(fields))) as unique_field_keys
                 FROM {self.table_name}
@@ -550,10 +550,10 @@ class DuckDBRepository(TimeSeriesRepository):
                 where_clause = f" AND {where_clause}"
 
             query = f"""
-                SELECT measurement, timestamp, tags, fields, created_at
+                SELECT measurement, time, tags, fields, created_at
                 FROM {self.table_name}
                 WHERE measurement = ?{where_clause}
-                ORDER BY timestamp DESC
+                ORDER BY time DESC
                 LIMIT ?
             """
 
@@ -597,12 +597,12 @@ class DuckDBRepository(TimeSeriesRepository):
 
             query = f"""
                 SELECT
-                    date_trunc('{time_bucket}', timestamp) as time_bucket,
+                    date_trunc('{time_bucket}', time) as time_bucket,
                     {agg_func}(CAST(json_extract_string(fields, '$.{field_name}') AS DOUBLE)) as {field_name}_{agg_func.lower()}
                 FROM {self.table_name}
                 WHERE measurement = ?
                 AND json_extract_string(fields, '$.{field_name}') IS NOT NULL
-                GROUP BY date_trunc('{time_bucket}', timestamp)
+                GROUP BY date_trunc('{time_bucket}', time)
                 ORDER BY time_bucket
             """
 

--- a/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/influxdb.py
@@ -32,7 +32,6 @@ __all__ = [
 ]
 
 import logging
-import math
 from datetime import datetime
 from datetime import timezone
 
@@ -50,6 +49,7 @@ from egse.env import int_env
 from egse.env import str_env
 from egse.metrics import PointLike
 from egse.metrics import TimeSeriesRepository
+from egse.plugins.metrics.line_protocol import to_line_protocol
 from egse.system import type_name
 
 logger = logging.getLogger("egse.plugins")
@@ -221,83 +221,8 @@ class InfluxDBRepository(TimeSeriesRepository):
 
     @staticmethod
     def _to_line_protocol(payload: dict) -> str | None:
-        """Convert a DataPoint-style dict to an InfluxDB line protocol string.
-
-        Args:
-            payload: Dictionary with `measurement`, optional `tags`, `fields`,
-                and optional `time`.
-
-        Returns:
-            A line-protocol string when conversion succeeds, otherwise `None`.
-
-        Rules:
-            - Missing/empty measurement returns `None`.
-            - `fields` must contain at least one supported non-`None` value,
-              otherwise `None` is returned.
-            - `tags` with `None` values are skipped.
-            - Float `NaN`/`Inf` values are skipped.
-            - `time` supports Unix seconds (int/float) or ISO-8601 string and is
-              emitted as nanoseconds.
-        """
-        measurement = payload.get("measurement", "")
-        if not measurement:
-            return None
-
-        fields = payload.get("fields") or {}
-        tags = payload.get("tags") or {}
-        timestamp = payload.get("time")
-
-        def _esc(s: str) -> str:
-            """Escape commas, equals signs, and spaces in tag/field keys and tag values."""
-            return s.replace(",", "\\,").replace("=", "\\=").replace(" ", "\\ ")
-
-        def _field_val(v: object) -> str | None:
-            if isinstance(v, bool):
-                return "true" if v else "false"
-            if isinstance(v, int):
-                return f"{v}i"
-            if isinstance(v, float):
-                if not math.isfinite(v):
-                    return None
-                return repr(v)
-            if isinstance(v, str):
-                return '"' + v.replace("\\", "\\\\").replace('"', '\\"') + '"'
-            return None
-
-        # measurement[,tag=val ...]
-        meas_escaped = measurement.replace(",", "\\,").replace(" ", "\\ ")
-        parts = [meas_escaped]
-        if tags:
-            tag_str = ",".join(f"{_esc(str(k))}={_esc(str(v))}" for k, v in sorted(tags.items()) if v is not None)
-            if tag_str:
-                parts.append("," + tag_str)
-
-        # field_key=field_val[,...]
-        field_parts = []
-        for k, v in fields.items():
-            if v is None:
-                continue
-            fv = _field_val(v)
-            if fv is not None:
-                field_parts.append(f"{_esc(str(k))}={fv}")
-
-        if not field_parts:
-            return None
-
-        lp = "".join(parts) + " " + ",".join(field_parts)
-
-        # Timestamp in nanoseconds
-        if timestamp is not None:
-            if isinstance(timestamp, (int, float)):
-                lp += f" {int(timestamp * 1_000_000_000)}"
-            elif isinstance(timestamp, str):
-                try:
-                    dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-                    lp += f" {int(dt.timestamp() * 1_000_000_000)}"
-                except ValueError:
-                    pass
-
-        return lp
+        """Convert a DataPoint-style dict to an InfluxDB line protocol string."""
+        return to_line_protocol(payload)
 
     def query(self, query_str: str, mode: str = "all") -> pyarrow.Table | pandas.DataFrame:
         try:

--- a/libs/cgse-common/src/egse/plugins/metrics/line_protocol.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/line_protocol.py
@@ -1,0 +1,77 @@
+"""Helpers for converting metric payloads to Influx/QuestDB line protocol."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any
+from typing import Mapping
+
+
+def to_line_protocol(payload: Mapping[str, Any]) -> str | None:
+    """Convert a DataPoint-style payload to a line protocol string.
+
+    The payload is expected to contain:
+    - measurement (required)
+    - fields (required, at least one valid value)
+    - tags (optional)
+    - time (optional: Unix seconds or ISO-8601 string)
+    """
+
+    measurement = payload.get("measurement", "")
+    if not measurement:
+        return None
+
+    fields = payload.get("fields") or {}
+    tags = payload.get("tags") or {}
+    timestamp = payload.get("time")
+
+    def _esc(value: str) -> str:
+        return value.replace(",", "\\,").replace("=", "\\=").replace(" ", "\\ ")
+
+    def _field_val(value: object) -> str | None:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, int):
+            return f"{value}i"
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                return None
+            return repr(value)
+        if isinstance(value, str):
+            return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+        return None
+
+    meas_escaped = str(measurement).replace(",", "\\,").replace(" ", "\\ ")
+    parts = [meas_escaped]
+    if tags:
+        tag_str = ",".join(
+            f"{_esc(str(key))}={_esc(str(value))}" for key, value in sorted(tags.items()) if value is not None
+        )
+        if tag_str:
+            parts.append("," + tag_str)
+
+    field_parts = []
+    for key, value in fields.items():
+        if value is None:
+            continue
+        field_value = _field_val(value)
+        if field_value is not None:
+            field_parts.append(f"{_esc(str(key))}={field_value}")
+
+    if not field_parts:
+        return None
+
+    lp = "".join(parts) + " " + ",".join(field_parts)
+
+    if timestamp is not None:
+        if isinstance(timestamp, (int, float)):
+            lp += f" {int(timestamp * 1_000_000_000)}"
+        elif isinstance(timestamp, str):
+            try:
+                dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+                lp += f" {int(dt.timestamp() * 1_000_000_000)}"
+            except ValueError:
+                pass
+
+    return lp

--- a/libs/cgse-common/src/egse/plugins/metrics/migrate.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/migrate.py
@@ -49,10 +49,11 @@ def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--questdb-schema",
         default=os.environ.get("CGSE_QUESTDB_SCHEMA", "unified"),
-        choices=["unified", "per_measurement"],
+        choices=["unified", "per_measurement", "line_protocol"],
         help=(
             "QuestDB schema mode. 'unified' stores all measurements in a single table (default). "
-            "'per_measurement' creates one table per measurement, mirroring InfluxDB's structure."
+            "'per_measurement' creates one table per measurement. "
+            "'line_protocol' writes via QuestDB ILP and auto-creates typed columns."
         ),
     )
 
@@ -504,10 +505,11 @@ def _delete_destination_range(
     if repo.conn is None:
         raise ConnectionError("QuestDB repository is not connected")
 
-    # For per_measurement schema the target table IS the measurement; no
+    # For per_measurement/line_protocol schema the target table IS the
+    # measurement; no
     # measurement-column filter needed.  For unified schema we filter by both
     # the measurement column and the time range.
-    if repo.schema == "per_measurement":
+    if repo.schema in {"per_measurement", "line_protocol"}:
         target_table = f'"{measurement}"'
         where_parts: list[str] = []
         params: list[Any] = []
@@ -730,7 +732,7 @@ def migrate(args: argparse.Namespace) -> int:
         print(f"  Influx:  {args.influx_host} / {args.influx_database}")
         print(
             f"  QuestDB: {args.questdb_host}:{args.questdb_port} / {args.questdb_database} / "
-            + (f"table={args.questdb_table}" if args.questdb_schema == "unified" else "schema=per_measurement")
+            + (f"table={args.questdb_table}" if args.questdb_schema == "unified" else f"schema={args.questdb_schema}")
         )
         print(f"  Tables:  {', '.join(tables)}")
         print(f"  Filter:  {where_clause if where_clause else '(none)'}")
@@ -769,7 +771,7 @@ def migrate(args: argparse.Namespace) -> int:
             return 0
 
         if args.drop_destination_table and not args.dry_run:
-            if args.questdb_schema == "per_measurement":
+            if args.questdb_schema in {"per_measurement", "line_protocol"}:
                 # Drop each individual measurement table so they are recreated fresh.
                 for _t in tables:
                     print(f"Dropping destination table '{_t}'...")

--- a/libs/cgse-common/src/egse/plugins/metrics/questdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/questdb.py
@@ -7,6 +7,7 @@ from typing import cast
 
 import pandas
 import psycopg
+import requests
 from psycopg import sql
 from psycopg.abc import Query
 from psycopg.rows import dict_row
@@ -15,6 +16,7 @@ from egse.metrics import MeasurementSchema
 from egse.metrics import PointLike
 from egse.metrics import TimeSeriesRepository
 from egse.metrics import get_measurement_schema
+from egse.plugins.metrics.line_protocol import to_line_protocol
 
 __all__ = [
     "QuestDBRepository",
@@ -24,14 +26,15 @@ __all__ = [
 
 SCHEMA_UNIFIED = "unified"
 SCHEMA_PER_MEASUREMENT = "per_measurement"
+SCHEMA_LINE_PROTOCOL = "line_protocol"
 
 
 class QuestDBRepository(TimeSeriesRepository):
     """TimeSeriesRepository implementation backed by QuestDB over PGWire.
 
-    Two schema modes are supported (`schema` parameter):
+    Three schema modes are supported (`schema` parameter):
 
-    `"unified"` (default)
+    `"unified"`
         All measurements are stored in a single table (`table_name`, default
         `"timeseries"`) with columns `(measurement SYMBOL, time TIMESTAMP,
         tags VARCHAR, fields VARCHAR)`.  Simple but mixes all measurements.
@@ -45,8 +48,14 @@ class QuestDBRepository(TimeSeriesRepository):
         `DAQ6510`), with columns `(time TIMESTAMP, tags VARCHAR, fields
         VARCHAR)` by default. When a measurement schema is declared in the
         shared metrics registry, the table is created with native typed columns
-        instead. This preserves the generic fallback while allowing stable
-        measurements to be stored efficiently.
+        and writes are validated/coerced via PGWire. If no schema is declared,
+        points are written via line protocol ingestion so QuestDB infers typed
+        columns.
+
+    `"line_protocol"`
+        Data points are serialized to line protocol and written through QuestDB's
+        HTTP ingress endpoint. Tags become SYMBOL columns and fields become typed
+        columns inferred by QuestDB from line protocol values.
     """
 
     def __init__(
@@ -57,10 +66,18 @@ class QuestDBRepository(TimeSeriesRepository):
         user: str = "admin",
         password: str = "quest",
         table_name: str = "timeseries",
-        schema: str = SCHEMA_UNIFIED,
+        schema: str = SCHEMA_PER_MEASUREMENT,
+        ilp_port: int = 9000,
+        ilp_path: str = "/write",
+        ilp_timeout: float = 5.0,
+        ilp_precision: str = "n",
     ):
-        if schema not in (SCHEMA_UNIFIED, SCHEMA_PER_MEASUREMENT):
-            raise ValueError(f"schema must be '{SCHEMA_UNIFIED}' or '{SCHEMA_PER_MEASUREMENT}', got {schema!r}")
+        if schema not in (SCHEMA_UNIFIED, SCHEMA_PER_MEASUREMENT, SCHEMA_LINE_PROTOCOL):
+            raise ValueError(
+                "schema must be "
+                f"'{SCHEMA_UNIFIED}', '{SCHEMA_PER_MEASUREMENT}', or '{SCHEMA_LINE_PROTOCOL}', "
+                f"got {schema!r}"
+            )
         # QuestDB requires timestamps to be inserted in strictly increasing order.
         # Concurrent flushes can arrive out-of-order, so we must serialize writes.
         self.max_flush_concurrency: int = 1
@@ -71,9 +88,71 @@ class QuestDBRepository(TimeSeriesRepository):
         self.password = password
         self.table_name = table_name
         self.schema = schema
+        self.ilp_port = int(ilp_port)
+        self.ilp_path = ilp_path if ilp_path.startswith("/") else f"/{ilp_path}"
+        self.ilp_timeout = float(ilp_timeout)
+        self.ilp_precision = ilp_precision
         self.conn: psycopg.Connection[Any] | None = None
         self._ping_conn: psycopg.Connection[Any] | None = None
         self._created_tables: set[str] = set()
+
+    def _ilp_url(self) -> str:
+        return f"http://{self.host}:{self.ilp_port}{self.ilp_path}"
+
+    def _ensure_lp_measurement_table(self, measurement: str) -> None:
+        """Ensure an ILP measurement table exists with `time` as designated timestamp."""
+        if measurement in self._created_tables:
+            return
+
+        assert self.conn is not None
+        with self.conn.cursor() as cur:
+            cur.execute(
+                sql.SQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS {} (
+                        time TIMESTAMP
+                    ) TIMESTAMP(time) PARTITION BY DAY
+                    """
+                ).format(sql.Identifier(measurement))
+            )
+
+        self._created_tables.add(measurement)
+
+    def _write_line_protocol(self, payloads: list[dict[str, Any]]) -> None:
+        # Accept payloads that use 'timestamp' as an alias of 'time'.
+        normalized_payloads: list[dict[str, Any]] = []
+        for payload in payloads:
+            if "time" in payload or "timestamp" not in payload:
+                normalized_payloads.append(payload)
+                continue
+            normalized = dict(payload)
+            normalized["time"] = payload.get("timestamp")
+            normalized_payloads.append(normalized)
+
+        # Create measurement tables with `time` as designated timestamp so LP
+        # ingestion uses consistent temporal-column naming.
+        measurement_names = {
+            str(payload.get("measurement")) for payload in normalized_payloads if payload.get("measurement")
+        }
+        for measurement in measurement_names:
+            self._ensure_lp_measurement_table(measurement)
+
+        lines = [line for payload in normalized_payloads if (line := to_line_protocol(payload))]
+        if not lines:
+            return
+
+        response = requests.post(
+            self._ilp_url(),
+            params={"precision": self.ilp_precision},
+            data="\n".join(lines).encode("utf-8"),
+            headers={"Content-Type": "text/plain; charset=utf-8"},
+            timeout=self.ilp_timeout,
+        )
+
+        if response.status_code >= 300:
+            body = response.text.strip()
+            details = f": {body}" if body else ""
+            raise RuntimeError(f"QuestDB line protocol write failed with HTTP {response.status_code}{details}")
 
     def _make_connection(self) -> psycopg.Connection[Any]:
         """Create a new connection to QuestDB. This is used for both the main connection and the
@@ -368,6 +447,7 @@ class QuestDBRepository(TimeSeriesRepository):
         all points are written to the same table with a 'measurement' column. For the per-measurement schema,
         points are grouped by their 'measurement' and written to separate tables. If a measurement has a
         declared schema, the data is validated and coerced to the appropriate types before writing.
+        If no schema is declared, fallback ingestion uses line protocol so QuestDB infers typed columns.
         """
 
         if self.conn is None:
@@ -378,6 +458,11 @@ class QuestDBRepository(TimeSeriesRepository):
 
         if not isinstance(points, list):
             points = [points]
+
+        if self.schema == SCHEMA_LINE_PROTOCOL:
+            payloads = [self._to_dict(point) for point in points]
+            self._write_line_protocol(payloads)
+            return
 
         if self.schema == SCHEMA_UNIFIED:
             rows: list[tuple[str, datetime, str, str]] = []
@@ -411,21 +496,9 @@ class QuestDBRepository(TimeSeriesRepository):
                     self._write_schema_rows(measurement, schema, payloads)
                     continue
 
-                mrows: list[tuple[datetime, str, str]] = []
-                for payload in payloads:
-                    timestamp = self._to_datetime(payload.get("time") or payload.get("timestamp"))
-                    tags = payload.get("tags") or {}
-                    fields = payload.get("fields") or {}
-                    mrows.append((timestamp, json.dumps(tags), json.dumps(fields)))
-
-                self._ensure_measurement_table(measurement)
-                with self.conn.cursor() as cur:
-                    cur.executemany(
-                        sql.SQL("INSERT INTO {} (time, tags, fields) VALUES (%s, %s, %s)").format(
-                            sql.Identifier(measurement)
-                        ),
-                        mrows,
-                    )
+                # Fallback for measurements without a declared schema: write via
+                # line protocol so QuestDB creates inferred typed columns.
+                self._write_line_protocol(payloads)
 
     def query(
         self,
@@ -480,11 +553,12 @@ class QuestDBRepository(TimeSeriesRepository):
     def get_measurement_names(self) -> list[str]:
         """Return distinct measurement names.
 
-        For `per_measurement` schema this is the same as `get_table_names()`.
+        For `per_measurement` and `line_protocol` schemas this is the same as
+        `get_table_names()`.
         For `unified` schema this queries the distinct values in the
         `measurement` column of the unified table.
         """
-        if self.schema == SCHEMA_PER_MEASUREMENT:
+        if self.schema in {SCHEMA_PER_MEASUREMENT, SCHEMA_LINE_PROTOCOL}:
             return self.get_table_names()
         rows = self.query(
             sql.SQL("SELECT DISTINCT measurement FROM {} ORDER BY measurement").format(sql.Identifier(self.table_name)),
@@ -526,10 +600,12 @@ class QuestDBRepository(TimeSeriesRepository):
 
         For the `unified` schema, *table_name* is the unified table name and
         *measurement* can be supplied to filter by a specific measurement.
-        For the `per_measurement` schema, *table_name* is the measurement
-        name directly and *measurement* is ignored.
+        For the `per_measurement` and `line_protocol` schemas, *table_name* is
+        the measurement name directly and *measurement* is ignored.
         """
-        if self.schema == SCHEMA_UNIFIED and measurement is not None:
+        has_fields_json = "fields" in set(self.get_column_names(table_name))
+
+        if has_fields_json and self.schema == SCHEMA_UNIFIED and measurement is not None:
             query = sql.SQL(
                 """
                 SELECT time, fields
@@ -540,7 +616,7 @@ class QuestDBRepository(TimeSeriesRepository):
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(int(hours), measurement))
-        else:
+        elif has_fields_json:
             query = sql.SQL(
                 """
                 SELECT time, fields
@@ -550,7 +626,18 @@ class QuestDBRepository(TimeSeriesRepository):
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(int(hours),))
-        parsed = self._extract_field(rows, column_name)
+        else:
+            query = sql.SQL(
+                """
+                SELECT time, {}
+                FROM {}
+                WHERE time >= dateadd('h', -%s, now())
+                ORDER BY time DESC
+                """
+            ).format(sql.Identifier(column_name), sql.Identifier(table_name))
+            rows = self.query(query, mode="all", params=(int(hours),))
+
+        parsed = self._extract_field(rows, column_name) if has_fields_json else self._extract_value(rows, column_name)
         if mode == "pandas":
             return pandas.DataFrame(parsed)
         return parsed
@@ -568,10 +655,12 @@ class QuestDBRepository(TimeSeriesRepository):
 
         For the `unified` schema, *table_name* is the unified table name and
         *measurement* can be supplied to filter by a specific measurement.
-        For the `per_measurement` schema, *table_name* is the measurement
-        name directly and *measurement* is ignored.
+        For the `per_measurement` and `line_protocol` schemas, *table_name* is
+        the measurement name directly and *measurement* is ignored.
         """
-        if self.schema == SCHEMA_UNIFIED and measurement is not None:
+        has_fields_json = "fields" in set(self.get_column_names(table_name))
+
+        if has_fields_json and self.schema == SCHEMA_UNIFIED and measurement is not None:
             query = sql.SQL(
                 """
                 SELECT time, fields
@@ -583,7 +672,7 @@ class QuestDBRepository(TimeSeriesRepository):
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(start_time, end_time, measurement))
-        else:
+        elif has_fields_json:
             query = sql.SQL(
                 """
                 SELECT time, fields
@@ -594,10 +683,27 @@ class QuestDBRepository(TimeSeriesRepository):
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(start_time, end_time))
-        parsed = self._extract_field(rows, column_name)
+        else:
+            query = sql.SQL(
+                """
+                SELECT time, {}
+                FROM {}
+                WHERE time >= %s
+                  AND time < %s
+                ORDER BY time DESC
+                """
+            ).format(sql.Identifier(column_name), sql.Identifier(table_name))
+            rows = self.query(query, mode="all", params=(start_time, end_time))
+
+        parsed = self._extract_field(rows, column_name) if has_fields_json else self._extract_value(rows, column_name)
         if mode == "pandas":
             return pandas.DataFrame(parsed)
         return parsed
+
+    @staticmethod
+    def _extract_value(rows: list[dict[str, Any]], column_name: str) -> list[dict[str, Any]]:
+        """Extract a typed column value from query results."""
+        return [{"time": row.get("time"), column_name: row.get(column_name)} for row in rows]
 
     @staticmethod
     def _extract_field(rows: list[dict[str, Any]], column_name: str) -> list[dict[str, Any]]:

--- a/libs/cgse-common/tests/script_migrate_influx_to_questdb.py
+++ b/libs/cgse-common/tests/script_migrate_influx_to_questdb.py
@@ -62,10 +62,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--questdb-schema",
         default=os.environ.get("CGSE_QUESTDB_SCHEMA", "unified"),
-        choices=["unified", "per_measurement"],
+        choices=["unified", "per_measurement", "line_protocol"],
         help=(
             "QuestDB schema mode. 'unified' stores all measurements in a single table (default). "
-            "'per_measurement' creates one table per measurement, mirroring InfluxDB's structure."
+            "'per_measurement' creates one table per measurement. "
+            "'line_protocol' writes via QuestDB ILP and auto-creates typed columns."
         ),
     )
 
@@ -512,10 +513,11 @@ def _delete_destination_range(
     if repo.conn is None:
         raise ConnectionError("QuestDB repository is not connected")
 
-    # For per_measurement schema the target table IS the measurement; no
+    # For per_measurement/line_protocol schema the target table IS the
+    # measurement; no
     # measurement-column filter needed.  For unified schema we filter by both
     # the measurement column and the time range.
-    if repo.schema == "per_measurement":
+    if repo.schema in {"per_measurement", "line_protocol"}:
         target_table = f'"{measurement}"'
         where_parts: list[str] = []
         params: list[Any] = []
@@ -733,7 +735,7 @@ def migrate(args: argparse.Namespace) -> int:
         print(f"  Influx:  {args.influx_host} / {args.influx_database}")
         print(
             f"  QuestDB: {args.questdb_host}:{args.questdb_port} / {args.questdb_database} / "
-            + (f"table={args.questdb_table}" if args.questdb_schema == "unified" else "schema=per_measurement")
+            + (f"table={args.questdb_table}" if args.questdb_schema == "unified" else f"schema={args.questdb_schema}")
         )
         print(f"  Tables:  {', '.join(tables)}")
         print(f"  Filter:  {where_clause if where_clause else '(none)'}")
@@ -758,7 +760,7 @@ def migrate(args: argparse.Namespace) -> int:
             return 0
 
         if args.drop_destination_table and not args.dry_run:
-            if args.questdb_schema == "per_measurement":
+            if args.questdb_schema in {"per_measurement", "line_protocol"}:
                 # Drop each individual measurement table so they are recreated fresh.
                 for _t in tables:
                     print(f"Dropping destination table '{_t}'...")

--- a/libs/cgse-common/tests/test_questdb_plugin.py
+++ b/libs/cgse-common/tests/test_questdb_plugin.py
@@ -55,7 +55,10 @@ class FakeCursor:
         elif "SELECT table_name FROM tables()" in query_text:
             self.conn.rows = [{"table_name": "timeseries"}]
         elif "SHOW COLUMNS FROM" in query_text:
-            self.conn.rows = [{"column": "measurement"}, {"column": "time"}, {"column": "fields"}]
+            if "typed_metrics" in query_text:
+                self.conn.rows = [{"column": "time"}, {"column": "temperature"}]
+            else:
+                self.conn.rows = [{"column": "measurement"}, {"column": "time"}, {"column": "fields"}]
         elif "information_schema.columns" in query_text:
             # Return all columns that are expected by any schema registered in the fake.
             # We model this as: the table was freshly created so all schema columns exist.
@@ -67,6 +70,17 @@ class FakeCursor:
                 {
                     "time": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
                     "fields": '{"temperature": 22.5}',
+                }
+            ]
+        elif (
+            "SELECT time" in query_text
+            and "fields" not in query_text
+            and ("temperature" in query_text or "Identifier('temperature')" in query_text)
+        ):
+            self.conn.rows = [
+                {
+                    "time": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
+                    "temperature": 22.5,
                 }
             ]
         else:
@@ -120,7 +134,7 @@ def test_connect_creates_table(monkeypatch):
 
     monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", fake_connect)
 
-    repo = QuestDBRepository()
+    repo = QuestDBRepository(schema="unified")
     repo.connect()
 
     assert repo.conn is fake_conn
@@ -134,7 +148,7 @@ def test_ping_query_and_close(monkeypatch):
     fake_conn = FakeConnection()
     monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
 
-    repo = QuestDBRepository()
+    repo = QuestDBRepository(schema="unified")
     repo.connect()
 
     assert repo.ping() is True
@@ -157,7 +171,7 @@ def test_write_and_helpers(monkeypatch):
     fake_conn = FakeConnection()
     monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
 
-    repo = QuestDBRepository(table_name="metrics")
+    repo = QuestDBRepository(table_name="metrics", schema="unified")
     repo.connect()
 
     repo.write(
@@ -267,3 +281,135 @@ def test_write_rejects_unknown_declared_fields(monkeypatch):
                 "time": "2026-04-24T12:00:00Z",
             }
         )
+
+
+def test_line_protocol_schema_is_supported(monkeypatch):
+    fake_conn = FakeConnection()
+    monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
+
+    repo = QuestDBRepository(schema="line_protocol")
+    repo.connect()
+
+    assert repo.schema == "line_protocol"
+    # line_protocol mode should not create unified table on connect.
+    assert not any('CREATE TABLE IF NOT EXISTS "timeseries"' in query for query, _ in fake_conn.executed)
+
+
+def test_write_line_protocol_posts_to_ilp_endpoint(monkeypatch):
+    fake_conn = FakeConnection()
+    monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
+
+    class _Response:
+        status_code = 204
+        text = ""
+
+    captured: dict[str, object] = {}
+
+    def fake_post(url, params, data, headers, timeout):
+        captured["url"] = url
+        captured["params"] = params
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("egse.plugins.metrics.questdb.requests.post", fake_post)
+
+    repo = QuestDBRepository(schema="line_protocol", host="questdb.local", ilp_port=9000)
+    repo.connect()
+    repo.write(
+        {
+            "measurement": "camera_tm",
+            "tags": {"device_id": "cam_01"},
+            "fields": {"temperature": 23.4, "counter": 3},
+            "time": "2026-04-24T12:00:00Z",
+        }
+    )
+
+    assert captured["url"] == "http://questdb.local:9000/write"
+    assert captured["params"] == {"precision": "n"}
+    assert captured["headers"] == {"Content-Type": "text/plain; charset=utf-8"}
+    assert captured["timeout"] == 5.0
+    body = captured["data"]
+    assert isinstance(body, bytes)
+    text_body = body.decode("utf-8")
+    assert text_body.startswith("camera_tm,device_id=cam_01 ")
+    assert "temperature=23.4" in text_body
+    assert "counter=3i" in text_body
+
+
+def test_write_line_protocol_raises_on_http_error(monkeypatch):
+    fake_conn = FakeConnection()
+    monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
+
+    class _Response:
+        status_code = 400
+        text = "invalid line protocol"
+
+    monkeypatch.setattr("egse.plugins.metrics.questdb.requests.post", lambda *args, **kwargs: _Response())
+
+    repo = QuestDBRepository(schema="line_protocol")
+    repo.connect()
+
+    with pytest.raises(RuntimeError, match="QuestDB line protocol write failed"):
+        repo.write({"measurement": "cpu", "fields": {"value": 1}})
+
+
+def test_get_values_helpers_support_typed_tables(monkeypatch):
+    fake_conn = FakeConnection()
+    monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
+
+    repo = QuestDBRepository(schema="per_measurement")
+    repo.connect()
+
+    values = repo.get_values_last_hours("typed_metrics", "temperature", hours=1, mode="")
+    assert len(values) == 1
+    assert values[0]["temperature"] == 22.5
+
+    values_range = repo.get_values_in_range("typed_metrics", "temperature", "2026-04-24", "2026-04-25", mode="")
+    assert len(values_range) == 1
+    assert values_range[0]["temperature"] == 22.5
+
+
+def test_per_measurement_fallback_uses_line_protocol(monkeypatch):
+    fake_conn = FakeConnection()
+    monkeypatch.setattr("egse.plugins.metrics.questdb.psycopg.connect", lambda **kwargs: fake_conn)
+
+    class _Response:
+        status_code = 204
+        text = ""
+
+    captured: dict[str, object] = {}
+
+    def fake_post(url, params, data, headers, timeout):
+        captured["url"] = url
+        captured["params"] = params
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response()
+
+    monkeypatch.setattr("egse.plugins.metrics.questdb.requests.post", fake_post)
+
+    repo = QuestDBRepository(schema="per_measurement", host="questdb.local", ilp_port=9000)
+    repo.connect()
+    repo.write(
+        {
+            "measurement": "fallback_measurement",
+            "tags": {"device_id": "cam_01"},
+            "fields": {"temperature": 23.4},
+            "timestamp": "2026-04-24T12:00:00Z",
+        }
+    )
+
+    assert captured["url"] == "http://questdb.local:9000/write"
+    assert captured["params"] == {"precision": "n"}
+    assert captured["headers"] == {"Content-Type": "text/plain; charset=utf-8"}
+    assert captured["timeout"] == 5.0
+    body = captured["data"]
+    assert isinstance(body, bytes)
+    text_body = body.decode("utf-8")
+    assert text_body.startswith("fallback_measurement,device_id=cam_01 ")
+    assert "temperature=23.4" in text_body
+    # No PGWire INSERTs should happen for fallback measurements.
+    assert fake_conn.executed_many == []

--- a/libs/cgse-core/src/egse/metricshub/server.py
+++ b/libs/cgse-core/src/egse/metricshub/server.py
@@ -114,8 +114,10 @@ def _get_backend_config() -> tuple[str, dict[str, Any], dict[str, Any]]:
             password = str_env("CGSE_QUESTDB_PASSWORD", "quest")
             table_name = str_env("CGSE_QUESTDB_TABLE", "timeseries")
             schema = str_env("CGSE_QUESTDB_SCHEMA", "per_measurement").strip().lower()
-            if schema not in {"unified", "per_measurement"}:
-                raise ValueError(f"Invalid CGSE_QUESTDB_SCHEMA '{schema}'. Supported: 'unified', 'per_measurement'.")
+            if schema not in {"unified", "per_measurement", "line_protocol"}:
+                raise ValueError(
+                    f"Invalid CGSE_QUESTDB_SCHEMA '{schema}'. Supported: 'unified', 'per_measurement', 'line_protocol'."
+                )
             config = {
                 "host": host,
                 "port": port,

--- a/libs/cgse-core/tests/test_metricshub.py
+++ b/libs/cgse-core/tests/test_metricshub.py
@@ -436,6 +436,17 @@ def test_get_backend_config_questdb_defaults_to_per_measurement(monkeypatch):
     assert public_info["schema"] == "per_measurement"
 
 
+def test_get_backend_config_questdb_line_protocol(monkeypatch):
+    monkeypatch.setenv("CGSE_METRICS_BACKEND", "questdb")
+    monkeypatch.setenv("CGSE_QUESTDB_SCHEMA", "line_protocol")
+
+    backend, config, public_info = _get_backend_config()
+
+    assert backend == "questdb"
+    assert config["schema"] == "line_protocol"
+    assert public_info["schema"] == "line_protocol"
+
+
 def test_get_backend_config_unknown_backend(monkeypatch):
     monkeypatch.setenv("CGSE_METRICS_BACKEND", "nope")
 

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_admin.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_admin.py
@@ -430,15 +430,30 @@ def _inspect_questdb(
             print(f"\nTable: {table}")
             stats: dict[str, Any] | None = None
             columns: list[str] | None = None
+            time_column: str | None = None
             try:
                 columns = repo.get_column_names(table)
                 print(f"  Columns: {', '.join(columns) if columns else '(none)'}")
+                if columns:
+                    if "time" in columns:
+                        time_column = "time"
+                    elif "timestamp" in columns:
+                        time_column = "timestamp"
             except Exception as exc:
                 print(f"  Columns: n/a ({exc})")
 
             try:
+                if not time_column:
+                    raise ValueError("No time column found (expected 'time' or 'timestamp')")
+                time_expr = f'"{time_column}"'
+                stats_query = (
+                    "SELECT COUNT(*) AS row_count, "
+                    f"MIN({time_expr}) AS min_time, "
+                    f"MAX({time_expr}) AS max_time "
+                    f'FROM "{table}"'
+                )
                 stats_rows = repo.query(
-                    f'SELECT COUNT(*) AS row_count, MIN(time) AS min_time, MAX(time) AS max_time FROM "{table}"',
+                    stats_query,
                     mode="all",
                 )
                 if stats_rows:
@@ -458,14 +473,17 @@ def _inspect_questdb(
                 print("  Time window: n/a")
                 print(f"  Warning: could not compute stats ({exc})")
 
-            # Check if this is unified schema (with tags/fields columns) or typed schema (per_measurement)
+            # Check if this is unified schema (with tags/fields columns) or typed schema.
             has_tags_fields = "tags" in columns and "fields" in columns if columns else False
 
             if has_tags_fields:
                 # Unified schema with JSON-stored tags and fields
                 try:
+                    if not time_column:
+                        raise ValueError("No time column found (expected 'time' or 'timestamp')")
+                    time_expr = f'"{time_column}"'
                     sample = repo.query(
-                        f'SELECT tags, fields FROM "{table}" ORDER BY time DESC LIMIT {int(sample_rows)}',
+                        f'SELECT tags, fields FROM "{table}" ORDER BY {time_expr} DESC LIMIT {int(sample_rows)}',
                         mode="all",
                     )
                     tag_keys = _parse_json_keys([row.get("tags") for row in sample])
@@ -531,16 +549,19 @@ def _inspect_questdb(
                 except Exception as exc:
                     print(f"  Tag/field keys (sampled): n/a ({exc})")
             else:
-                # Typed schema with native columns (per_measurement with measurement schema)
-                # Display the typed columns (excluding time column) and their actual values
-                typed_columns = [col for col in columns if col != "time"] if columns else []
+                # Typed schema with native columns (per_measurement or line_protocol).
+                # Display the typed columns (excluding temporal column) and their actual values
+                typed_columns = [col for col in columns if col not in {"time", "timestamp"}] if columns else []
                 if typed_columns:
                     print(f"  Tag/field keys (typed): {', '.join(typed_columns)}")
 
                     # Try to show some sample values for the typed columns
                     try:
+                        if not time_column:
+                            raise ValueError("No time column found (expected 'time' or 'timestamp')")
+                        time_expr = f'"{time_column}"'
                         quoted_cols = ", ".join([f'"{col}"' for col in typed_columns[:5]])
-                        sample_query = f'SELECT {quoted_cols} FROM "{table}" ORDER BY time DESC LIMIT 1'
+                        sample_query = f'SELECT {quoted_cols} FROM "{table}" ORDER BY {time_expr} DESC LIMIT 1'
                         sample_rows_data = repo.query(sample_query, mode="all")
                         if sample_rows_data:
                             sample_row = sample_rows_data[0]
@@ -607,8 +628,8 @@ def _inspect_duckdb(
                 f"""
                 SELECT
                     COUNT(*) AS row_count,
-                    MIN(timestamp) AS min_time,
-                    MAX(timestamp) AS max_time
+                    MIN(time) AS min_time,
+                    MAX(time) AS max_time
                 FROM {duckdb_table}
                 WHERE measurement = '{measurement}'
                 """
@@ -623,7 +644,7 @@ def _inspect_duckdb(
                 SELECT tags, fields
                 FROM {duckdb_table}
                 WHERE measurement = '{measurement}'
-                ORDER BY timestamp DESC
+                ORDER BY time DESC
                 LIMIT 200
                 """
             )
@@ -656,7 +677,7 @@ def migrate_influx_to_questdb(
     questdb_password: Annotated[str, typer.Option(help="QuestDB password")] = "quest",
     questdb_table: Annotated[str, typer.Option(help="QuestDB table name (unified schema mode)")] = "timeseries",
     questdb_schema: Annotated[
-        str, typer.Option(help="QuestDB schema mode: 'unified' or 'per_measurement'")
+        str, typer.Option(help="QuestDB schema mode: 'unified', 'per_measurement', or 'line_protocol'")
     ] = "unified",
     tables: Annotated[
         str, typer.Option(help="Comma-separated list of measurements to migrate (auto-discover if empty)")
@@ -772,7 +793,7 @@ def inspect_db(
     questdb_table: Annotated[str, typer.Option(help="QuestDB unified table name")] = "timeseries",
     questdb_schema: Annotated[
         str,
-        typer.Option(help="QuestDB schema mode: unified or per_measurement"),
+        typer.Option(help="QuestDB schema mode: unified, per_measurement, or line_protocol"),
     ] = "per_measurement",
     duckdb_path: Annotated[str, typer.Option(help="DuckDB file path")] = "",
     duckdb_table: Annotated[str, typer.Option(help="DuckDB main table name")] = "timeseries",
@@ -884,7 +905,7 @@ def execute_sql(
     questdb_table: Annotated[str, typer.Option(help="QuestDB unified table name")] = "timeseries",
     questdb_schema: Annotated[
         str,
-        typer.Option(help="QuestDB schema mode: unified or per_measurement"),
+        typer.Option(help="QuestDB schema mode: unified, per_measurement, or line_protocol"),
     ] = "per_measurement",
     duckdb_path: Annotated[str, typer.Option(help="DuckDB file path")] = "",
     duckdb_table: Annotated[str, typer.Option(help="DuckDB main table name")] = "timeseries",


### PR DESCRIPTION
Introduce line protocol schema support for QuestDB

- Added support for a new schema mode 'line_protocol' in QuestDBRepository.
- Implemented line protocol conversion in a new helper module.
- Updated InfluxDBRepository to utilize the new line protocol helper.
- Enhanced migration scripts to accommodate the new schema option.
- Modified tests to validate functionality for the line protocol schema.
- Updated server configuration to recognize the new schema mode.
- Make temporal columns consistently use `time` instead of `timestamp`.

Why line protocol (LP)?

- The InfluxDB plugin also works with LP
- If no measurement table is specified, LP will infer types, so we will always have typed tables with fast querying in Grafana
