### PR TITLE
update psycopg dependency with binary extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Dependencies
+
+- The `psycopg` package is now always installed with its `binary` extra.
+
 ## [0.25.2] - 2026-06-22
 
 ### IVS ThermalVac

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "influxdb3-python",
     "duckdb>=1.3.1",
     "requests>=2.32.4",
-    "psycopg>=3.2.9",
+    "psycopg[binary]>=3.2.9",
     "python-dotenv>=1.1.1",
     "typing-extensions>=4.14.0",
 ]


### PR DESCRIPTION
Especially on Linux the `psycopg` package needs the binary installed, so we add this  extra in the project dependencies of cgse-common.