### PR TITLE
Add version checking functionality to display latest package versions

### DIFF
--- a/libs/cgse-common/src/cgse_common/cgse.py
+++ b/libs/cgse-common/src/cgse_common/cgse.py
@@ -33,6 +33,8 @@ from egse.plugin import HierarchicalEntryPoints
 from egse.plugin import entry_points
 from egse.system import get_package_description
 from egse.system import snake_to_title
+from egse.version import get_version_from_pip
+from egse.version import is_latest_version
 
 
 def broken_command(name: str, module: str, exc: Exception):
@@ -114,10 +116,14 @@ def version(ctx: typer.Context):
     #     rich.print(f"CGSE-CORE installed version = [bold default]{installed_version}[/]")
 
     for ep in sorted(entry_points("cgse.version"), key=lambda x: x.name):
+        pypi_version = get_version_from_pip(ep.name)
+        is_latest = is_latest_version(ep.name)
         if installed_version := get_version_installed(ep.name):
             rich.print(
-                f"{ep.name.upper()} installed version = [bold default]{installed_version}[/] — "
-                f"{get_package_description(ep.name)}"
+                f"{ep.name.upper()} installed version = [bold default]{installed_version}[/] - "
+                f"{get_package_description(ep.name)} - "
+                f"{'latest' if is_latest else 'outdated'}"
+                f"{f' (latest version on PyPI: {pypi_version})' if not is_latest and pypi_version else ''}"
             )
 
 
@@ -168,9 +174,9 @@ def main(ctx: typer.Context, verbose: bool = False):
     """
     The `cgse` command is used to:
 
-    - initialise your project environment
+    - initialize your project environment
 
-    - visualise and check project and environment settings
+    - visualize and check project and environment settings
 
     - inspect, configure, monitor the core services and device control servers.
     """

--- a/libs/cgse-common/src/egse/version.py
+++ b/libs/cgse-common/src/egse/version.py
@@ -12,9 +12,17 @@ The actual numbers are updated for each release in the `settings.yaml` configura
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+import urllib
+from packaging.version import Version
 from pathlib import Path
+from urllib.error import HTTPError
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from packaging.version import Version
 
 # WARNING: Make sure you are not importing any `egse` packages at the module level.
 # This module is magically loaded by pip to determine the VERSION number before the
@@ -27,6 +35,8 @@ __all__ = [
     "get_version_installed",
     "get_version_from_git",
     "get_version_from_settings",
+    "is_latest_version",
+    "is_installed",
     "VERSION",
 ]
 
@@ -136,6 +146,26 @@ def get_version_from_git(location: str | Path | None = None) -> str:
     return version
 
 
+def get_version_from_pip(package_name: str) -> str | None:
+    """
+    Returns the latest version that is available from the Python Package Index (PyPI).
+
+    Args:
+        package_name: the name of the installed package, e.g. cgse or cgse-common
+    Returns:
+        The latest version of the package available on PyPI. When the package is not on PyPI, None is returned.
+    """
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        with urlopen(url) as response:
+            data = json.load(response)
+        latest = data["info"]["version"]
+    except (HTTPError, URLError, json.JSONDecodeError):
+        latest = None
+
+    return latest
+
+
 def get_version_installed(package_name: str) -> str:
     """
     Returns the version that is installed, i.e. read from the metadata in the import lib.
@@ -158,6 +188,49 @@ def get_version_installed(package_name: str) -> str:
             version = "0.0.0"
 
     return version
+
+
+def is_installed(package_name: str) -> bool:
+    """
+    Returns True if package metadata exists in the current environment.
+    """
+    from egse.system import chdir
+
+    with chdir(Path(__file__).parent):
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as get_version
+
+        try:
+            get_version(package_name)
+            return True
+        except PackageNotFoundError:
+            return False
+
+
+def is_latest_version(package_name: str) -> bool:
+    """
+    Checks if the installed version of the package is the latest version available on PyPI.
+
+    If the package is not available on PyPI, it is assumed that the installed version is the latest.
+
+    Args:
+        package_name: the name of the installed package, e.g. cgse or cgse-ts
+
+    Returns:
+        True if the installed version is the latest, False otherwise and if the package is not installed.
+    """
+    if not is_installed(package_name):
+        return False
+
+    installed_version = get_version_installed(package_name)
+    latest_version = get_version_from_pip(package_name)
+
+    if not latest_version:
+        return True
+
+    up_to_date = Version(installed_version) >= Version(latest_version)
+
+    return up_to_date
 
 
 # The version will be the installed version of the `egse.common`, because this is the package that is guaranteed


### PR DESCRIPTION
- Implemented `get_version_from_pip` to fetch the latest version from PyPI.
- Added `is_latest_version` to check if the installed version is up-to-date.
- Updated the `version` command output to indicate if packages are outdated.
- Minor corrections in documentation for clarity.

The `cgse version` command will now inform you which packages are outdated, as an example:

```
$ cgse version
AIM-TTI-AWG installed version = 0.22.0 - Aim-TTi TGF4000 Arbitrary Wave Generator - outdated (latest version on PyPI: 0.25.0)
CGSE-COMMON installed version = 0.25.0 - Software framework to support hardware testing - latest
CGSE-CORE installed version = 0.22.0 - Core services for the CGSE framework - outdated (latest version on PyPI: 0.25.0)
CGSE-GUI installed version = 0.22.0 - GUI components for CGSE - outdated (latest version on PyPI: 0.25.0)
CGSE-TOOLS installed version = 0.22.0 - Tools for CGSE - outdated (latest version on PyPI: 0.25.0)
CUBESPEC-TVAC-TS installed version = 0.0.1 - CubeSpec TVAC testing at KU Leuven - latest
DIGILENT installed version = 0.22.0 - Digilent temperature and voltage monitoring for CGSE - outdated (latest version on PyPI: 0.25.0)
KEITHLEY-TEMPCONTROL installed version = 0.22.0 - Keithley Temperature Control for CGSE - outdated (latest version on PyPI: 0.25.0)
KIKUSUI-POWER-SUPPLY installed version = 0.22.0 - KIKUSUI PMX power supplies - outdated (latest version on PyPI: 0.25.0)
```