### PR TITLE
Fix QuestDB PGWire/ILP race condition and rename timestamp column

### DIFF
--- a/libs/cgse-common/src/egse/plugins/metrics/questdb.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/questdb.py
@@ -99,25 +99,6 @@ class QuestDBRepository(TimeSeriesRepository):
     def _ilp_url(self) -> str:
         return f"http://{self.host}:{self.ilp_port}{self.ilp_path}"
 
-    def _ensure_lp_measurement_table(self, measurement: str) -> None:
-        """Ensure an ILP measurement table exists with `time` as designated timestamp."""
-        if measurement in self._created_tables:
-            return
-
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                sql.SQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS {} (
-                        time TIMESTAMP
-                    ) TIMESTAMP(time) PARTITION BY DAY
-                    """
-                ).format(sql.Identifier(measurement))
-            )
-
-        self._created_tables.add(measurement)
-
     def _write_line_protocol(self, payloads: list[dict[str, Any]]) -> None:
         # Accept payloads that use 'timestamp' as an alias of 'time'.
         normalized_payloads: list[dict[str, Any]] = []
@@ -128,14 +109,6 @@ class QuestDBRepository(TimeSeriesRepository):
             normalized = dict(payload)
             normalized["time"] = payload.get("timestamp")
             normalized_payloads.append(normalized)
-
-        # Create measurement tables with `time` as designated timestamp so LP
-        # ingestion uses consistent temporal-column naming.
-        measurement_names = {
-            str(payload.get("measurement")) for payload in normalized_payloads if payload.get("measurement")
-        }
-        for measurement in measurement_names:
-            self._ensure_lp_measurement_table(measurement)
 
         lines = [line for payload in normalized_payloads if (line := to_line_protocol(payload))]
         if not lines:
@@ -189,6 +162,28 @@ class QuestDBRepository(TimeSeriesRepository):
             self._ping_conn = None
             return False
 
+    def _reconnect_main_conn(self) -> bool:
+        """Recreate the main write connection after an unexpected server disconnect.
+
+        QuestDB may close PGWire connections (e.g. due to a server restart or an
+        internal error during DDL). This method attempts a transparent reconnect so
+        that the next write can retry without requiring a MetricsHub restart.
+        The _created_tables cache is kept intact because the tables still exist in
+        QuestDB after a reconnect.
+        """
+        try:
+            if self.conn is not None:
+                self.conn.close()
+        except Exception:
+            pass
+        self.conn = None
+
+        try:
+            self.conn = self._make_connection()
+            return True
+        except Exception:
+            return False
+
     def connect(self) -> None:
         """Establish connection to QuestDB and create the unified table if using unified schema.
         For the per-measurement schema, tables are created lazily on first write.
@@ -207,10 +202,10 @@ class QuestDBRepository(TimeSeriesRepository):
                         """
                         CREATE TABLE IF NOT EXISTS {} (
                             measurement SYMBOL,
-                            time TIMESTAMP,
+                            timestamp TIMESTAMP,
                             tags VARCHAR,
                             fields VARCHAR
-                        ) TIMESTAMP(time) PARTITION BY DAY
+                        ) TIMESTAMP(timestamp) PARTITION BY DAY
                         """
                     ).format(sql.Identifier(self.table_name))
                 )
@@ -357,7 +352,7 @@ class QuestDBRepository(TimeSeriesRepository):
         if measurement in self._created_tables:
             return
 
-        columns: list[sql.Composable] = [sql.SQL("time TIMESTAMP")]
+        columns: list[sql.Composable] = [sql.SQL("timestamp TIMESTAMP")]
         for column in schema.tags:
             columns.append(
                 sql.SQL("{} {}").format(
@@ -378,7 +373,7 @@ class QuestDBRepository(TimeSeriesRepository):
                     """
                     CREATE TABLE IF NOT EXISTS {} (
                         {}
-                    ) TIMESTAMP(time) PARTITION BY DAY
+                    ) TIMESTAMP(timestamp) PARTITION BY DAY
                     """
                 ).format(sql.Identifier(measurement), sql.SQL(", ").join(columns))
             )
@@ -387,13 +382,8 @@ class QuestDBRepository(TimeSeriesRepository):
         # pre-existed with a different layout (e.g. a prior generic-fallback table
         # with 'tags'/'fields' JSON columns) the CREATE above is a no-op and
         # subsequent typed INSERTs will fail with confusing errors.
-        expected = {"time"} | {c.name for c in schema.tags} | {c.name for c in schema.fields}
-        with self.conn.cursor(row_factory=dict_row) as cur:
-            cur.execute(
-                "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
-                (measurement,),
-            )
-            actual = {row["column_name"] for row in cur.fetchall()}
+        expected = {"timestamp"} | {c.name for c in schema.tags} | {c.name for c in schema.fields}
+        actual = set(self.get_column_names(measurement))
 
         missing = expected - actual
         if missing:
@@ -428,7 +418,7 @@ class QuestDBRepository(TimeSeriesRepository):
                 row.append(self._coerce_value(fields.get(column.name), column.data_type))
             rows.append(tuple(row))
 
-        column_names = ["time"]
+        column_names = ["timestamp"]
         column_names.extend(column.name for column in schema.tags)
         column_names.extend(column.name for column in schema.fields)
 
@@ -443,13 +433,12 @@ class QuestDBRepository(TimeSeriesRepository):
             )
 
     def write(self, points: PointLike | dict | list[PointLike | dict]) -> None:
-        """Write one or more points to QuestDB. The points can be PointLike objects or dicts. For the unified schema,
-        all points are written to the same table with a 'measurement' column. For the per-measurement schema,
-        points are grouped by their 'measurement' and written to separate tables. If a measurement has a
-        declared schema, the data is validated and coerced to the appropriate types before writing.
-        If no schema is declared, fallback ingestion uses line protocol so QuestDB infers typed columns.
-        """
+        """Write one or more points to QuestDB.
 
+        If the server closes the connection unexpectedly (e.g. during a DDL statement
+        for a new measurement table), the connection is transparently re-established and
+        the batch is retried once before raising.
+        """
         if self.conn is None:
             raise ConnectionError("Not connected. Call connect() first.")
 
@@ -458,6 +447,16 @@ class QuestDBRepository(TimeSeriesRepository):
 
         if not isinstance(points, list):
             points = [points]
+
+        try:
+            self._write_impl(points)
+        except psycopg.OperationalError:
+            if not self._reconnect_main_conn():
+                raise
+            self._write_impl(points)
+
+    def _write_impl(self, points: list[PointLike | dict]) -> None:
+        """Internal write implementation. Callers must ensure points is a non-empty list."""
 
         if self.schema == SCHEMA_LINE_PROTOCOL:
             payloads = [self._to_dict(point) for point in points]
@@ -474,9 +473,9 @@ class QuestDBRepository(TimeSeriesRepository):
                 fields = payload.get("fields") or {}
                 rows.append((measurement, timestamp, json.dumps(tags), json.dumps(fields)))
 
-            with self.conn.cursor() as cur:
+            with self.conn.cursor() as cur:  # type: ignore[union-attr]
                 cur.executemany(
-                    sql.SQL("INSERT INTO {} (measurement, time, tags, fields) VALUES (%s, %s, %s, %s)").format(
+                    sql.SQL("INSERT INTO {} (measurement, timestamp, tags, fields) VALUES (%s, %s, %s, %s)").format(
                         sql.Identifier(self.table_name)
                     ),
                     rows,
@@ -530,25 +529,6 @@ class QuestDBRepository(TimeSeriesRepository):
             return rows
 
         raise ValueError(f"Invalid mode '{mode}', use 'all', or 'pandas'.")
-
-    def _ensure_measurement_table(self, measurement: str) -> None:
-        """Create the per-measurement table if it doesn't exist yet (cached)."""
-        if measurement in self._created_tables:
-            return
-        assert self.conn is not None
-        with self.conn.cursor() as cur:
-            cur.execute(
-                sql.SQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS {} (
-                        time TIMESTAMP,
-                        tags VARCHAR,
-                        fields VARCHAR
-                    ) TIMESTAMP(time) PARTITION BY DAY
-                    """
-                ).format(sql.Identifier(measurement))
-            )
-        self._created_tables.add(measurement)
 
     def get_measurement_names(self) -> list[str]:
         """Return distinct measurement names.
@@ -608,31 +588,31 @@ class QuestDBRepository(TimeSeriesRepository):
         if has_fields_json and self.schema == SCHEMA_UNIFIED and measurement is not None:
             query = sql.SQL(
                 """
-                SELECT time, fields
+                SELECT timestamp, fields
                 FROM {}
-                WHERE time >= dateadd('h', -%s, now())
+                WHERE timestamp >= dateadd('h', -%s, now())
                   AND measurement = %s
-                ORDER BY time DESC
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(int(hours), measurement))
         elif has_fields_json:
             query = sql.SQL(
                 """
-                SELECT time, fields
+                SELECT timestamp, fields
                 FROM {}
-                WHERE time >= dateadd('h', -%s, now())
-                ORDER BY time DESC
+                WHERE timestamp >= dateadd('h', -%s, now())
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(int(hours),))
         else:
             query = sql.SQL(
                 """
-                SELECT time, {}
+                SELECT timestamp, {}
                 FROM {}
-                WHERE time >= dateadd('h', -%s, now())
-                ORDER BY time DESC
+                WHERE timestamp >= dateadd('h', -%s, now())
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(column_name), sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(int(hours),))
@@ -663,34 +643,34 @@ class QuestDBRepository(TimeSeriesRepository):
         if has_fields_json and self.schema == SCHEMA_UNIFIED and measurement is not None:
             query = sql.SQL(
                 """
-                SELECT time, fields
+                SELECT timestamp, fields
                 FROM {}
-                WHERE time >= %s
-                  AND time < %s
+                WHERE timestamp >= %s
+                  AND timestamp < %s
                   AND measurement = %s
-                ORDER BY time DESC
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(start_time, end_time, measurement))
         elif has_fields_json:
             query = sql.SQL(
                 """
-                SELECT time, fields
+                SELECT timestamp, fields
                 FROM {}
-                WHERE time >= %s
-                  AND time < %s
-                ORDER BY time DESC
+                WHERE timestamp >= %s
+                  AND timestamp < %s
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(start_time, end_time))
         else:
             query = sql.SQL(
                 """
-                SELECT time, {}
+                SELECT timestamp, {}
                 FROM {}
-                WHERE time >= %s
-                  AND time < %s
-                ORDER BY time DESC
+                WHERE timestamp >= %s
+                  AND timestamp < %s
+                ORDER BY timestamp DESC
                 """
             ).format(sql.Identifier(column_name), sql.Identifier(table_name))
             rows = self.query(query, mode="all", params=(start_time, end_time))
@@ -703,7 +683,7 @@ class QuestDBRepository(TimeSeriesRepository):
     @staticmethod
     def _extract_value(rows: list[dict[str, Any]], column_name: str) -> list[dict[str, Any]]:
         """Extract a typed column value from query results."""
-        return [{"time": row.get("time"), column_name: row.get(column_name)} for row in rows]
+        return [{"timestamp": row.get("timestamp"), column_name: row.get(column_name)} for row in rows]
 
     @staticmethod
     def _extract_field(rows: list[dict[str, Any]], column_name: str) -> list[dict[str, Any]]:
@@ -724,7 +704,7 @@ class QuestDBRepository(TimeSeriesRepository):
             if not isinstance(fields, dict):
                 fields = {}
 
-            result.append({"time": row.get("time"), column_name: fields.get(column_name)})
+            result.append({"timestamp": row.get("timestamp"), column_name: fields.get(column_name)})
 
         return result
 

--- a/libs/cgse-common/tests/test_questdb_integration.py
+++ b/libs/cgse-common/tests/test_questdb_integration.py
@@ -34,7 +34,11 @@ import psycopg
 import pytest
 
 from egse.metrics import DataPoint
+from egse.metrics import MeasurementColumn
+from egse.metrics import MeasurementSchema
+from egse.metrics import clear_measurement_schemas
 from egse.metrics import get_metrics_repo
+from egse.metrics import register_measurement_schema
 from egse.plugins.metrics.questdb import QuestDBRepository
 
 # ---------------------------------------------------------------------------
@@ -47,8 +51,12 @@ QUESTDB_DATABASE = os.environ.get("CGSE_QUESTDB_DATABASE", "qdb")
 QUESTDB_USER = os.environ.get("CGSE_QUESTDB_USER", "admin")
 QUESTDB_PASSWORD = os.environ.get("CGSE_QUESTDB_PASSWORD", "quest")
 
-# Table used by all integration tests — dropped + recreated per test session
+# Table used by unified-schema integration tests
 _INTEGRATION_TABLE = "cgse_integration_test"
+
+# Tables used by per_measurement integration tests
+_PM_ILP_TABLE = "cgse_pm_ilp_test"
+_PM_TYPED_TABLE = "cgse_pm_typed_test"
 
 pytestmark = pytest.mark.integration
 
@@ -73,6 +81,19 @@ def _wait_for_rows(repo: QuestDBRepository, table: str, expected: int, timeout: 
     return 0
 
 
+def _wait_for_table(repo: QuestDBRepository, table: str, timeout: float = 5.0) -> bool:
+    """Poll until ``table`` appears in QuestDB (ILP WAL commit fence)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if table in repo.get_table_names():
+                return True
+        except Exception:
+            pass
+        time.sleep(0.1)
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Session-scoped fixture: live QuestDB repo
 # ---------------------------------------------------------------------------
@@ -92,6 +113,7 @@ def questdb():
         user=QUESTDB_USER,
         password=QUESTDB_PASSWORD,
         table_name=_INTEGRATION_TABLE,
+        schema="unified",
     )
 
     try:
@@ -136,7 +158,7 @@ def test_table_is_listed(questdb):
 def test_column_names(questdb):
     cols = questdb.get_column_names(_INTEGRATION_TABLE)
     assert "measurement" in cols
-    assert "time" in cols
+    assert "timestamp" in cols
     assert "tags" in cols
     assert "fields" in cols
 
@@ -195,14 +217,14 @@ def test_write_batch(questdb):
 def test_query_raw_returns_list(questdb):
     _wait_for_rows(questdb, _INTEGRATION_TABLE, 1)
 
-    rows = questdb.query(f"SELECT * FROM {_INTEGRATION_TABLE} ORDER BY time LIMIT 3", mode="all")
+    rows = questdb.query(f"SELECT * FROM {_INTEGRATION_TABLE} ORDER BY timestamp LIMIT 3", mode="all")
     assert isinstance(rows, list)
     assert len(rows) >= 1
     assert "measurement" in rows[0]
 
 
 def test_query_pandas_returns_dataframe(questdb):
-    df = questdb.query(f"SELECT * FROM {_INTEGRATION_TABLE} ORDER BY time LIMIT 5", mode="pandas")
+    df = questdb.query(f"SELECT * FROM {_INTEGRATION_TABLE} ORDER BY timestamp LIMIT 5", mode="pandas")
     assert isinstance(df, pd.DataFrame)
     assert "measurement" in df.columns
 
@@ -236,14 +258,14 @@ def test_get_values_in_range_returns_list(questdb):
     assert isinstance(rows, list)
     assert len(rows) >= 1
     row = rows[0]
-    assert "time" in row
+    assert "timestamp" in row
     assert "temperature" in row
 
 
 def test_query_field_extraction_from_json(questdb):
     """Verify that _extract_field correctly parses the JSON fields column."""
     rows = questdb.query(
-        f"SELECT time, fields FROM {_INTEGRATION_TABLE} WHERE measurement = 'camera_tm' ORDER BY time LIMIT 5",
+        f"SELECT timestamp, fields FROM {_INTEGRATION_TABLE} WHERE measurement = 'camera_tm' ORDER BY timestamp LIMIT 5",
         mode="all",
     )
     assert rows, "Expected at least one camera_tm row"
@@ -310,3 +332,110 @@ def test_context_manager():
         assert repo.ping() is True
     # After __exit__ the connection is closed
     assert repo.conn is None
+
+
+# ---------------------------------------------------------------------------
+# per_measurement schema tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def questdb_pm():
+    """QuestDBRepository in per_measurement mode.
+
+    Tables are NOT created on connect() — they appear lazily on first write,
+    either via ILP (no schema) or PGWire DDL (declared schema).
+    """
+    repo = QuestDBRepository(
+        host=QUESTDB_HOST,
+        port=QUESTDB_PORT,
+        database=QUESTDB_DATABASE,
+        user=QUESTDB_USER,
+        password=QUESTDB_PASSWORD,
+        schema="per_measurement",
+    )
+
+    try:
+        repo.connect()
+    except Exception as exc:
+        pytest.skip(f"QuestDB not reachable at {QUESTDB_HOST}:{QUESTDB_PORT}: {exc}")
+
+    assert repo.conn is not None
+    with repo.conn.cursor() as cur:
+        for table in (_PM_ILP_TABLE, _PM_TYPED_TABLE):
+            cur.execute(f"DROP TABLE IF EXISTS {table}")
+
+    yield repo
+
+    try:
+        assert repo.conn is not None
+        with repo.conn.cursor() as cur:
+            for table in (_PM_ILP_TABLE, _PM_TYPED_TABLE):
+                cur.execute(f"DROP TABLE IF EXISTS {table}")
+    finally:
+        repo.close()
+
+
+def test_pm_tables_absent_before_write(questdb_pm):
+    """No per-measurement table exists before the first write."""
+    tables = questdb_pm.get_table_names()
+    assert _PM_ILP_TABLE not in tables
+    assert _PM_TYPED_TABLE not in tables
+
+
+def test_pm_ilp_write_creates_table(questdb_pm):
+    """Writing a schema-less measurement creates the table lazily via ILP."""
+    questdb_pm.write(
+        {
+            "measurement": _PM_ILP_TABLE,
+            "tags": {"sensor": "s1"},
+            "fields": {"value": 42.0},
+            "time": "2026-06-21T10:00:00Z",
+        }
+    )
+    assert _wait_for_table(questdb_pm, _PM_ILP_TABLE), f"Table {_PM_ILP_TABLE!r} was not created after ILP write"
+    count = _wait_for_rows(questdb_pm, _PM_ILP_TABLE, 1)
+    assert count >= 1
+
+
+def test_pm_ilp_table_has_expected_columns(questdb_pm):
+    """ILP-created table has QuestDB's native 'timestamp' column plus tag/field columns."""
+    cols = questdb_pm.get_column_names(_PM_ILP_TABLE)
+    assert "timestamp" in cols
+    assert "sensor" in cols
+    assert "value" in cols
+
+
+def test_pm_typed_write_creates_table(questdb_pm):
+    """Writing a measurement with a declared schema creates a typed table synchronously via PGWire DDL."""
+    register_measurement_schema(
+        MeasurementSchema(
+            name=_PM_TYPED_TABLE,
+            tags=(MeasurementColumn("sensor_id", "symbol"),),
+            fields=(MeasurementColumn("temperature", "double"), MeasurementColumn("sample_idx", "long")),
+        )
+    )
+    try:
+        questdb_pm.write(
+            {
+                "measurement": _PM_TYPED_TABLE,
+                "tags": {"sensor_id": "s42"},
+                "fields": {"temperature": 25.0, "sample_idx": 1},
+                "time": "2026-06-21T10:00:00Z",
+            }
+        )
+        # DDL via PGWire is synchronous — table is present immediately
+        assert _PM_TYPED_TABLE in questdb_pm.get_table_names()
+        cols = questdb_pm.get_column_names(_PM_TYPED_TABLE)
+        assert "timestamp" in cols
+        assert "sensor_id" in cols
+        assert "temperature" in cols
+        assert "sample_idx" in cols
+    finally:
+        clear_measurement_schemas()
+
+
+def test_pm_typed_data_is_readable(questdb_pm):
+    """Data written to a typed per_measurement table is visible after WAL commit."""
+    count = _wait_for_rows(questdb_pm, _PM_TYPED_TABLE, 1)
+    assert count >= 1

--- a/libs/cgse-common/tests/test_questdb_plugin.py
+++ b/libs/cgse-common/tests/test_questdb_plugin.py
@@ -55,31 +55,30 @@ class FakeCursor:
         elif "SELECT table_name FROM tables()" in query_text:
             self.conn.rows = [{"table_name": "timeseries"}]
         elif "SHOW COLUMNS FROM" in query_text:
+            # Let tests control per-measurement columns via schema_columns dict.
+            for table_name, cols in self.conn.schema_columns.items():
+                if f'"{table_name}"' in query_text or f"Identifier('{table_name}')" in query_text:
+                    self.conn.rows = [{"column": c} for c in cols]
+                    return
             if "typed_metrics" in query_text:
-                self.conn.rows = [{"column": "time"}, {"column": "temperature"}]
+                self.conn.rows = [{"column": "timestamp"}, {"column": "temperature"}]
             else:
-                self.conn.rows = [{"column": "measurement"}, {"column": "time"}, {"column": "fields"}]
-        elif "information_schema.columns" in query_text:
-            # Return all columns that are expected by any schema registered in the fake.
-            # We model this as: the table was freshly created so all schema columns exist.
-            measurement = params[0] if params else ""
-            cols = self.conn.schema_columns.get(measurement, [])
-            self.conn.rows = [{"column_name": c} for c in cols]
-        elif "SELECT time, fields" in query_text:
+                self.conn.rows = [{"column": "measurement"}, {"column": "timestamp"}, {"column": "fields"}]
+        elif "SELECT timestamp, fields" in query_text:
             self.conn.rows = [
                 {
-                    "time": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
+                    "timestamp": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
                     "fields": '{"temperature": 22.5}',
                 }
             ]
         elif (
-            "SELECT time" in query_text
+            "SELECT timestamp" in query_text
             and "fields" not in query_text
             and ("temperature" in query_text or "Identifier('temperature')" in query_text)
         ):
             self.conn.rows = [
                 {
-                    "time": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
+                    "timestamp": datetime.datetime(2026, 4, 24, 12, 0, tzinfo=datetime.timezone.utc),
                     "temperature": 22.5,
                 }
             ]
@@ -192,7 +191,7 @@ def test_write_and_helpers(monkeypatch):
     assert rows[0][0] == "camera_tm"
 
     assert repo.get_table_names() == ["timeseries"]
-    assert repo.get_column_names("metrics") == ["measurement", "time", "fields"]
+    assert repo.get_column_names("metrics") == ["measurement", "timestamp", "fields"]
 
     values = repo.get_values_last_hours("metrics", "temperature", hours=1, mode="")
     assert len(values) == 1
@@ -221,7 +220,7 @@ def test_write_uses_declared_measurement_schema(monkeypatch):
 
     # Pre-populate fake schema_columns so the column-existence verification in
     # _ensure_schema_table succeeds (simulates the table being freshly created).
-    fake_conn.schema_columns["synthetic_load"] = ["time", "device_id", "profile", "temperature", "sample_idx"]
+    fake_conn.schema_columns["synthetic_load"] = ["timestamp", "device_id", "profile", "temperature", "sample_idx"]
 
     repo = QuestDBRepository(schema="per_measurement")
     repo.connect()
@@ -237,7 +236,8 @@ def test_write_uses_declared_measurement_schema(monkeypatch):
     create_queries = [
         query
         for query, _ in fake_conn.executed
-        if _query_contains(query, 'CREATE TABLE IF NOT EXISTS "synthetic_load"', "synthetic_load")
+        if "CREATE TABLE IF NOT EXISTS" in query
+        and _query_contains(query, 'CREATE TABLE IF NOT EXISTS "synthetic_load"', "synthetic_load")
     ]
     assert len(create_queries) == 1
     # SYMBOL is mapped to VARCHAR for PGWire DDL compatibility
@@ -249,7 +249,7 @@ def test_write_uses_declared_measurement_schema(monkeypatch):
     insert_query, rows = fake_conn.executed_many[-1]
     assert _query_contains(
         insert_query,
-        'INSERT INTO "synthetic_load" ("time", "device_id", "profile", "temperature", "sample_idx")',
+        'INSERT INTO "synthetic_load" ("timestamp", "device_id", "profile", "temperature", "sample_idx")',
         "synthetic_load",
     )
     assert rows[0][1:] == ("srcA_000", "source-A", 21.5, 42)
@@ -267,7 +267,7 @@ def test_write_rejects_unknown_declared_fields(monkeypatch):
         )
     )
 
-    fake_conn.schema_columns["synthetic_load"] = ["time", "device_id", "temperature"]
+    fake_conn.schema_columns["synthetic_load"] = ["timestamp", "device_id", "temperature"]
 
     repo = QuestDBRepository(schema="per_measurement")
     repo.connect()


### PR DESCRIPTION
On Ubuntu with QuestDB 9.4.0, writing to a new measurement via line protocol (ILP) while simultaneously issuing a CREATE TABLE via PGWire caused QuestDB to drop the PGWire connection with psycopg.OperationalError: server closed the connection unexpectedly. This required a MetricsHub restart on every new measurement name.

Changes:

- Remove _ensure_lp_measurement_table() and _ensure_measurement_table() — these methods pre-created tables via PGWire DDL just before ILP writes to the same table, triggering a metadata lock race. ILP auto-creates tables natively; the explicit DDL was the root cause of the MetricsHub errors.
- Add _reconnect_main_conn() and retry in write() — if QuestDB drops the main connection (e.g. during DDL for a typed per_measurement table), the connection is transparently re-established and the batch is retried once. This is a safeguard to minimize data loss.
- Rename designated timestamp column from time to timestamp — aligns PGWire-created tables with ILP auto-created tables, which use timestamp as the default column name. Existing tables created before this change must be dropped and recreated.
- Switch column existence check to SHOW COLUMNS FROM — replaces the fragile information_schema.columns query used in _ensure_schema_table.

Tests:

- Unit tests updated to reflect the timestamp column rename and the switch from information_schema to SHOW COLUMNS FROM.
- Integration test fixture corrected to use schema="unified" explicitly (previously defaulted to per_measurement, so connect() never created the integration table).
- New per_measurement integration test suite added, covering lazy table creation via ILP (schema-less) and synchronous typed table creation via PGWire DDL (declared schema).
