### PR TITLE
bumped version to 0.25.8

### DIFF
--- a/libs/cgse-common/pyproject.toml
+++ b/libs/cgse-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-common"
-version = "0.25.7"
+version = "0.25.8"
 description = "Software framework to support hardware testing"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-coordinates/pyproject.toml
+++ b/libs/cgse-coordinates/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-coordinates"
-version = "0.25.7"
+version = "0.25.8"
 description = "Reference Frames and Coordinate Transofrmations for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-core/pyproject.toml
+++ b/libs/cgse-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-core"
-version = "0.25.7"
+version = "0.25.8"
 description = "Core services for the CGSE framework"
 authors = [
     {name = "IvS KU Leuven"}

--- a/libs/cgse-gui/pyproject.toml
+++ b/libs/cgse-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-gui"
-version = "0.25.7"
+version = "0.25.8"
 description = "GUI components for CGSE"
 authors = [
     {name = "Rik Huygen", email = "rik.huygen@kuleuven.be"},

--- a/projects/ariel/ariel-facility/pyproject.toml
+++ b/projects/ariel/ariel-facility/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-facility"
-version = "0.25.7"
+version = "0.25.8"
 description = "Extract HK from MySQL Facility Database for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/ariel/ariel-tcu/pyproject.toml
+++ b/projects/ariel/ariel-tcu/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ariel-tcu"
-version = "0.25.7"
+version = "0.25.8"
 description = "Telescope Control Unit (TCU) for Ariel"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/aim-tti-awg/pyproject.toml
+++ b/projects/generic/aim-tti-awg/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aim_tti_awg"
-version = "0.25.7"
+version = "0.25.8"
 description = "Aim-TTi TGF4000 Arbitrary Wave Generator"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/cgse-tools/pyproject.toml
+++ b/projects/generic/cgse-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse-tools"
-version = "0.25.7"
+version = "0.25.8"
 description = "Tools for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/digilent/pyproject.toml
+++ b/projects/generic/digilent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "digilent"
-version = "0.25.7"
+version = "0.25.8"
 description = "Digilent temperature and voltage monitoring for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/keithley-tempcontrol/pyproject.toml
+++ b/projects/generic/keithley-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keithley-tempcontrol"
-version = "0.25.7"
+version = "0.25.8"
 description = "Keithley Temperature Control for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/kikusui-power-supply/pyproject.toml
+++ b/projects/generic/kikusui-power-supply/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kikusui_power_supply"
-version = "0.25.7"
+version = "0.25.8"
 description = "KIKUSUI PMX power supplies"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/generic/lakeshore-tempcontrol/pyproject.toml
+++ b/projects/generic/lakeshore-tempcontrol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lakeshore-tempcontrol"
-version = "0.25.7"
+version = "0.25.8"
 description = "Lakeshore Temperature Control for CGSE"
 authors = [
     {name = "IVS KU Leuven"}

--- a/projects/generic/symetrie-hexapod/pyproject.toml
+++ b/projects/generic/symetrie-hexapod/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "symetrie-hexapod"
-version = "0.25.7"
+version = "0.25.8"
 description = "Symetrie Hexapod implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/ivs/tvac/pyproject.toml
+++ b/projects/ivs/tvac/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ivs_tvac"
-version = "0.25.7"
+version = "0.25.8"
 description = "Thermal Vacuum Chamber"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-fits/pyproject.toml
+++ b/projects/plato/plato-fits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-fits"
-version = "0.25.7"
+version = "0.25.8"
 description = "FITS Persistence implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-hdf5/pyproject.toml
+++ b/projects/plato/plato-hdf5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-hdf5"
-version = "0.25.7"
+version = "0.25.8"
 description = "HDF5 Persistence sub-class for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/projects/plato/plato-spw/pyproject.toml
+++ b/projects/plato/plato-spw/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plato-spw"
-version = "0.25.7"
+version = "0.25.8"
 description = "SpaceWire implementation for CGSE"
 authors = [
     {name = "IvS KU Leuven"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cgse"
-version = "0.25.7"
+version = "0.25.8"
 description = "Generic Common-EGSE: Commanding and monitoring lab equipment"
 authors = [
     {name = "IvS KU Leuven"}


### PR DESCRIPTION
Fixed `migrate-influx-to-questdb` crash when a measurement contains a field whose `float64` value is a whole number but exceeds the int64 range (e.g. corrupt sensor data such as `4.1e+36`).