### PR TITLE
Fixed InfluxDB file-scan limit detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### CGSE Admin
+
+- Fixed InfluxDB file-scan limit detection in `inspect-db` and `migrate-influx-to-questdb`. The `influxdb.py` query method wraps `InfluxDB3ClientError` in a plain `ValueError` with a generic "check the query" message, discarding the original error text. Both `_is_influx_file_limit_error` (admin) and `_is_influx_query_file_limit_error` (migrate) now walk the full exception chain via `__cause__` to find the original "Query would scan N Parquet files" message, so the file-scan limit fallback behaviour triggers correctly for long-lived measurements that have accumulated many Parquet files.
+
 ## [0.25.3] - 2026-07-01
 
 ### CGSE Admin

--- a/libs/cgse-common/src/egse/plugins/metrics/migrate.py
+++ b/libs/cgse-common/src/egse/plugins/metrics/migrate.py
@@ -658,8 +658,15 @@ def _iter_influx_batches(
 
 
 def _is_influx_query_file_limit_error(exc: Exception) -> bool:
-    message = str(exc).lower()
-    return "query would scan" in message and "exceeding the file limit" in message
+    # Walk the exception chain: influxdb.py wraps InfluxDB3ClientError in a
+    # ValueError whose message omits the original details.
+    candidate: BaseException | None = exc
+    while candidate is not None:
+        msg = str(candidate).lower()
+        if "query would scan" in msg and "exceeding the file limit" in msg:
+            return True
+        candidate = candidate.__cause__
+    return False
 
 
 def migrate(args: argparse.Namespace) -> int:

--- a/projects/generic/cgse-tools/src/cgse_tools/cgse_admin.py
+++ b/projects/generic/cgse-tools/src/cgse_tools/cgse_admin.py
@@ -101,8 +101,15 @@ def _normalize_backend_name(backend: str) -> str:
 
 
 def _is_influx_file_limit_error(exc: Exception) -> bool:
-    msg = str(exc).lower()
-    return "query would scan" in msg and "exceeding the file limit" in msg
+    # Walk the exception chain: influxdb.py wraps InfluxDB3ClientError in a
+    # ValueError whose message omits the original details.
+    candidate: BaseException | None = exc
+    while candidate is not None:
+        msg = str(candidate).lower()
+        if "query would scan" in msg and "exceeding the file limit" in msg:
+            return True
+        candidate = candidate.__cause__
+    return False
 
 
 def _is_read_only_statement(sql: str) -> bool:


### PR DESCRIPTION
Fixed InfluxDB file-scan limit detection in `inspect-db` and `migrate-influx-to-questdb`.