### PR TITLE
Fix service registry host changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### TVAC Updates and Improvements
+
+- Module `async_tvac.py` renamed to `tvac_acs.py` to be consistent with other devices.
+- A new TVAC simulator was added to test and validate workflows without the real chamber hardware.
+- Rename the `tvac` command to `tvac_cs` (control server: `start`/`stop`/`status`/`get-latest`) and add `tvac_sim`
+  (simulator: `start`/`stop`).
+- The `uv run cgse tvac` command now has `start-cs`, `stop-cs`, `start-sim`, and `stop-sim` sub-commands.
+- Lookup table OPC_UA_NODES moved into `tvac_devif.py`.
+- Fixed undefined `service_type` and `service_name` that caused registration of default auto-generated name.
+- Thermal vacuum control now handles temporary connection problems with a backoff reconnection strategy.
+- Added proper registration to the Storage manager and send housekeeping to write into CSV file.
+- Data collection during TVAC runs was improved to better handle sustained streams of measurements.
+- Stopping a running scan is now more responsive, even while the system is waiting between retry attempts.
+- Health and error reporting was improved to make troubleshooting faster and clearer.
+- Test coverage was expanded for `tvac` and device-interface behavior.
+
 ## [0.25.10] - 2026-07-13
 
 ### Logging and CLI Improvements

--- a/libs/cgse-core/src/egse/async_control.py
+++ b/libs/cgse-core/src/egse/async_control.py
@@ -334,6 +334,9 @@ class AsyncControlServer:
         self._service_id = None
         """The unique service ID assigned by the registry on registration, used for deregistration and heartbeats."""
 
+        self.storage_manager_active = False
+        """Set at start-up to whether the Storage Manager was active and this server registered to it."""
+
         self._sequential_queue: asyncio.Queue[Coroutine[Any, Any, Any]] = asyncio.Queue()
         """Queue for sequential operations that must preserve order of execution."""
 
@@ -465,6 +468,15 @@ class AsyncControlServer:
 
         await self.register_service()
 
+        self.storage_manager_active = await asyncio.to_thread(self.is_storage_manager_active)
+        if self.storage_manager_active:
+            self.logger.info(f"Storage Manager is active, registering {self.service_name} to Storage Manager.")
+            await asyncio.to_thread(self.register_to_storage_manager)
+        else:
+            self.logger.warning(
+                f"Storage Manager is not active, housekeeping information will not be stored for {self.service_name}."
+            )
+
         self._tasks = self.create_background_tasks()
 
         try:
@@ -475,6 +487,9 @@ class AsyncControlServer:
             self.logger.debug(f"Caught CancelledError on server keep-alive loop, terminating {type(self).__name__}.")
         finally:
             await self._cleanup_running_tasks()
+
+        if self.storage_manager_active:
+            await asyncio.to_thread(self.unregister_from_storage_manager)
 
         await self.deregister_service()
 
@@ -494,6 +509,20 @@ class AsyncControlServer:
             asyncio.create_task(self.send_status_updates(), name="send-status-updates"),
             asyncio.create_task(self.process_sequential_queue(), name="process-sequential-queue"),
         ]
+
+    def is_storage_manager_active(self) -> bool:
+        """Hook for subclasses: return True if this server should register with the Storage Manager.
+
+        If True, `register_to_storage_manager()` and `unregister_from_storage_manager()` must also
+        be implemented by the subclass.
+        """
+        return False
+
+    def register_to_storage_manager(self) -> None:
+        """Hook for subclasses that need to register with the Storage Manager."""
+
+    def unregister_from_storage_manager(self) -> None:
+        """Hook for subclasses that need to unregister from the Storage Manager."""
 
     async def register_service(self):
         self.logger.info(f"Registering service {self.service_name} as type {self.service_type}")

--- a/libs/cgse-core/src/egse/registry/client.py
+++ b/libs/cgse-core/src/egse/registry/client.py
@@ -11,14 +11,15 @@ from typing import Union
 
 import zmq
 import zmq.asyncio
-
 from egse.env import bool_env
 from egse.log import logging
+from egse.system import do_every
+from egse.system import get_host_ip
+
 from egse.registry import DEFAULT_RS_HB_PORT
 from egse.registry import DEFAULT_RS_PUB_PORT
 from egse.registry import DEFAULT_RS_REQ_PORT
 from egse.registry import MessageType
-from egse.system import do_every
 
 VERBOSE_DEBUG = bool_env("VERBOSE_DEBUG")
 
@@ -243,6 +244,7 @@ class RegistryClient:
         ttl: int = 30,
         singleton: bool = False,
         allow_duplicate_service_type: bool = False,
+        service_id: str | None = None,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -260,6 +262,8 @@ class RegistryClient:
             allow_duplicate_service_type: When True, allow registration even if another
                 service with the same service_type is already registered while the
                 server enforces unique service types globally.
+            service_id: When given, resubmits this exact id so the registry updates the existing
+                entry in place (e.g. to refresh a stale host) instead of allocating a new one.
 
         Returns:
             The service ID if successful, None otherwise
@@ -269,6 +273,9 @@ class RegistryClient:
 
         # Prepare service info
         service_info: dict[str, str | int | dict | list] = {"name": name, "host": host, "port": port}
+
+        if service_id:
+            service_info["id"] = service_id
 
         # Add optional fields
         if service_type:
@@ -345,12 +352,16 @@ class RegistryClient:
             )
             return None
 
+        new_host = get_host_ip() or str(self._service_info["host"])
+
         return self.register(
             name=self._service_info["name"],
-            host=self._service_info["host"],
+            host=new_host,
             port=self._service_info["port"],
-            service_type=self._service_info["type"],
-            metadata=self._service_info["metadata"],
+            service_type=self._service_info.get("type"),
+            metadata=self._service_info.get("metadata"),
+            ttl=self._ttl or 30,
+            service_id=self._service_id,
         )
 
     def discover_service(self, service_type: str) -> dict[str, Any] | None:
@@ -490,6 +501,15 @@ class RegistryClient:
 
         def send_heartbeat():
             try:
+                current_host = get_host_ip()
+                if current_host and self._service_info and current_host != self._service_info.get("host"):
+                    self.logger.info(
+                        f"Detected IP address change ({self._service_info.get('host')} -> {current_host}); "
+                        f"re-registering"
+                    )
+                    self.reregister()
+                    return
+
                 request = {"action": "renew", "service_id": self._service_id}
 
                 response = self._send_heartbeat(request)
@@ -765,6 +785,7 @@ class AsyncRegistryClient:
         ttl: int = 30,
         singleton: bool = False,
         allow_duplicate_service_type: bool = False,
+        service_id: str | None = None,
     ) -> str | None:
         """
         Register this service with the registry.
@@ -782,6 +803,8 @@ class AsyncRegistryClient:
             allow_duplicate_service_type: When True, allow registration even if another
                 service with the same service_type is already registered while the
                 server enforces unique service types globally.
+            service_id: When given, resubmits this exact id so the registry updates the existing
+                entry in place (e.g. to refresh a stale host) instead of allocating a new one.
 
         Returns:
             The service ID if successful, None otherwise
@@ -791,6 +814,9 @@ class AsyncRegistryClient:
 
         # Prepare service info
         service_info: dict[str, Any] = {"name": name, "host": host, "port": port}
+
+        if service_id:
+            service_info["id"] = service_id
 
         # Add optional fields
         if service_type:
@@ -879,12 +905,16 @@ class AsyncRegistryClient:
             )
             return None
 
+        new_host = get_host_ip() or self._service_info["host"]
+
         return await self.register(
             name=self._service_info["name"],
-            host=self._service_info["host"],
+            host=new_host,
             port=self._service_info["port"],
-            service_type=self._service_info["type"],
-            metadata=self._service_info["metadata"],
+            service_type=self._service_info.get("type"),
+            metadata=self._service_info.get("metadata"),
+            ttl=self._ttl or 30,
+            service_id=self._service_id,
         )
 
     async def start_heartbeat(self, interval: int | None = None) -> asyncio.Task | None:
@@ -916,6 +946,16 @@ class AsyncRegistryClient:
             try:
                 while self._running and self._service_id:
                     try:
+                        current_host = get_host_ip()
+                        if current_host and self._service_info and current_host != self._service_info.get("host"):
+                            self.logger.info(
+                                f"Detected IP address change ({self._service_info.get('host')} -> {current_host}); "
+                                f"re-registering"
+                            )
+                            await self.reregister()
+                            await asyncio.sleep(interval)
+                            continue
+
                         request = {"action": "renew", "service_id": self._service_id}
 
                         response = await self._send_heartbeat(request)

--- a/libs/cgse-core/tests/test_async_control.py
+++ b/libs/cgse-core/tests/test_async_control.py
@@ -85,6 +85,28 @@ class SequentialExecutionTestServer(AsyncControlServer):
         return token
 
 
+class StorageAwareTestServer(AsyncControlServer):
+    """Test helper server with instrumented Storage Manager hooks."""
+
+    def __init__(self, active: bool):
+        super().__init__()
+        self._storage_active = active
+        self.storage_calls: list[str] = []
+
+    @override
+    def is_storage_manager_active(self) -> bool:
+        self.storage_calls.append("is_storage_manager_active")
+        return self._storage_active
+
+    @override
+    def register_to_storage_manager(self) -> None:
+        self.storage_calls.append("register_to_storage_manager")
+
+    @override
+    def unregister_from_storage_manager(self) -> None:
+        self.storage_calls.append("unregister_from_storage_manager")
+
+
 @pytest.mark.asyncio
 async def test_control_server(caplog):
     # First start the control server as a background task.
@@ -194,6 +216,42 @@ async def test_control_server_publishes_status_on_monitoring_port():
         server.stop()
         server_task.cancel()
         await asyncio.gather(server_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_control_server_registers_and_unregisters_from_storage_manager_when_active():
+    server = StorageAwareTestServer(active=True)
+    server_task = asyncio.create_task(server.start())
+
+    await asyncio.sleep(0.5)  # give the server time to startup
+
+    assert server.storage_manager_active is True
+    assert server.storage_calls == ["is_storage_manager_active", "register_to_storage_manager"]
+
+    server.stop()
+    await asyncio.wait_for(server_task, timeout=3.0)
+
+    assert server.storage_calls == [
+        "is_storage_manager_active",
+        "register_to_storage_manager",
+        "unregister_from_storage_manager",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_control_server_skips_storage_manager_when_not_active():
+    server = StorageAwareTestServer(active=False)
+    server_task = asyncio.create_task(server.start())
+
+    await asyncio.sleep(0.5)  # give the server time to startup
+
+    assert server.storage_manager_active is False
+    assert server.storage_calls == ["is_storage_manager_active"]
+
+    server.stop()
+    await asyncio.wait_for(server_task, timeout=3.0)
+
+    assert server.storage_calls == ["is_storage_manager_active"]
 
 
 def test_temp_control_server_status_extends_base_status():

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -916,6 +916,83 @@ async def test_client_heartbeat(client, server, req_socket):
     await client.stop_heartbeat()
 
 
+@pytest.mark.asyncio
+async def test_client_register_with_explicit_service_id_updates_in_place(client, server, req_socket):
+    """Passing `service_id` to `register()` should update the existing entry in place (same id, new
+    host) instead of being treated as a brand new registration.
+    """
+    server.enforce_unique_service_types = True
+
+    try:
+        service_id = await client.register(
+            "reconnect-test-service", "1.2.3.4", 8080, service_type="reconnect-test"
+        )
+        assert service_id is not None
+
+        updated_id = await client.register(
+            "reconnect-test-service", "5.6.7.8", 8080, service_type="reconnect-test", service_id=service_id
+        )
+
+        assert updated_id == service_id
+
+        response = await send_request(
+            MessageType.REQUEST_WITH_REPLY, req_socket, {"action": "get", "service_id": service_id}
+        )
+        assert response["service"]["host"] == "5.6.7.8"
+
+        listing = await send_request(
+            MessageType.REQUEST_WITH_REPLY, req_socket, {"action": "list", "service_type": "reconnect-test"}
+        )
+        assert len(listing["services"]) == 1
+    finally:
+        server.enforce_unique_service_types = False
+
+
+@pytest.mark.asyncio
+async def test_client_reregister_refreshes_host(client, server, req_socket, monkeypatch):
+    """`reregister()` should pick up the current IP (via `get_host_ip`) rather than resending the
+    stale cached host, while keeping the same service_id (in-place update).
+    """
+    service_id = await client.register("reregister-test-service", "1.2.3.4", 8080)
+    assert service_id is not None
+
+    monkeypatch.setattr("egse.registry.client.get_host_ip", lambda: "9.9.9.9")
+
+    new_id = await client.reregister()
+
+    assert new_id == service_id
+    assert client._service_info["host"] == "9.9.9.9"
+
+    response = await send_request(
+        MessageType.REQUEST_WITH_REPLY, req_socket, {"action": "get", "service_id": service_id}
+    )
+    assert response["service"]["host"] == "9.9.9.9"
+
+
+@pytest.mark.asyncio
+async def test_client_heartbeat_detects_host_change(client, server, req_socket, monkeypatch):
+    """The heartbeat loop itself should notice an IP change and re-register automatically, not just
+    `reregister()` when called directly.
+    """
+    service_id = await client.register("heartbeat-host-change-service", "1.2.3.4", 8080, ttl=5)
+    assert service_id is not None
+
+    monkeypatch.setattr("egse.registry.client.get_host_ip", lambda: "8.8.4.4")
+
+    await client.start_heartbeat(interval=1)
+
+    try:
+        await asyncio.sleep(1.5)
+
+        response = await send_request(
+            MessageType.REQUEST_WITH_REPLY, req_socket, {"action": "get", "service_id": service_id}
+        )
+        assert response["service"]["host"] == "8.8.4.4"
+        assert response["service"]["id"] == service_id
+    finally:
+        await client.stop_heartbeat()
+
+
 @pytest.mark.timeout(10)
 @pytest.mark.asyncio
 async def test_client_event_listener(client, server, req_socket):

--- a/libs/cgse-core/tests/test_registry_service.py
+++ b/libs/cgse-core/tests/test_registry_service.py
@@ -924,9 +924,7 @@ async def test_client_register_with_explicit_service_id_updates_in_place(client,
     server.enforce_unique_service_types = True
 
     try:
-        service_id = await client.register(
-            "reconnect-test-service", "1.2.3.4", 8080, service_type="reconnect-test"
-        )
+        service_id = await client.register("reconnect-test-service", "1.2.3.4", 8080, service_type="reconnect-test")
         assert service_id is not None
 
         updated_id = await client.register(

--- a/projects/ivs/tvac/pyproject.toml
+++ b/projects/ivs/tvac/pyproject.toml
@@ -28,10 +28,8 @@ dependencies = [
 test = ["pytest", "pytest-mock", "pytest-cov"]
 
 [project.scripts]
-tvac = "egse.ivs.tvac.async_tvac:app"
-
-##[project.gui-scripts]
-##tgf4000_ui = "egse.arbitrary_wave_generator.aim_tti.tgf4000_ui:main"
+tvac_cs = "egse.ivs.tvac.tvac_acs:app"
+tvac_sim = "egse.ivs.tvac.tvac_simulator:app"
 
 [project.entry-points."cgse.version"]
 ivs-tvac = 'egse.version:get_version_installed'

--- a/projects/ivs/tvac/src/egse/ivs/tvac/tvac_acs.py
+++ b/projects/ivs/tvac/src/egse/ivs/tvac/tvac_acs.py
@@ -14,12 +14,13 @@ from egse.ivs.tvac import (
 )
 import asyncio
 import datetime as dt
+import multiprocessing
 import sys
 from typing import Any
 
 import typer
 
-from egse.ivs.tvac.tvac_devif import ThermalVacOpcUaInterface, ThermalVacError
+from egse.ivs.tvac.tvac_devif import OPC_UA_NODES, ThermalVacOpcUaInterface, ThermalVacError
 from egse.metrics import DataPoint
 from egse.settings import get_site_id
 from egse.setup import load_setup
@@ -39,52 +40,21 @@ from egse.metricshub.client import AsyncMetricsHubSender
 
 **Key Architectural Components:**
 
-1. `ThermalVacController` — A `DeviceCommandRouter` sub-class that handles device-specific commands (start-scan, 
-   stop-scan, scan-status, etc.). It implements a command guard pattern that blocks certain commands while a scan is 
+1. `ThermalVacController` — A `DeviceCommandRouter` sub-class that handles device-specific commands (start-scan,
+   stop-scan, scan-status, etc.). It implements a command guard pattern that blocks certain commands while a scan is
    running to prevent conflicts with ongoing DAQ operations.
 
-2. `ThermalVacServices` — A `ServiceCommandRouter` for handling service-level commands like health checks and 
+2. `ThermalVacServices` — A `ServiceCommandRouter` for handling service-level commands like health checks and
    component info.
 
-3. `ThermalVacControlServer` — An `AcquisitionAsyncControlServer` subc-lass that manages the lifecycle of DAQ 
+3. `ThermalVacControlServer` — An `AcquisitionAsyncControlServer` subc-lass that manages the lifecycle of DAQ
    operations, including the background scan loop that reads data and forwards it to metric sinks.
 """
 
 SITE_ID = get_site_id()
 
-# Look-up table, relating the name of the command with the actual command that is passed on to the OPC UA interface
-
-OPC_UA_NODES = {
-    "is_vacuum_gauge_powered": "ns=4;s=MAIN.fbThermalVac.q_bVacuumGaugeOn",
-    "is_vacuum_gauge_error": "ns=4;s=MAIN.fbThermalVac.stSTAT.bVacuumGaugeError",
-    "get_vessel_pressure": "ns=4;s=MAIN.fbThermalVac.stSTAT.rVesselPressure",
-    "get_filtered_vessel_pressure": "ns=4;s=MAIN.fbThermalVac.stSTAT.rVesselPressureFilt",
-    "get_temperatures": "ns=4;s=MAIN.fbThermalVac.stSTAT.rPt100sTempCelcius",
-    "get_dut_temperatures": "ns=4;s=MAIN.fbThermalVac.stSTAT.rDUTTempSensCelcius",
-    "get_dut_temperature_weights": "ns=4;s=MAIN.fbThermalVac.stSTAT.iDUTTempSensWeight",
-    "get_avg_temperature": "ns=4;s=PRG_PID_CALL.fbAverageTemp.output",
-    "temperature_setpoint": "ns=4;s=PRG_PID_CALL.rSetpointTemp",
-    "get_pid_output_cooling": "ns=4;s=PRG_CTRL_PID_Cooling.stPID_STAT.lrOutput",
-    "get_pid_output_heating": "ns=4;s=PRG_CTRL_PID_Heating.stPID_STAT.lrOutput",
-    "temperature_ctrl_active": "ns=4;s=MAIN.fbThermalVac.stCMD.bStartTemperatureControl",
-    "is_scroll_pump_running": "ns=4;s=MAIN.fbThermalVac.stScrollPump_STAT.bRunning",
-    "is_scroll_pump_alarm": "ns=4;s=MAIN.fbThermalVac.stScrollPump_STAT.bAlarm",
-    "get_turbo_pump_rpm": "ns=4;s=MAIN.fbThermalVac.stTurboPump_STAT.udiRotorSpeed",
-    "is_turbo_pump_error": "ns=4;s=MAIN.fbThermalVac.stTurboPump_STAT.bError",
-    "get_tvac_state": "ns=4;s=MAIN.fbThermalVac.stSTAT.eState",
-    "set_stop_pumps": "ns=4;s=MAIN.fbThermalVac.bStopPumps",
-    "is_data_logging_active": "ns=4;s=PRG_DataLogging.bDataLoggingActive",
-    "start_data_logging": "ns=4;s=GVL.bStartDataLogging",
-    "stop_data_logging": "ns=4;s=GVL.bStopDataLogging",
-    "get_data_logging_state": "ns=4;s=PRG_DataLogging.fbDataLogger.eState",
-    "is_data_logging_error": "ns=4;s=PRG_DataLogging.fbDataLogger.bError",
-    "get_data_logging_error_id": "ns=4;s=PRG_DataLogging.fbDataLogger.eErrorId",
-    "get_data_logging_filename": "ns=4;s=PRG_DataLogging.sFileName",
-    "get_data_logging_directory": "ns=4;s=GVL.sDataLoggingDir",
-    "set_file_path_to_read": "ns=4;s=GVL.fbReadFileContents.sFilePath",
-    "trigger_state": "ns=4;s=GVL.fbReadFileContents.eReadState",
-    "get_file_content": "ns=4;s=GVL.fbReadFileContents.sFileContent",
-}
+# Cap [s] for the read-retry backoff in `_run_scan_loop` when the device connection is down.
+SCAN_RETRY_BACKOFF_MAX = 30.0
 
 
 class ThermalVacDaq:
@@ -1493,13 +1463,34 @@ class ThermalVacController(DeviceCommandRouter):
         When calling `start_scan`, this co-routine is schedule (in a spawn task), meaning that - in a loop - the DAQ
         acquires the data in a dictionary, which is handled by the `on_acquisition_data` method of the Control Server.
         This keeps on going as long as the DAQ is running and as long as the `stop_scan` co-routine has not been called.
+
+        A failed read (e.g. the OPC UA connection to the device dropped) does not end the scan: it's retried with
+        a growing backoff (capped at `SCAN_RETRY_BACKOFF_MAX`) until it succeeds or the scan is stopped, so an
+        unattended scan self-heals from a transient device outage instead of silently dying.
         """
+
+        backoff = SAMPLE_INTERVAL
 
         try:
             while not self.scan_stop_event.is_set() and self.daq.is_running():
                 # Data acquisition -> Dictionary with the data
 
-                data = await self.daq.read_buffer_chunk()
+                try:
+                    data = await self.daq.read_buffer_chunk()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    self._cs.logger.error(
+                        f"Buffered scan loop: read failed ({exc}); retrying in {backoff:.0f}s", exc_info=True
+                    )
+                    try:
+                        await asyncio.wait_for(self.scan_stop_event.wait(), timeout=backoff)
+                    except asyncio.TimeoutError:
+                        pass
+                    backoff = min(backoff * 2, SCAN_RETRY_BACKOFF_MAX)
+                    continue
+
+                backoff = SAMPLE_INTERVAL
 
                 # Now handle the data by passing it to `on_acquisition_data`
 
@@ -1552,6 +1543,9 @@ class ThermalVacServices(ServiceCommandRouter):
 
 
 class ThermalVacControlServer(AcquisitionAsyncControlServer):
+    service_type = SERVICE_TYPE
+    service_name = SERVICE_NAME
+
     def __init__(self):
         """Initialisation of ThermalVac Control Server."""
 
@@ -1800,7 +1794,7 @@ class ThermalVacControlServer(AcquisitionAsyncControlServer):
 
         # Best-effort metrics propagation: never block acquisition on sink failures.
         if self._metrics_sender is None:
-            self._metrics_sender: AsyncMetricsHubSender = AsyncMetricsHubSender()
+            self._metrics_sender = AsyncMetricsHubSender()
             self._metrics_sender.connect()  # noqa
 
         try:
@@ -1823,6 +1817,25 @@ class ThermalVacControlServer(AcquisitionAsyncControlServer):
             self.logger.warning(f"Failed to send metric to Metrics Hub: {exc!r}")
             return False
 
+    def create_background_tasks(self) -> list[asyncio.Task]:
+        """Creates the base server tasks plus a task that connects to the OPC UA interface and starts scanning.
+
+        `AsyncControlServer.start()` blocks in its own keep-alive loop until the server is stopped, so connecting
+        to the OPC UA interface and starting the scan cannot be done by simply awaiting them after `super().start()`
+        in `start()` below - that code would only run once the server is already shutting down. Instead, they run
+        as one of the concurrently-scheduled background tasks, like the base class already does for its own tasks.
+        """
+
+        tasks = super().create_background_tasks()
+        tasks.append(asyncio.create_task(self._connect_and_start_scan(), name="tvac-connect-and-start-scan"))
+        return tasks
+
+    async def _connect_and_start_scan(self) -> None:
+        """Connects to the OPC UA interface and starts the data acquisition scan."""
+
+        await self.controller.daq.connect_to_opcua()
+        await self.controller.start_scan()
+
     async def start(self) -> None:
         """Starts the asynchronous ThermalVac Control Server.
 
@@ -1832,10 +1845,9 @@ class ThermalVacControlServer(AcquisitionAsyncControlServer):
             - Starting a data acquisition scan.
         """
 
-        await super().start()
+        multiprocessing.current_process().name = "tvac_cs"
 
-        await self.controller.daq.connect_to_opcua()
-        self.controller.daq.start_scan()
+        await super().start()
 
     def stop(self) -> None:
         """Stops the asynchronous ThermalVac Control Server.
@@ -1856,13 +1868,21 @@ class ThermalVacControlServer(AcquisitionAsyncControlServer):
             self._metrics_sender.close()
             self._metrics_sender = None
 
-        asyncio.run(self.controller.daq.disconnect_from_opcua())
+        if self._loop is not None and self._loop.is_running():
+            # `stop()` is invoked from the (async) "terminate" service command handler, i.e. from inside the
+            # already-running event loop, so `asyncio.run()` would raise "cannot be called from a running
+            # event loop". Schedule the disconnect on that loop instead.
+            self._loop.create_task(self.controller.daq.disconnect_from_opcua())
+        else:
+            asyncio.run(self.controller.daq.disconnect_from_opcua())
 
         super().stop()
 
 
 class ThermalVacControlClient(TypedAsyncControlClient):
     """Typed client wrapper for ThermalVacControlServer commands."""
+
+    service_type = SERVICE_TYPE
 
     async def start_scan(self, *, timeout: float | None = None) -> dict[str, Any] | None:
         response = await self.send_device_command(
@@ -2049,7 +2069,7 @@ app = typer.Typer()
 
 
 @app.command(cls=TyperAsyncCommand)
-async def start_cs():
+async def start():
     """Starts the asynchronous ThermalVac Control Server."""
 
     with remote_logging():
@@ -2068,7 +2088,7 @@ async def start_cs():
 
 
 @app.command(cls=TyperAsyncCommand)
-async def stop_cs():
+async def stop():
     """Sends terminate command to the asynchronous ThermalVac Control Server.
 
     This includes:

--- a/projects/ivs/tvac/src/egse/ivs/tvac/tvac_devif.py
+++ b/projects/ivs/tvac/src/egse/ivs/tvac/tvac_devif.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from egse.device import DeviceConnectionError
 from asyncua import Client, ua
@@ -8,6 +8,43 @@ from asyncua import Client, ua
 from egse.ivs.tvac import DEVICE_SETTINGS
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Look-up table, relating the name of the command with the actual OPC UA node id it corresponds to on the PLC.
+# This table is shared between the real client (`ThermalVacOpcUaInterface`) and the `ThermalVacSimulator`, so both
+# always agree on which nodes exist.
+
+OPC_UA_NODES = {
+    "is_vacuum_gauge_powered": "ns=4;s=MAIN.fbThermalVac.q_bVacuumGaugeOn",
+    "is_vacuum_gauge_error": "ns=4;s=MAIN.fbThermalVac.stSTAT.bVacuumGaugeError",
+    "get_vessel_pressure": "ns=4;s=MAIN.fbThermalVac.stSTAT.rVesselPressure",
+    "get_filtered_vessel_pressure": "ns=4;s=MAIN.fbThermalVac.stSTAT.rVesselPressureFilt",
+    "get_temperatures": "ns=4;s=MAIN.fbThermalVac.stSTAT.rPt100sTempCelcius",
+    "get_dut_temperatures": "ns=4;s=MAIN.fbThermalVac.stSTAT.rDUTTempSensCelcius",
+    "get_dut_temperature_weights": "ns=4;s=MAIN.fbThermalVac.stSTAT.iDUTTempSensWeight",
+    "get_avg_temperature": "ns=4;s=PRG_PID_CALL.fbAverageTemp.output",
+    "temperature_setpoint": "ns=4;s=PRG_PID_CALL.rSetpointTemp",
+    "get_pid_output_cooling": "ns=4;s=PRG_CTRL_PID_Cooling.stPID_STAT.lrOutput",
+    "get_pid_output_heating": "ns=4;s=PRG_CTRL_PID_Heating.stPID_STAT.lrOutput",
+    "temperature_ctrl_active": "ns=4;s=MAIN.fbThermalVac.stCMD.bStartTemperatureControl",
+    "is_scroll_pump_running": "ns=4;s=MAIN.fbThermalVac.stScrollPump_STAT.bRunning",
+    "is_scroll_pump_alarm": "ns=4;s=MAIN.fbThermalVac.stScrollPump_STAT.bAlarm",
+    "get_turbo_pump_rpm": "ns=4;s=MAIN.fbThermalVac.stTurboPump_STAT.udiRotorSpeed",
+    "is_turbo_pump_error": "ns=4;s=MAIN.fbThermalVac.stTurboPump_STAT.bError",
+    "get_tvac_state": "ns=4;s=MAIN.fbThermalVac.stSTAT.eState",
+    "set_stop_pumps": "ns=4;s=MAIN.fbThermalVac.bStopPumps",
+    "is_data_logging_active": "ns=4;s=PRG_DataLogging.bDataLoggingActive",
+    "start_data_logging": "ns=4;s=GVL.bStartDataLogging",
+    "stop_data_logging": "ns=4;s=GVL.bStopDataLogging",
+    "get_data_logging_state": "ns=4;s=PRG_DataLogging.fbDataLogger.eState",
+    "is_data_logging_error": "ns=4;s=PRG_DataLogging.fbDataLogger.bError",
+    "get_data_logging_error_id": "ns=4;s=PRG_DataLogging.fbDataLogger.eErrorId",
+    "get_data_logging_filename": "ns=4;s=PRG_DataLogging.sFileName",
+    "get_data_logging_directory": "ns=4;s=GVL.sDataLoggingDir",
+    "set_file_path_to_read": "ns=4;s=GVL.fbReadFileContents.sFilePath",
+    "trigger_state": "ns=4;s=GVL.fbReadFileContents.eReadState",
+    "get_file_content": "ns=4;s=GVL.fbReadFileContents.sFileContent",
+}
 
 
 class ThermalVacError(Exception):
@@ -32,6 +69,7 @@ class ThermalVacOpcUaInterface:
         self._is_connection_open = False
         self.client = Client(self.server_url)
         self._lock = asyncio.Lock()
+        self._reconnect_lock = asyncio.Lock()
 
     async def connect(self) -> None:
         """Establish the connection to the device."""
@@ -62,8 +100,12 @@ class ThermalVacOpcUaInterface:
 
         async with self._lock:
             if self._is_connection_open:
-                await self.client.disconnect()
-                self._is_connection_open = False
+                try:
+                    await self.client.disconnect()
+                except Exception as e:
+                    LOGGER.warning(f"{self.device_id}: error while disconnecting (ignoring): {e}")
+                finally:
+                    self._is_connection_open = False
 
     async def reconnect(self) -> None:
         """Re-establishes the connection to the device."""
@@ -92,6 +134,32 @@ class ThermalVacOpcUaInterface:
             LOGGER.error(f"Connection health check failed: {e}")
             return False
 
+    async def _call_with_reconnect(self, op: Callable[[], Awaitable[Any]]) -> Any:
+        """Runs `op`, and if it fails, reconnects to the device and retries `op` exactly once.
+
+        This is what lets any read/write self-heal from a dropped OPC UA session (e.g. after the PLC or the
+        simulator briefly drops the connection) without the caller having to know or care about reconnecting.
+
+        Args:
+            op: Zero-argument coroutine function performing the actual OPC UA call.
+
+        Returns:
+            The result of `op()`.
+
+        Raises:
+            Whatever `op()` raises on its second (post-reconnect) attempt.
+        """
+
+        try:
+            return await op()
+        except Exception as e:
+            LOGGER.warning(f"{self.device_id}: I/O failed ({e}); reconnecting and retrying once")
+            async with self._reconnect_lock:
+                # Re-check: a concurrent caller may have already reconnected while we were waiting for the lock.
+                if not await self.is_connected():
+                    await self.reconnect()
+            return await op()
+
     async def read_node(self, command: str) -> Any:
         """Transmits the given command to the device and returns the response.
 
@@ -99,14 +167,20 @@ class ThermalVacOpcUaInterface:
             Response from the device.
         """
 
-        async with self._lock:
-            variable = self.client.get_node(command)
-            return await variable.read_value()
+        async def _op():
+            async with self._lock:
+                variable = self.client.get_node(command)
+                return await variable.read_value()
+
+        return await self._call_with_reconnect(_op)
 
     async def write_node(self, command: str, value, data_type: ua.VariantType) -> None:
-        async with self._lock:
-            variable = self.client.get_node(command)
-            await variable.set_value(ua.DataValue(ua.Variant(value, data_type)))
+        async def _op():
+            async with self._lock:
+                variable = self.client.get_node(command)
+                await variable.set_value(ua.DataValue(ua.Variant(value, data_type)))
+
+        await self._call_with_reconnect(_op)
 
     @property
     def server_url(self):

--- a/projects/ivs/tvac/src/egse/ivs/tvac/tvac_simulator.py
+++ b/projects/ivs/tvac/src/egse/ivs/tvac/tvac_simulator.py
@@ -1,0 +1,389 @@
+"""A minimal OPC UA simulator for the ThermalVac PLC.
+
+This exposes the same OPC UA nodes as the real device (see `OPC_UA_NODES` in `tvac_devif.py`), pre-loaded with
+static, plausible values, so the ThermalVac Control Server can be developed and tested without access to the
+physical hardware.
+
+Nodes are read/write exactly like on the real device: unregistered node ids and writes to read-only nodes are
+rejected by the OPC UA server itself (`BadNodeIdUnknown` / `BadNotWritable`), we don't need to implement that.
+
+Only one bit of device-side behaviour is simulated for now: the `start_data_logging` / `stop_data_logging`
+"pulse" bits are consumed by a background task, which updates `is_data_logging_active` accordingly and refuses to
+start a scan that is already running (reflected as `is_data_logging_error` / `get_data_logging_error_id`, since on
+a real OPC UA device a write to a command bit always succeeds — a busy/rejected command is reported back through
+separate status nodes, not through a failed write).
+
+The PLC file-read protocol (`trigger_state` and friends, see `ThermalVacDaq.read_file_from_plc`) is not simulated
+yet: `trigger_state` just holds whatever was last written to it, so `read_file_from_plc()` will time out against
+this simulator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import multiprocessing
+import os
+import random
+import signal
+import time
+from pathlib import Path
+from typing import Any
+
+import typer
+from asyncua import Server, ua
+from rich.console import Console
+
+from egse.env import get_log_file_location
+from egse.ivs.tvac import DEVICE_SETTINGS
+from egse.ivs.tvac.tvac_devif import OPC_UA_NODES
+from egse.process import kill_process
+from egse.system import TyperAsyncCommand
+
+LOGGER = logging.getLogger(__name__)
+
+# Poll interval [s] for the background task that reacts to pulse-bit writes.
+POLL_INTERVAL = 0.2
+
+DATA_LOGGING_IDLE = 0
+DATA_LOGGING_RUNNING = 1
+
+# --- Simulated temperature/pressure profile ---------------------------------------------------
+#
+# A repeating 1-hour thermal cycle, so Grafana/MetricsHub dashboards fed by this simulator have
+# something more realistic to show than a flat line: the chamber cools from room temperature down
+# to -20 degC over 20 minutes, holds for 10 minutes, then heats back up to room temperature over
+# 30 minutes. The vessel pressure follows the same phase timing, pumping down to a rough vacuum
+# while the chamber cools and venting back to atmosphere while it heats up. Both curves are
+# asymptotic (fast at first, slowing down towards the target), which is how pump-down/vent and
+# thermal transients actually behave.
+
+PROFILE_PERIOD = 3600.0  # s, total duration of one thermal cycle
+COOLING_DURATION = 1200.0  # s, 20 min
+STABLE_DURATION = 600.0  # s, 10 min
+HEATING_DURATION = 1800.0  # s, 30 min
+
+ROOM_TEMPERATURE = 20.0  # degC
+COLD_TEMPERATURE = -20.0  # degC
+
+ATMOSPHERIC_PRESSURE = 1000.0  # mbar, matches the simulator's baseline value
+HIGH_VACUUM_PRESSURE = 1.0e-3  # mbar
+
+# Per-sensor offsets so the individual channels don't all read exactly the same value.
+PT100_OFFSETS = (0.0, 0.4, -0.3)
+DUT_OFFSETS = (0.2, -0.5, 0.1)
+
+TEMPERATURE_NOISE_STD = 0.05  # degC
+PRESSURE_NOISE_FRAC = 0.02  # relative (2%) noise on the raw pressure reading
+
+PROFILE_UPDATE_INTERVAL = 1.0  # s
+
+
+def _asymptotic_approach(elapsed: float, duration: float, start: float, end: float) -> float:
+    """Interpolates from `start` to `end` over `duration` seconds, changing quickly at first and
+    slowing down as it nears `end` (exponential asymptote), landing exactly on `end` when
+    `elapsed >= duration`.
+    """
+
+    if elapsed <= 0:
+        return start
+    if elapsed >= duration:
+        return end
+
+    tau = duration / 3.0
+    raw = 1 - math.exp(-elapsed / tau)
+    norm = 1 - math.exp(-duration / tau)
+    return start + (end - start) * (raw / norm)
+
+
+def _base_temperature(elapsed_in_cycle: float) -> float:
+    """The noise-free chamber temperature [degC] at a point in the 1-hour thermal cycle."""
+
+    if elapsed_in_cycle < COOLING_DURATION:
+        return _asymptotic_approach(elapsed_in_cycle, COOLING_DURATION, ROOM_TEMPERATURE, COLD_TEMPERATURE)
+    elif elapsed_in_cycle < COOLING_DURATION + STABLE_DURATION:
+        return COLD_TEMPERATURE
+    else:
+        heating_elapsed = elapsed_in_cycle - COOLING_DURATION - STABLE_DURATION
+        return _asymptotic_approach(heating_elapsed, HEATING_DURATION, COLD_TEMPERATURE, ROOM_TEMPERATURE)
+
+
+def _base_pressure(elapsed_in_cycle: float) -> float:
+    """The noise-free vessel pressure [mbar] at a point in the 1-hour thermal cycle."""
+
+    if elapsed_in_cycle < COOLING_DURATION:
+        return _asymptotic_approach(elapsed_in_cycle, COOLING_DURATION, ATMOSPHERIC_PRESSURE, HIGH_VACUUM_PRESSURE)
+    elif elapsed_in_cycle < COOLING_DURATION + STABLE_DURATION:
+        return HIGH_VACUUM_PRESSURE
+    else:
+        heating_elapsed = elapsed_in_cycle - COOLING_DURATION - STABLE_DURATION
+        return _asymptotic_approach(heating_elapsed, HEATING_DURATION, HIGH_VACUUM_PRESSURE, ATMOSPHERIC_PRESSURE)
+
+# Variant type, initial value and read/write access for every node in OPC_UA_NODES.
+#
+# The variant type must be declared explicitly and must match what the client reads/writes: OPC UA is
+# strongly typed, e.g. `ua.VariantType.Float` (32-bit) and `.Double` (64-bit) are NOT interchangeable, and a
+# write with the "wrong" numeric variant is rejected with `BadTypeMismatch` — exactly as a real device would.
+
+NODE_SPECS: dict[str, tuple[ua.VariantType, Any, bool]] = {
+    "is_vacuum_gauge_powered": (ua.VariantType.Boolean, True, False),
+    "is_vacuum_gauge_error": (ua.VariantType.Boolean, False, False),
+    "get_vessel_pressure": (ua.VariantType.Float, 1000.0, False),
+    "get_filtered_vessel_pressure": (ua.VariantType.Float, 1000.0, False),
+    "get_temperatures": (ua.VariantType.Float, [20.0, 20.0, 20.0], False),
+    "get_dut_temperatures": (ua.VariantType.Float, [20.0, 20.0, 20.0], False),
+    "get_dut_temperature_weights": (ua.VariantType.Int32, [1, 1, 1], False),
+    "get_avg_temperature": (ua.VariantType.Float, 20.0, False),
+    "temperature_setpoint": (ua.VariantType.Float, 20.0, True),
+    "get_pid_output_cooling": (ua.VariantType.Float, 0.0, False),
+    "get_pid_output_heating": (ua.VariantType.Float, 0.0, False),
+    "temperature_ctrl_active": (ua.VariantType.Boolean, False, True),
+    "is_scroll_pump_running": (ua.VariantType.Boolean, False, False),
+    "is_scroll_pump_alarm": (ua.VariantType.Boolean, False, False),
+    "get_turbo_pump_rpm": (ua.VariantType.Int32, 0, False),
+    "is_turbo_pump_error": (ua.VariantType.Boolean, False, False),
+    "get_tvac_state": (ua.VariantType.Int32, 1, False),  # 1 = Idle, see `tvac_state_to_string`
+    "set_stop_pumps": (ua.VariantType.Boolean, False, True),
+    "is_data_logging_active": (ua.VariantType.Boolean, False, False),
+    "start_data_logging": (ua.VariantType.Boolean, False, True),
+    "stop_data_logging": (ua.VariantType.Boolean, False, True),
+    "get_data_logging_state": (ua.VariantType.Int32, DATA_LOGGING_IDLE, False),
+    "is_data_logging_error": (ua.VariantType.Boolean, False, False),
+    "get_data_logging_error_id": (ua.VariantType.Int32, 0, False),
+    "get_data_logging_filename": (ua.VariantType.String, "", False),
+    "get_data_logging_directory": (ua.VariantType.String, "C:\\Logs", False),
+    "set_file_path_to_read": (ua.VariantType.String, "", True),
+    "trigger_state": (ua.VariantType.Int32, 0, True),
+    "get_file_content": (ua.VariantType.String, "", False),
+}
+
+
+class ThermalVacSimulator:
+    """A minimal OPC UA server standing in for the ThermalVac PLC."""
+
+    def __init__(self, hostname: str | None = None, port: int | None = None):
+        """Initialisation of the ThermalVac simulator.
+
+        Args:
+            hostname (str | None): Hostname to listen on. If None, read from the settings.
+            port (int | None): Port to listen on. If None, read from the settings.
+        """
+
+        self.hostname = DEVICE_SETTINGS["HOSTNAME"] if hostname is None else hostname
+        self.port = DEVICE_SETTINGS["PORT"] if port is None else port
+
+        self.server = Server()
+        self._nodes: dict[str, Any] = {}
+        self._poll_task: asyncio.Task | None = None
+        self._profile_task: asyncio.Task | None = None
+
+    @property
+    def server_url(self) -> str:
+        return f"opc.tcp://{self.hostname}:{self.port}"
+
+    async def start(self) -> None:
+        """Initialises the OPC UA server, registers all simulated nodes and starts listening."""
+
+        multiprocessing.current_process().name = "tvac_sim"
+
+        await self.server.init()
+        self.server.set_endpoint(self.server_url)
+
+        objects = self.server.get_objects_node()
+
+        for key, node_id in OPC_UA_NODES.items():
+            variant_type, initial_value, writable = NODE_SPECS[key]
+            node = await objects.add_variable(node_id, f"4:{key}", initial_value, varianttype=variant_type)
+            if writable:
+                await node.set_writable()
+            self._nodes[key] = node
+
+        await self.server.start()
+
+        self._poll_task = asyncio.create_task(self._poll_loop(), name="tvac-simulator-poll")
+        self._profile_task = asyncio.create_task(self._profile_loop(), name="tvac-simulator-profile")
+
+        LOGGER.info(f"ThermalVac simulator listening on {self.server_url}")
+
+    async def stop(self) -> None:
+        """Stops the background tasks and the OPC UA server."""
+
+        tasks = [t for t in (self._poll_task, self._profile_task) if t is not None]
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._poll_task = None
+        self._profile_task = None
+
+        await self.server.stop()
+
+        LOGGER.info("ThermalVac simulator stopped")
+
+    async def _write(self, key: str, value: Any) -> None:
+        """Writes a node's value using its declared OPC UA variant type.
+
+        `Node.write_value()` infers a variant type from the Python type of `value` when none is given, which
+        does not necessarily match the node's declared type (e.g. a Python `int` is inferred as `Int64`, not
+        `Int32`) and would be rejected with `BadTypeMismatch`. Always writing with the type from `NODE_SPECS`
+        avoids that.
+        """
+
+        variant_type, _, _ = NODE_SPECS[key]
+        await self._nodes[key].write_value(value, varianttype=variant_type)
+
+    async def _poll_loop(self) -> None:
+        """Background task that plays the role of the PLC logic reacting to command bits."""
+
+        while True:
+            try:
+                await self._handle_data_logging_commands()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.exception("ThermalVac simulator poll loop iteration failed")
+
+            await asyncio.sleep(POLL_INTERVAL)
+
+    async def _handle_data_logging_commands(self) -> None:
+        """Consumes the start/stop data-logging pulse bits and updates the logging status nodes."""
+
+        start_requested = await self._nodes["start_data_logging"].read_value()
+        stop_requested = await self._nodes["stop_data_logging"].read_value()
+        is_active = await self._nodes["is_data_logging_active"].read_value()
+
+        if start_requested:
+            await self._write("start_data_logging", False)  # command bits are one-shot pulses
+
+            if is_active:
+                # Not allowed: a scan is already running. A real write never fails for this; the PLC
+                # reports the rejection through the error nodes instead.
+                await self._write("is_data_logging_error", True)
+                await self._write("get_data_logging_error_id", 1)
+            else:
+                await self._write("is_data_logging_active", True)
+                await self._write("get_data_logging_state", DATA_LOGGING_RUNNING)
+                await self._write("is_data_logging_error", False)
+
+        if stop_requested:
+            await self._write("stop_data_logging", False)
+
+            if is_active:
+                await self._write("is_data_logging_active", False)
+                await self._write("get_data_logging_state", DATA_LOGGING_IDLE)
+            # Stopping while not running: the real PLC would just ignore this, so we do too.
+
+    async def _profile_loop(self) -> None:
+        """Background task that continuously writes a repeating 1-hour temperature/pressure profile
+        to the simulated housekeeping nodes (see the module docstring above `PROFILE_PERIOD`).
+        """
+
+        start_time = time.monotonic()
+
+        while True:
+            try:
+                elapsed_in_cycle = (time.monotonic() - start_time) % PROFILE_PERIOD
+                await self._update_temperatures(elapsed_in_cycle)
+                await self._update_pressures(elapsed_in_cycle)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.exception("ThermalVac simulator profile loop iteration failed")
+
+            await asyncio.sleep(PROFILE_UPDATE_INTERVAL)
+
+    async def _update_temperatures(self, elapsed_in_cycle: float) -> None:
+        base = _base_temperature(elapsed_in_cycle)
+
+        pt100_temperatures = [base + offset + random.gauss(0.0, TEMPERATURE_NOISE_STD) for offset in PT100_OFFSETS]
+        dut_temperatures = [base + offset + random.gauss(0.0, TEMPERATURE_NOISE_STD) for offset in DUT_OFFSETS]
+
+        await self._write("get_temperatures", pt100_temperatures)
+        await self._write("get_dut_temperatures", dut_temperatures)
+        await self._write("get_avg_temperature", base)
+
+    async def _update_pressures(self, elapsed_in_cycle: float) -> None:
+        base = _base_pressure(elapsed_in_cycle)
+        noisy = base * (1 + random.gauss(0.0, PRESSURE_NOISE_FRAC))
+
+        await self._write("get_vessel_pressure", noisy)
+        await self._write("get_filtered_vessel_pressure", base)
+
+    async def __aenter__(self) -> "ThermalVacSimulator":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()
+
+
+# ----- CLI Commands ------------------------------------------------------------------------------------------------
+
+app = typer.Typer()
+
+
+def _simulator_pid_file() -> Path:
+    """Location of the ThermalVac simulator's pid file, used by `stop` to find the running process.
+
+    A pid file (write our own pid on start, read + kill that exact pid on stop) is used instead of matching
+    processes by name/command line: a `start`/`stop` substring search can accidentally match unrelated
+    processes whose command line happens to mention those words (e.g. a shell running a script that itself
+    contains the text "tvac_sim start", such as this very CLI's own test/dev tooling).
+    """
+
+    return Path(get_log_file_location()).expanduser() / "tvac-simulator.pid"
+
+
+@app.command(cls=TyperAsyncCommand)
+async def start():
+    """Starts the ThermalVac OPC UA simulator (blocks until interrupted)."""
+
+    console = Console()
+    simulator = ThermalVacSimulator()
+
+    pid_file = _simulator_pid_file()
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()))
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    # SIGINT (Ctrl-C) is turned into a KeyboardInterrupt automatically, but SIGTERM (what `stop` sends via
+    # `kill_process`) is not: by default it kills the process immediately, without running this coroutine's
+    # `finally` block below. Handling both explicitly guarantees `simulator.stop()` always runs, mirroring
+    # the pattern `reg_cs` uses (see `egse.registry.server.start`).
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop_event.set)
+
+    try:
+        await simulator.start()
+        console.print(f"ThermalVac simulator listening on [green]{simulator.server_url}[/]. Press Ctrl-C to stop.")
+        await stop_event.wait()
+    finally:
+        await simulator.stop()
+        pid_file.unlink(missing_ok=True)
+
+
+@app.command(cls=TyperAsyncCommand)
+async def stop():
+    """Terminates a running ThermalVac OPC UA simulator process."""
+
+    console = Console()
+    pid_file = _simulator_pid_file()
+
+    if not pid_file.exists():
+        console.print("No running ThermalVac simulator process found.", style="yellow")
+        return
+
+    pid = int(pid_file.read_text().strip())
+
+    if kill_process(pid):
+        console.print(f"Stopped ThermalVac simulator (pid={pid}).")
+    else:
+        console.print(f"ThermalVac simulator (pid={pid}) was not running.", style="yellow")
+
+    pid_file.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/projects/ivs/tvac/src/egse/ivs/tvac/tvac_simulator.py
+++ b/projects/ivs/tvac/src/egse/ivs/tvac/tvac_simulator.py
@@ -120,6 +120,7 @@ def _base_pressure(elapsed_in_cycle: float) -> float:
         heating_elapsed = elapsed_in_cycle - COOLING_DURATION - STABLE_DURATION
         return _asymptotic_approach(heating_elapsed, HEATING_DURATION, HIGH_VACUUM_PRESSURE, ATMOSPHERIC_PRESSURE)
 
+
 # Variant type, initial value and read/write access for every node in OPC_UA_NODES.
 #
 # The variant type must be declared explicitly and must match what the client reads/writes: OPC UA is

--- a/projects/ivs/tvac/src/ivs_tvac/cgse_services.py
+++ b/projects/ivs/tvac/src/ivs_tvac/cgse_services.py
@@ -11,28 +11,54 @@ from egse.system import redirect_output_to_log
 tvac = typer.Typer(name="tvac", help="Thermal Vacuum Chamber", no_args_is_help=True)
 
 
-@tvac.command(name="start")
-def start_tvac():
-    """Starts the ThermalVac service."""
+@tvac.command(name="start-cs")
+def start_tvac_cs():
+    """Starts the ThermalVac control server service."""
 
-    rich.print("Starting ThermalVac service")
+    rich.print("Starting ThermalVac control server service")
 
-    out = redirect_output_to_log("tvac.start.log")
+    out = redirect_output_to_log("tvac.start-cs.log")
 
-    cmd = [sys.executable, "-m", "egse.ivs.tvac.async_tvac", "start"]
+    cmd = [sys.executable, "-m", "egse.ivs.tvac.tvac_acs", "start"]
 
     subprocess.Popen(cmd, stdout=out, stderr=out, stdin=subprocess.DEVNULL, close_fds=True)
 
 
-@tvac.command(name="stop")
-def stop_tvac():
-    """Stops the ThermalVac service."""
+@tvac.command(name="stop-cs")
+def stop_tvac_cs():
+    """Stops the ThermalVac control server service."""
 
-    rich.print("Terminating the ThermalVac service")
+    rich.print("Terminating the ThermalVac control server service")
 
-    out = redirect_output_to_log("tvac.stop.log")
+    out = redirect_output_to_log("tvac.stop-cs.log")
 
-    cmd = [sys.executable, "-m", "egse.ivs.tvac.async_tvac", "stop"]
+    cmd = [sys.executable, "-m", "egse.ivs.tvac.tvac_acs", "stop"]
+
+    subprocess.Popen(cmd, stdout=out, stderr=out, stdin=subprocess.DEVNULL, close_fds=True)
+
+
+@tvac.command(name="start-sim")
+def start_tvac_sim():
+    """Starts the ThermalVac OPC UA simulator service."""
+
+    rich.print("Starting ThermalVac OPC UA simulator service")
+
+    out = redirect_output_to_log("tvac.start-sim.log")
+
+    cmd = [sys.executable, "-m", "egse.ivs.tvac.tvac_simulator", "start"]
+
+    subprocess.Popen(cmd, stdout=out, stderr=out, stdin=subprocess.DEVNULL, close_fds=True)
+
+
+@tvac.command(name="stop-sim")
+def stop_tvac_sim():
+    """Stops the ThermalVac OPC UA simulator service."""
+
+    rich.print("Terminating the ThermalVac OPC UA simulator service")
+
+    out = redirect_output_to_log("tvac.stop-sim.log")
+
+    cmd = [sys.executable, "-m", "egse.ivs.tvac.tvac_simulator", "stop"]
 
     subprocess.Popen(cmd, stdout=out, stderr=out, stdin=subprocess.DEVNULL, close_fds=True)
 
@@ -42,6 +68,6 @@ def status_tvac():
     """Prints status information for the ThermalVac service."""
 
     with all_logging_disabled():
-        from egse.ivs.tvac import async_tvac
+        from egse.ivs.tvac import tvac_acs
 
-        asyncio.run(async_tvac.status())
+        asyncio.run(tvac_acs.status())

--- a/projects/ivs/tvac/tests/test_thermalvac_acs.py
+++ b/projects/ivs/tvac/tests/test_thermalvac_acs.py
@@ -1,0 +1,99 @@
+"""Unit tests for ThermalVacController._run_scan_loop's retry/backoff behaviour."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from egse.ivs.tvac import tvac_acs
+from egse.ivs.tvac.tvac_acs import ThermalVacController
+
+
+def make_fake_controller():
+    """A minimal duck-typed stand-in exposing only what `_run_scan_loop` touches, so the test doesn't
+    need to construct a full `ThermalVacController` (which requires a real control server / ZMQ setup).
+    """
+
+    fake = MagicMock()
+    fake.scan_stop_event = asyncio.Event()
+    fake.daq.is_running.return_value = True
+    fake.daq.stop_scan = MagicMock()
+    fake._cs.logger = MagicMock()
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_scan_loop_retries_on_read_failure_instead_of_dying(monkeypatch):
+    """A failed `read_buffer_chunk()` must not end the scan: the loop keeps retrying (with backoff) until
+    a read succeeds, instead of the previous behaviour of logging one ERROR and returning for good.
+    """
+
+    monkeypatch.setattr(tvac_acs, "SAMPLE_INTERVAL", 0.01)
+    monkeypatch.setattr(tvac_acs, "SCAN_RETRY_BACKOFF_MAX", 0.02)
+
+    fake = make_fake_controller()
+    fake.daq.read_buffer_chunk = AsyncMock(
+        side_effect=[ConnectionError("client is disconnected"), ConnectionError("client is disconnected"), {"ok": 1}]
+    )
+
+    def stop_after_first_success(*args, **kwargs):
+        fake.scan_stop_event.set()
+
+    fake._cs.on_acquisition_data = MagicMock(side_effect=stop_after_first_success)
+
+    await asyncio.wait_for(ThermalVacController._run_scan_loop(fake), timeout=5)
+
+    assert fake.daq.read_buffer_chunk.call_count == 3
+    assert fake._cs.logger.error.call_count == 2  # one per failed read
+    fake._cs.on_acquisition_data.assert_called_once_with(
+        {"ok": 1}, source="tvac-buffer", metadata={"mode": "buffered-scan"}
+    )
+    fake.daq.stop_scan.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_loop_stops_retrying_once_scan_is_stopped(monkeypatch):
+    """Setting `scan_stop_event` while the loop is backed off waiting to retry must interrupt that wait
+    promptly, rather than blocking for the full backoff duration.
+    """
+
+    monkeypatch.setattr(tvac_acs, "SAMPLE_INTERVAL", 0.01)
+    monkeypatch.setattr(tvac_acs, "SCAN_RETRY_BACKOFF_MAX", 30.0)  # deliberately large
+
+    fake = make_fake_controller()
+    fake.daq.read_buffer_chunk = AsyncMock(side_effect=ConnectionError("client is disconnected"))
+    fake._cs.on_acquisition_data = MagicMock()
+
+    async def stop_soon():
+        await asyncio.sleep(0.05)
+        fake.scan_stop_event.set()
+
+    stopper = asyncio.create_task(stop_soon())
+
+    # If the stop event didn't interrupt the backoff wait, this would block for ~30s and hit the timeout.
+    await asyncio.wait_for(ThermalVacController._run_scan_loop(fake), timeout=2)
+    await stopper
+
+    fake._cs.on_acquisition_data.assert_not_called()
+    fake.daq.stop_scan.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_scan_loop_still_ends_on_unexpected_non_read_error(monkeypatch):
+    """Errors outside the read path (e.g. a bug in `on_acquisition_data`) are not retried indefinitely —
+    the outer safety net still logs and ends the loop, same as before this change.
+    """
+
+    monkeypatch.setattr(tvac_acs, "SAMPLE_INTERVAL", 0.01)
+    monkeypatch.setattr(tvac_acs, "SCAN_RETRY_BACKOFF_MAX", 0.02)
+
+    fake = make_fake_controller()
+    fake.daq.read_buffer_chunk = AsyncMock(return_value={"ok": 1})
+    fake._cs.on_acquisition_data = MagicMock(side_effect=RuntimeError("bug, not a connectivity issue"))
+
+    await asyncio.wait_for(ThermalVacController._run_scan_loop(fake), timeout=5)
+
+    fake.daq.read_buffer_chunk.assert_called_once()
+    fake._cs.logger.error.assert_called_once()
+    assert "Buffered scan loop failed" in fake._cs.logger.error.call_args.args[0]
+    fake.daq.stop_scan.assert_called_once()

--- a/projects/ivs/tvac/tests/test_thermalvac_devif.py
+++ b/projects/ivs/tvac/tests/test_thermalvac_devif.py
@@ -7,7 +7,7 @@ import pytest
 from asyncua import Client, ua
 
 from egse.device import DeviceConnectionError
-from egse.ivs.tvac.thermalvac_devif import ThermalVacOpcUaInterface
+from egse.ivs.tvac.tvac_devif import ThermalVacOpcUaInterface
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def mock_client():
 @pytest.fixture
 def thermalvac_interface(default_hostname, default_port, mock_client):
     """Create ThermalVacOpcUaInterface instance with mocked client."""
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=default_hostname, port=default_port)
     return interface
 
@@ -54,7 +54,7 @@ async def test_successful_connection(thermalvac_interface, mock_client):
 @pytest.mark.asyncio
 async def test_connection_raises_error_when_hostname_missing(default_port, mock_client):
     """Test connection fails when hostname is not initialized."""
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=None, port=default_port)
         interface.hostname = None
 
@@ -67,7 +67,7 @@ async def test_connection_raises_error_when_hostname_missing(default_port, mock_
 @pytest.mark.asyncio
 async def test_connection_raises_error_when_port_missing(default_hostname, mock_client):
     """Test connection fails when port is not initialized."""
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=default_hostname, port=None)
         interface.port = None
 
@@ -128,6 +128,23 @@ async def test_disconnection_when_not_connected(thermalvac_interface, mock_clien
 
     assert thermalvac_interface._is_connection_open is False
     mock_client.disconnect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_flag_even_if_client_disconnect_raises(thermalvac_interface, mock_client):
+    """A failed close (e.g. the socket is already dead) must not leave `_is_connection_open` stuck True,
+    since that would permanently block any future `connect()`/`reconnect()` call.
+    """
+    mock_root = MagicMock()
+    mock_root.read_browse_name = AsyncMock()
+    mock_client.get_root_node.return_value = mock_root
+
+    await thermalvac_interface.connect()
+    mock_client.disconnect.side_effect = ConnectionError("socket already closed")
+
+    await thermalvac_interface.disconnect()
+
+    assert thermalvac_interface._is_connection_open is False
 
 
 @pytest.mark.asyncio
@@ -233,7 +250,7 @@ async def test_write_node_sets_value(thermalvac_interface, mock_client):
     mock_variable.set_value = AsyncMock()
     mock_client.get_node.return_value = mock_variable
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.ua") as mock_ua:
+    with patch("egse.ivs.tvac.tvac_devif.ua") as mock_ua:
         mock_ua.DataValue = MagicMock()
         mock_ua.Variant = MagicMock()
 
@@ -250,7 +267,7 @@ async def test_write_node_with_integer_value(thermalvac_interface, mock_client):
     mock_variable.set_value = AsyncMock()
     mock_client.get_node.return_value = mock_variable
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.ua") as mock_ua:
+    with patch("egse.ivs.tvac.tvac_devif.ua") as mock_ua:
         mock_ua.DataValue = MagicMock()
         mock_ua.Variant = MagicMock()
 
@@ -273,7 +290,7 @@ async def test_server_url_with_custom_hostname_and_port(mock_client):
     custom_hostname = "192.168.1.100"
     custom_port = 4841
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=custom_hostname, port=custom_port)
 
     expected_url = f"opc.tcp://{custom_hostname}:{custom_port}"
@@ -287,7 +304,7 @@ async def test_context_manager_establishes_connection(default_hostname, default_
     mock_root.read_browse_name = AsyncMock()
     mock_client.get_root_node.return_value = mock_root
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         async with ThermalVacOpcUaInterface(hostname=default_hostname, port=default_port) as interface:
             assert interface._is_connection_open is True
 
@@ -299,7 +316,7 @@ async def test_context_manager_closes_connection(default_hostname, default_port,
     mock_root.read_browse_name = AsyncMock()
     mock_client.get_root_node.return_value = mock_root
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         async with ThermalVacOpcUaInterface(hostname=default_hostname, port=default_port) as interface:
             pass
 
@@ -314,7 +331,7 @@ async def test_context_manager_closes_on_exception(default_hostname, default_por
     mock_root.read_browse_name = AsyncMock()
     mock_client.get_root_node.return_value = mock_root
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         try:
             async with ThermalVacOpcUaInterface(hostname=default_hostname, port=default_port) as interface:
                 raise RuntimeError("Test exception")
@@ -345,10 +362,10 @@ async def test_concurrent_operations_with_lock(thermalvac_interface, mock_client
 @pytest.mark.asyncio
 async def test_device_id_is_set_correctly(default_hostname, default_port, mock_client):
     """Test that device_id is set correctly during initialization."""
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=default_hostname, port=default_port)
 
-    assert interface.device_id == "ThermalVac"
+    assert interface.device_id == "TVAC"
 
 
 @pytest.mark.asyncio
@@ -357,7 +374,7 @@ async def test_initialization_uses_provided_hostname_and_port(mock_client):
     custom_hostname = "custom.host.com"
     custom_port = 9999
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.Client", return_value=mock_client):
+    with patch("egse.ivs.tvac.tvac_devif.Client", return_value=mock_client):
         interface = ThermalVacOpcUaInterface(hostname=custom_hostname, port=custom_port)
 
     assert interface.hostname == custom_hostname
@@ -381,7 +398,7 @@ async def test_read_and_write_operations_sequence(thermalvac_interface, mock_cli
 
     await thermalvac_interface.connect()
 
-    with patch("egse.ivs.thermalvac.thermalvac_devif.ua") as mock_ua:
+    with patch("egse.ivs.tvac.tvac_devif.ua") as mock_ua:
         mock_ua.DataValue = MagicMock()
         mock_ua.Variant = MagicMock()
 
@@ -391,3 +408,80 @@ async def test_read_and_write_operations_sequence(thermalvac_interface, mock_cli
     assert read_result == 25.5
     assert read_variable.read_value.called
     assert write_variable.set_value.called
+
+
+@pytest.mark.asyncio
+async def test_read_node_reconnects_and_retries_once_on_failure(thermalvac_interface, mock_client):
+    """A failed read triggers exactly one reconnect, then a retry that succeeds."""
+    variable = AsyncMock()
+    variable.read_value = AsyncMock(side_effect=[ConnectionError("client is disconnected"), 42])
+    mock_client.get_node.return_value = variable
+
+    with (
+        patch.object(thermalvac_interface, "is_connected", AsyncMock(return_value=False)) as mock_is_connected,
+        patch.object(thermalvac_interface, "reconnect", AsyncMock()) as mock_reconnect,
+    ):
+        result = await thermalvac_interface.read_node("ns=2;i=1234")
+
+    assert result == 42
+    mock_is_connected.assert_called_once()
+    mock_reconnect.assert_called_once()
+    assert variable.read_value.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_write_node_reconnects_and_retries_once_on_failure(thermalvac_interface, mock_client):
+    """A failed write triggers exactly one reconnect, then a retry that succeeds."""
+    variable = AsyncMock()
+    variable.set_value = AsyncMock(side_effect=[ConnectionError("client is disconnected"), None])
+    mock_client.get_node.return_value = variable
+
+    with (
+        patch.object(thermalvac_interface, "is_connected", AsyncMock(return_value=False)),
+        patch.object(thermalvac_interface, "reconnect", AsyncMock()) as mock_reconnect,
+        patch("egse.ivs.tvac.tvac_devif.ua") as mock_ua,
+    ):
+        mock_ua.DataValue = MagicMock()
+        mock_ua.Variant = MagicMock()
+
+        await thermalvac_interface.write_node("ns=2;i=1234", 1.0, ua.VariantType.Double)
+
+    mock_reconnect.assert_called_once()
+    assert variable.set_value.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_read_node_raises_if_retry_after_reconnect_also_fails(thermalvac_interface, mock_client):
+    """If the retried op also fails, that second failure propagates instead of being swallowed."""
+    variable = AsyncMock()
+    variable.read_value = AsyncMock(side_effect=ConnectionError("still disconnected"))
+    mock_client.get_node.return_value = variable
+
+    with (
+        patch.object(thermalvac_interface, "is_connected", AsyncMock(return_value=False)),
+        patch.object(thermalvac_interface, "reconnect", AsyncMock()),
+    ):
+        with pytest.raises(ConnectionError, match="still disconnected"):
+            await thermalvac_interface.read_node("ns=2;i=1234")
+
+    assert variable.read_value.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_reconnect_skipped_if_already_reconnected_by_another_caller(thermalvac_interface, mock_client):
+    """The `is_connected()` re-check taken under `_reconnect_lock` exists so that if another concurrent
+    caller already reconnected while this one was waiting for the lock, it skips its own redundant
+    `reconnect()` call and just retries directly.
+    """
+    variable = AsyncMock()
+    variable.read_value = AsyncMock(side_effect=[ConnectionError("down"), 7])
+    mock_client.get_node.return_value = variable
+
+    with (
+        patch.object(thermalvac_interface, "is_connected", AsyncMock(return_value=True)),
+        patch.object(thermalvac_interface, "reconnect", AsyncMock()) as mock_reconnect,
+    ):
+        result = await thermalvac_interface.read_node("ns=2;i=1234")
+
+    assert result == 7
+    mock_reconnect.assert_not_called()


### PR DESCRIPTION
When working/debugging on a laptop the host-ip might change from Ethernet to Wifi when unplugging the network. This is really inconvenient, because the registration of the service will stay alive (due to the heartbeats) but the service becomes unreachable. This pull request detects the host-ip change and re-registers the service with the updated IP address. 