### PR TITLE
Release/v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-22
+
+- Added QuestDB `line_protocol` schema mode with HTTP ILP ingestion, including typed-column inference and support for configurable ILP host/port/path/timeout/precision.
+- Improved QuestDB `per_measurement` behavior for measurements without declared schemas by falling back to line protocol ingestion instead of JSON `fields` inserts.
+- Added a shared metrics line-protocol serializer (`egse.plugins.metrics.line_protocol.to_line_protocol`) and updated the InfluxDB repository to use it.
+- Extended Metrics Hub QuestDB backend configuration validation to accept `CGSE_QUESTDB_SCHEMA=line_protocol`.
+- Extended CGSE admin tooling (`cgse admin inspect-db`, migration, and SQL flows) to support `line_protocol` schema mode and to handle both `time` and `timestamp` temporal columns during inspection/statistics queries.
+- Aligned DuckDB metrics repository time-column naming to `time` (from `timestamp`) for schema consistency.
+- Expanded test coverage for QuestDB line protocol ingestion, typed-table value queries, per-measurement fallback behavior, and Metrics Hub QuestDB schema handling.
+
 ## [0.24.1] - 2026-05-21
 
 - Reduced the root CGSE source distribution and wheel to a minimal set of files, so published archives are smaller and contain only the required packaging assets.
@@ -438,7 +448,8 @@ This release is mainly on maintenance and improvements to the `cgse-common` pack
 - Renamed `cgse` subcommands `registry` →  `reg`, `notify` →  `not`.
 
 
-[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/IvS-KULeuven/cgse/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/IvS-KULeuven/cgse/compare/v0.22.2...v0.23.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Common-EGSE
 
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 This is a monorepo with all the code and documentation for the common egse framework.
 
 This repository is organized in two main areas, `libs` and `projects`. The `libs` folder contains library type 

--- a/libs/cgse-common/README.md
+++ b/libs/cgse-common/README.md
@@ -6,6 +6,13 @@
 
 # Generic Functionality used in the Common-EGSE
 
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse-common/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 This package 'cgse-common' contains functionality that is used by all `cgse` sub-packages, but it is designed to be a stand-alone generic package that can be used also in any other project.
 
 

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -115,3 +115,10 @@ dev = [
     "nox",
     "setuptools>=75.8.2",  # needed by PyCharm
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/libs/cgse-common"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.24.1"
+version = "0.25.0"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/README.md
+++ b/libs/cgse-coordinates/README.md
@@ -1,1 +1,8 @@
 # Reference Frames for the CGSE
+
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse-coordinates/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -72,3 +72,10 @@ dev = [
     "pytest-mock>=3.14.0",
     "ruff>=0.9.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/libs/cgse-coordinates"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.24.1"
+version = "0.25.0"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/refmodel.py
@@ -726,8 +726,13 @@ def get_vectors(reference_frame_1, reference_frame_2, model: ReferenceFrameModel
     )
 
 
-def print_vectors(reference_frame_1: str, reference_frame_2: str, model: ReferenceFrameModel,
-                    format: str = "10.5f", decimals: int = None) -> None:
+def print_vectors(
+    reference_frame_1: str,
+    reference_frame_2: str,
+    model: ReferenceFrameModel,
+    format: str = "10.5f",
+    decimals: int = None,
+) -> None:
     """
     Prints the translation and rotation vectors for the active transformation for the 1st reference frame to the 2nd.
 
@@ -739,7 +744,8 @@ def print_vectors(reference_frame_1: str, reference_frame_2: str, model: Referen
         decimals=None  (int): if given a positive value, decimals is used instead (passed to np.round)
     """
     trans, rot = model.get_frame(reference_frame_1).get_active_translation_rotation_vectors_to(
-        model.get_frame(reference_frame_2))
+        model.get_frame(reference_frame_2)
+    )
 
     if decimals is None:
         fmt = f"{{:{format}}}"
@@ -751,10 +757,7 @@ def print_vectors(reference_frame_1: str, reference_frame_2: str, model: Referen
         trans_str = ", ".join(str(x) for x in trans_r)
         rot_str = ", ".join(str(x) for x in rot_r)
 
-    print(
-        f"{reference_frame_1:8s} -> {reference_frame_2:8s} : "
-        f"Trans [{trans_str}]    Rot [{rot_str}]"
-    )
+    print(f"{reference_frame_1:8s} -> {reference_frame_2:8s} : Trans [{trans_str}]    Rot [{rot_str}]")
     return
 
 

--- a/libs/cgse-coordinates/src/egse/coordinates/transform3d_addon.py
+++ b/libs/cgse-coordinates/src/egse/coordinates/transform3d_addon.py
@@ -442,7 +442,7 @@ tr2t = translation_rotation_to_transformation
 t2tr = translation_rotation_from_transformation
 
 
-def vector_plane_intersection(pt, frame, plane='xy', epsilon=1.e-6):
+def vector_plane_intersection(pt, frame, plane="xy", epsilon=1.0e-6):
     """
 
     Args:
@@ -468,26 +468,26 @@ def vector_plane_intersection(pt, frame, plane='xy', epsilon=1.e-6):
 
     if pt.ref == frame:
         # The point is defined in frame => the origin of the vector is the origin of the target plane.
-        return np.array([0,0,0])
+        return np.array([0, 0, 0])
     else:
         # Express all inputs in 'frame'
 
         # Vector Origin (website: p0)
-        vec_orig = Point(pt.ref.get_origin().coordinates[:3], ref=pt.ref, name='ptorig').express_in(frame)[:3]
+        vec_orig = Point(pt.ref.get_origin().coordinates[:3], ref=pt.ref, name="ptorig").express_in(frame)[:3]
         # Vector End (website: p1)
-        vec_end  = pt.express_in(frame)[:3]
+        vec_end = pt.express_in(frame)[:3]
         # Vector (website: u)
         vec = vec_end - vec_orig
 
         # A point in Plane (website: pco)
         plane_orig = frame.get_origin().coordinates[:3]
         # Normal to the plane (website: pno)
-        if plane in ['xy', 'yx']:
-            plane_normal = frame.get_axis('z').coordinates[:3]
-        elif plane in ['yz', 'zy']:
-            plane_normal = frame.get_axis('x').coordinates[:3]
-        elif plane in ['xz', 'zx']:
-            plane_normal = frame.get_axis('y').coordinates[:3]
+        if plane in ["xy", "yx"]:
+            plane_normal = frame.get_axis("z").coordinates[:3]
+        elif plane in ["yz", "zy"]:
+            plane_normal = frame.get_axis("x").coordinates[:3]
+        elif plane in ["xz", "zx"]:
+            plane_normal = frame.get_axis("y").coordinates[:3]
         else:
             raise ValueError(f"{plane=}; must be a string in ['xy', 'yz', 'zx']")
 
@@ -497,16 +497,15 @@ def vector_plane_intersection(pt, frame, plane='xy', epsilon=1.e-6):
         # Test if there is an intersection (and if it's unique)
         # --> input vector and normal mustn't be perpendicular, else the vector is // to the plane or inside it
         #
-        if (np.allclose(vec_x_normal, 0., atol=epsilon)):
-            print('The input vector is // to the plane normal (or inside the plane)')
-            print('--> there exists no intersection (or an infinity of them)')
+        if np.allclose(vec_x_normal, 0.0, atol=epsilon):
+            print("The input vector is // to the plane normal (or inside the plane)")
+            print("--> there exists no intersection (or an infinity of them)")
             return None
         else:
             # Vector from the point in the plane to the origin of the vector (w = p0 - pco)
             plane_to_vec = vec_orig - plane_orig
 
             # Solution  ("how many 'vectors' away is the interesection ?" ; factor=-(plane * w) / vec_x_normal)
-            vec_multiplicator = - np.dot(plane_normal, plane_to_vec) / vec_x_normal
+            vec_multiplicator = -np.dot(plane_normal, plane_to_vec) / vec_x_normal
 
             return Point(vec_orig + (vec * vec_multiplicator), ref=frame)
-

--- a/libs/cgse-core/README.md
+++ b/libs/cgse-core/README.md
@@ -1,1 +1,8 @@
 # The core services for the CGSE platform
+
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse-core/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -133,3 +133,10 @@ dev = [
     "pytest-timeout>=2.3.1",
     "ruff>=0.9.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/libs/cgse-core"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.24.1"
+version = "0.25.0"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/README.md
+++ b/libs/cgse-gui/README.md
@@ -1,1 +1,8 @@
 # GUI Components used in CGSE apps
+
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse-gui/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.24.1"
+version = "0.25.0"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -35,3 +35,10 @@ packages = ["src/egse"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/libs/cgse-gui"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/ariel/ariel-facility/README.md
+++ b/projects/ariel/ariel-facility/README.md
@@ -1,5 +1,12 @@
 # Extraction of HK from the MySQL Facility Database
 
+## Latest release
+
+- PyPI: https://pypi.org/project/ariel-facility/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 During the Ariel TA test campaign at CSL, facility (and potentially other) housekeeping data will be stored in the MySQL 
 facility database.  To store (housekeeping) data in a consistent way across devices/processes and to enable quick-look 
 analysis (e.g. via Grafana dashboards), we want to extract the data from the MySQL facility database and ingest it 

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -61,3 +61,10 @@ extend-select = ["E501"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/ariel/ariel-facility"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.24.1"
+version = "0.25.0"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/README.md
+++ b/projects/ariel/ariel-tcu/README.md
@@ -1,5 +1,12 @@
 # Telescope Control Unit (TCU)
 
+## Latest release
+
+- PyPI: https://pypi.org/project/ariel-tcu/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 ## Reference Document
 
 - RD01: TCU User Manual (ARIEL-IEEC-PL-TN-002), v1.2

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -62,3 +62,10 @@ extend-select = ["E501"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/ariel/ariel-tcu"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.24.1"
+version = "0.25.0"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/README.md
+++ b/projects/generic/aim-tti-awg/README.md
@@ -1,5 +1,12 @@
 # Aim-TTi TGF4000 Arbitrary Wave Generator
 
+## Latest release
+
+- PyPI: https://pypi.org/project/aim_tti_awg/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 ## Reference Documents
 
 - [Aim-TTi TGF4000 Series Instruction Manual, v3.0](https://resources.aimtti.com/manuals/TGF4000_Series_Instruction_Manual-Iss3.pdf)

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.24.1"
+version = "0.25.0"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -80,3 +80,10 @@ dev = [
     "pytest-asyncio>=0.26.0",
     "ipython",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/aim-tti-awg"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/cgse-tools/README.md
+++ b/projects/generic/cgse-tools/README.md
@@ -1,1 +1,8 @@
 # Tools for the CGSE framework
+
+## Latest release
+
+- PyPI: https://pypi.org/project/cgse-tools/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.24.1"
+version = "0.25.0"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -68,3 +68,10 @@ dev = [
     "pytest-mock>=3.14.0",
     "ruff>=0.9.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/cgse-tools"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/digilent/README.md
+++ b/projects/generic/digilent/README.md
@@ -1,5 +1,12 @@
 # Digilent MEASURpoint/TEMPpoint/VOLTpoint
 
+## Latest release
+
+- PyPI: https://pypi.org/project/digilent/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 ## Reference Documents
 
 - User's Manual for Standard TEMPpoint, VOLTpoint, and MEASURpointLXI Instruments (DT8871, DT8871U, DT8872, DT8873, DT8874)

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.24.1"
+version = "0.25.0"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -79,3 +79,10 @@ dev = [
     "setuptools>=75.8.2", # needed by PyCharm
     "pytest-asyncio>=0.26.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/digilent"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/keithley-tempcontrol/README.md
+++ b/projects/generic/keithley-tempcontrol/README.md
@@ -1,5 +1,12 @@
 # Keithley Temperature Control
 
+## Latest release
+
+- PyPI: https://pypi.org/project/keithley-tempcontrol/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 # Implemented Devices
 
 - DAQ6510

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -85,3 +85,10 @@ dev = [
     "ruff>=0.9.0",
     "nox>=2025.2.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/keithley-tempcontrol"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.24.1"
+version = "0.25.0"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/README.md
+++ b/projects/generic/kikusui-power-supply/README.md
@@ -1,5 +1,12 @@
 # KIKUSUI Regulated Power Supply 
 
+## Latest release
+
+- PyPI: https://pypi.org/project/kikusui_power_supply/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md
+
 Implementation of the commanding and monitoring of the KIKUSUI PMX-A power supplies.  
 
 ## Reference Documents

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -80,3 +80,10 @@ dev = [
     "pytest-asyncio>=0.26.0",
     "ipython",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/kikusui-power-supply"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.24.1"
+version = "0.25.0"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/README.md
+++ b/projects/generic/lakeshore-tempcontrol/README.md
@@ -1,1 +1,8 @@
 # Driver for the LakeShore Temperature Controller
+
+## Latest release
+
+- PyPI: https://pypi.org/project/lakeshore-tempcontrol/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -82,3 +82,10 @@ dev = [
     "ruff>=0.9.0",
     "nox>=2025.2.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/lakeshore-tempcontrol"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.24.1"
+version = "0.25.0"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/README.md
+++ b/projects/generic/symetrie-hexapod/README.md
@@ -1,1 +1,8 @@
 # Drivers for the Symétrie Hexapods
+
+## Latest release
+
+- PyPI: https://pypi.org/project/symetrie-hexapod/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -91,3 +91,10 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/generic/symetrie-hexapod"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.24.1"
+version = "0.25.0"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/README.md
+++ b/projects/plato/plato-fits/README.md
@@ -1,1 +1,8 @@
 # FITS plugin for the CGSE storage manager
+
+## Latest release
+
+- PyPI: https://pypi.org/project/plato-fits/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.24.1"
+version = "0.25.0"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -52,3 +52,10 @@ extend-select = ["E501"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/plato/plato-fits"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/plato/plato-hdf5/README.md
+++ b/projects/plato/plato-hdf5/README.md
@@ -1,0 +1,8 @@
+# plato-hdf5
+
+## Latest release
+
+- PyPI: https://pypi.org/project/plato-hdf5/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -53,3 +53,10 @@ extend-select = ["E501"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/plato/plato-hdf5"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.24.1"
+version = "0.25.0"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/README.md
+++ b/projects/plato/plato-spw/README.md
@@ -1,0 +1,8 @@
+# plato-spw
+
+## Latest release
+
+- PyPI: https://pypi.org/project/plato-spw/
+- GitHub releases: https://github.com/IvS-KULeuven/cgse/releases
+- Latest release notes: https://github.com/IvS-KULeuven/cgse/releases/latest
+- Changelog: https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.24.1"
+version = "0.25.0"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -47,3 +47,10 @@ extend-select = ["E501"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse/tree/main/projects/plato/plato-spw"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.24.1"
+version = "0.25.0"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,10 @@ docs = [
     "mkdocstrings<1",
     "mkdocstrings-python<2",
 ]
+
+[project.urls]
+Homepage = "https://github.com/IvS-KULeuven/cgse"
+Repository = "https://github.com/IvS-KULeuven/cgse"
+Releases = "https://github.com/IvS-KULeuven/cgse/releases"
+Changelog = "https://github.com/IvS-KULeuven/cgse/blob/main/CHANGELOG.md"
+Documentation = "https://ivs-kuleuven.github.io/cgse/"


### PR DESCRIPTION
This release introduces QuestDB line protocol support in the metrics stack and related tooling updates.

Highlights:

- Added a new QuestDB schema mode: line_protocol
- Added HTTP ILP ingestion with configurable host, port, path, timeout, and precision
- Added shared line protocol serialization and reused it in InfluxDB code paths
- Improved per_measurement behavior by falling back to line protocol for measurements without declared schemas
- Extended Metrics Hub configuration validation to accept CGSE_QUESTDB_SCHEMA=line_protocol
- Updated cgse admin database tooling to support line_protocol and handle both time and timestamp temporal columns
- Aligned DuckDB metrics repository temporal column naming to time
- Expanded test coverage for line protocol ingestion, typed-table queries, fallback behavior, and Metrics Hub schema handling
