### PR TITLE
bumped to v0.25.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 
+## [0.25.7] - 2026-07-02
+
 ### InfluxDB → QuestDB migration
 
 - Fixed `migrate-influx-to-questdb` writing all migrated rows with the server's current timestamp instead of the original InfluxDB timestamps. The `to_line_protocol` helper only handled `int`, `float`, and `str` timestamps; when the migration passes a `datetime` object (as returned by pandas after converting a `pd.Timestamp`), the timestamp branch was silently skipped and QuestDB fell back to the ingestion time. Added a `datetime` branch that converts to nanosecond epoch so the ILP line carries the correct historical timestamp. This affected measurements migrated via the ILP fallback path (i.e. `per_measurement` schema for measurements without a declared `MeasurementSchema`).
@@ -511,7 +513,8 @@ This release is mainly on maintenance and improvements to the `cgse-common` pack
 - Renamed `cgse` subcommands `registry` →  `reg`, `notify` →  `not`.
 
 
-[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.6...HEAD
+[Unreleased]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.7...HEAD
+[0.25.7]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.6...v0.25.7
 [0.25.6]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.5...v0.25.6
 [0.25.5]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.4...v0.25.5
 [0.25.4]: https://github.com/IvS-KULeuven/cgse/compare/v0.25.3...v0.25.4

--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.25.6"
+version = "0.25.7"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.25.6"
+version = "0.25.7"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.25.6"
+version = "0.25.7"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.25.6"
+version = "0.25.7"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.25.6"
+version = "0.25.7"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.25.6"
+version = "0.25.7"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.25.6"
+version = "0.25.7"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.25.6"
+version = "0.25.7"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.25.6"
+version = "0.25.7"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.25.6"
+version = "0.25.7"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.25.6"
+version = "0.25.7"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.25.6"
+version = "0.25.7"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.25.6"
+version = "0.25.7"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/ivs/tvac/pyproject.toml
+++ b/projects/ivs/tvac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ivs_tvac"
-version = "0.25.6"
+version = "0.25.7"
 description = "Thermal Vacuum Chamber"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.25.6"
+version = "0.25.7"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.25.6"
+version = "0.25.7"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.25.6"
+version = "0.25.7"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.25.6"
+version = "0.25.7"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
Fixed `migrate-influx-to-questdb` writing all migrated rows with the server's current timestamp instead of the original InfluxDB timestamps. The `to_line_protocol` helper only handled `int`, `float`, and `str` timestamps; when the migration passes a `datetime` object (as returned by pandas after converting a `pd.Timestamp`), the timestamp branch was silently skipped and QuestDB fell back to the ingestion time. Added a `datetime` branch that converts to nanosecond epoch so the ILP line carries the correct historical timestamp. This affected measurements migrated via the ILP fallback path (i.e. `per_measurement` schema for measurements without a declared `MeasurementSchema`).